### PR TITLE
Indexed db cleanup

### DIFF
--- a/packages/example-broadcast-channel/src/lib/trimergeClient.ts
+++ b/packages/example-broadcast-channel/src/lib/trimergeClient.ts
@@ -19,19 +19,17 @@ export function useTrimergeState<State, EditMetadata, Delta>(
   );
   useEffect(() => {
     let mounted = true;
-    let store: TrimergeIndexedDb<State, EditMetadata, Delta> | undefined;
     let unsub: (() => void) | undefined;
-    TrimergeIndexedDb.create<State, EditMetadata, Delta>(docId, differ)
-      .then((_store) => {
-        store = _store;
-        return TrimergeClient.create(_store, differ);
-      })
-      .then((_client) => {
-        if (mounted) {
-          client.current = _client;
-          unsub = _client.subscribe(setState);
-        }
-      });
+    const store = new TrimergeIndexedDb<State, EditMetadata, Delta>(
+      docId,
+      differ,
+    );
+    TrimergeClient.create(store, differ).then((_client) => {
+      if (mounted) {
+        client.current = _client;
+        unsub = _client.subscribe(setState);
+      }
+    });
     return () => {
       unsub?.();
       client.current?.shutdown();

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
@@ -23,30 +23,22 @@ function getSyncCounter(
 
 export class TrimergeIndexedDb<State, EditMetadata, Delta>
   implements TrimergeSyncStore<State, EditMetadata, Delta> {
-  static async create<State, EditMetadata, Delta>(
-    docId: string,
-    differ: Differ<State, EditMetadata, Delta>,
-  ): Promise<TrimergeIndexedDb<State, EditMetadata, Delta>> {
-    const dbName = `trimerge-sync:${docId}`;
-    const db = await createIndexedDb(dbName);
-    return new TrimergeIndexedDb<State, EditMetadata, Delta>(
-      dbName,
-      db,
-      differ,
-    );
-  }
-
+  private readonly dbName: string;
+  private db: Promise<IDBPDatabase<TrimergeSyncDbSchema>>;
   private readonly listeners = new Map<
     SyncSubscriber<State, EditMetadata, Delta>,
     number
   >();
   private readonly channel: BroadcastChannel | undefined;
 
-  private constructor(
-    private readonly dbName: string,
-    private readonly db: IDBPDatabase<TrimergeSyncDbSchema>,
+  public constructor(
+    private readonly docId: string,
     private readonly differ: Differ<State, EditMetadata, Delta>,
   ) {
+    const dbName = `trimerge-sync:${docId}`;
+    this.dbName = dbName;
+    this.db = this.connect();
+
     if (typeof window.BroadcastChannel !== 'undefined') {
       console.log(`[trimerge-sync] Using BroadcastChannel for ${dbName}`);
       this.channel = new window.BroadcastChannel(dbName);
@@ -71,11 +63,25 @@ export class TrimergeIndexedDb<State, EditMetadata, Delta>
       throw new Error('BroadcastChannel and localStorage unavailable');
     }
   }
+  private async connect(
+    reconnect: boolean = false,
+  ): Promise<IDBPDatabase<TrimergeSyncDbSchema>> {
+    if (reconnect) {
+      console.log('Reconnecting after 3 second timeout…');
+      await new Promise((resolve) => setTimeout(resolve, 3_000));
+    }
+    const db = await createIndexedDb(this.dbName);
+    db.onclose = () => {
+      this.db = this.connect(true);
+    };
+    return db;
+  }
 
   async addNodes(
     newNodes: DiffNode<State, EditMetadata, Delta>[],
   ): Promise<number> {
-    const tx = this.db.transaction(['heads', 'nodes'], 'readwrite');
+    const db = await this.db;
+    const tx = db.transaction(['heads', 'nodes'], 'readwrite');
 
     const heads = tx.objectStore('heads');
     const nodes = tx.objectStore('nodes');
@@ -123,7 +129,8 @@ export class TrimergeIndexedDb<State, EditMetadata, Delta>
   }
 
   async getSnapshot(): Promise<Snapshot<State, EditMetadata, Delta>> {
-    const nodes = await this.db.getAllFromIndex('nodes', 'syncId');
+    const db = await this.db;
+    const nodes = await db.getAllFromIndex('nodes', 'syncId');
     return { nodes, syncCounter: getSyncCounter(nodes) };
   }
 
@@ -131,7 +138,8 @@ export class TrimergeIndexedDb<State, EditMetadata, Delta>
     onNodes: SyncSubscriber<State, EditMetadata, Delta>,
     lastSyncCounter: number,
   ) {
-    const newNodes = await this.db.getAllFromIndex(
+    const db = await this.db;
+    const newNodes = await db.getAllFromIndex(
       'nodes',
       'syncId',
       IDBKeyRange.lowerBound(lastSyncCounter, true),
@@ -154,7 +162,11 @@ export class TrimergeIndexedDb<State, EditMetadata, Delta>
 
   close() {
     this.channel?.close();
-    this.db.close();
+    this.db.then((db) => {
+      // To prevent reconnect
+      db.onclose = null;
+      db.close();
+    });
   }
 }
 


### PR DESCRIPTION
- integrate BroadcastChannel to use instead of localstorage (if available)
- simplify head computation
- auto-reconnecting database
  - remove TrimergeIndexedDb.create (and make constructor public)