### PR TITLE
Fix local remote status

### DIFF
--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -8,6 +8,7 @@ import {
   NodesEvent,
   OnEventFn,
   Remote,
+  RemoteStateEvent,
   SyncEvent,
 } from './types';
 import { PromiseQueue } from './lib/PromiseQueue';
@@ -37,6 +38,13 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
     | undefined;
   private remote: Remote<EditMetadata, Delta, PresenceState> | undefined;
   private reconnectDelayMs: number;
+  private remoteSyncState: RemoteStateEvent = {
+    type: 'remote-state',
+    save: 'ready',
+    connect: 'offline',
+    read: 'offline',
+  };
+  private readonly unacknowledgedRefs = new Set<string>();
   private readonly remoteQueue = new PromiseQueue();
 
   public constructor(
@@ -80,16 +88,26 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
     return { userId, clientId, ...this.presence };
   }
 
-  // Three sources of events: self, local broadcast, and remote broadcast
+  private async setRemoteState(
+    update: RemoteStateEvent,
+    sendEvent: boolean = true,
+  ): Promise<void> {
+    this.remoteSyncState = { ...this.remoteSyncState, ...update };
+    if (sendEvent) {
+      await this.sendEvent(update, { local: true, self: true });
+    }
+  }
 
   protected processEvent = async (
     event: SyncEvent<EditMetadata, Delta, PresenceState>,
+    // Three sources of events: self, local broadcast, and remote broadcast
     origin: 'self' | 'local' | 'remote',
   ): Promise<void> => {
     console.log(
       `processing "${event.type}" from ${origin}: ${JSON.stringify(event)}`,
     );
 
+    // Re-broadcast event to other channels
     await this.sendEvent(event, {
       self: origin !== 'self',
       local: origin !== 'local',
@@ -100,10 +118,7 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
       case 'ready':
         // Reset reconnect timeout
         this.reconnectDelayMs = this.reconnectSettings.initialDelayMs;
-        await this.sendEvent(
-          { type: 'remote-state', read: 'ready' },
-          { self: true, local: true },
-        );
+        await this.setRemoteState({ type: 'remote-state', read: 'ready' });
         break;
 
       case 'nodes':
@@ -124,11 +139,12 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
       case 'ack':
         if (origin === 'remote') {
           await this.acknowledgeRemoteNodes(event.refs, event.syncId);
-          // FIXME: we might have sent more stuff since this acknowledgement
-          await this.sendEvent(
-            { type: 'remote-state', save: 'ready' },
-            { self: true, local: true },
-          );
+          for (const ref of event.refs) {
+            this.unacknowledgedRefs.delete(ref);
+          }
+          if (this.unacknowledgedRefs.size === 0) {
+            await this.setRemoteState({ type: 'remote-state', save: 'ready' });
+          }
         }
         break;
 
@@ -140,6 +156,9 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
           },
           { local: true, remote: true },
         );
+        if (origin === 'local' && this.remote) {
+          await this.sendEvent(this.remoteSyncState, { local: true });
+        }
         break;
       case 'client-presence':
         break;
@@ -155,6 +174,7 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
             { local: true, remote: true },
           );
         }
+        await this.setRemoteState(event, false);
         break;
       case 'error':
         if (origin === 'remote') {
@@ -210,14 +230,11 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
       return;
     }
     await this.remote.shutdown();
-    await this.sendEvent(
-      {
-        type: 'remote-state',
-        connect: 'offline',
-        read: 'offline',
-      },
-      { local: true, self: true },
-    );
+    await this.setRemoteState({
+      type: 'remote-state',
+      connect: 'offline',
+      read: 'offline',
+    });
     this.remote = undefined;
   }
 
@@ -229,14 +246,11 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
       if (this.closed) {
         return;
       }
-      await this.sendEvent(
-        {
-          type: 'remote-state',
-          connect: 'connecting',
-          read: 'loading',
-        },
-        { self: true, local: true },
-      );
+      await this.setRemoteState({
+        type: 'remote-state',
+        connect: 'connecting',
+        read: 'loading',
+      });
       this.remote = getRemote(
         this.userId,
         await this.getLastRemoteSyncId(),
@@ -248,11 +262,11 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
       );
       let saving = false;
       for await (const event of this.getNodesForRemote()) {
+        for (const { ref } of event.nodes) {
+          this.unacknowledgedRefs.add(ref);
+        }
         if (!saving) {
-          await this.sendEvent(
-            { type: 'remote-state', save: 'saving' },
-            { self: true, local: true },
-          );
+          await this.setRemoteState({ type: 'remote-state', save: 'saving' });
           saving = true;
         }
         await this.sendEvent(event, { remote: true });
@@ -333,10 +347,7 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
       this.presence = presenceRef;
     }
     if (nodes.length > 0) {
-      await this.sendEvent(
-        { type: 'remote-state', save: 'pending' },
-        { self: true, local: true },
-      );
+      await this.setRemoteState({ type: 'remote-state', save: 'pending' });
     }
 
     const syncId = await this.addNodes(nodes);
@@ -354,10 +365,7 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
       clientId: this.clientId,
     };
     if (nodes.length > 0) {
-      await this.sendEvent(
-        { type: 'remote-state', save: 'saving' },
-        { self: true, local: true },
-      );
+      await this.setRemoteState({ type: 'remote-state', save: 'saving' });
       await this.sendEvent(
         {
           type: 'nodes',

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -103,9 +103,11 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
     // Three sources of events: self, local broadcast, and remote broadcast
     origin: 'self' | 'local' | 'remote',
   ): Promise<void> => {
-    console.log(
-      `processing "${event.type}" from ${origin}: ${JSON.stringify(event)}`,
-    );
+    if (process.env.NODE_ENV === 'development') {
+      console.log(
+        `processing "${event.type}" from ${origin}: ${JSON.stringify(event)}`,
+      );
+    }
 
     // Re-broadcast event to other channels
     await this.sendEvent(event, {
@@ -165,7 +167,7 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
       case 'client-leave':
         break;
       case 'remote-state':
-        if (event.connect === 'online') {
+        if (origin === 'remote' && event.connect === 'online') {
           await this.sendEvent(
             {
               type: 'client-join',
@@ -299,7 +301,9 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
     }: { remote?: boolean; local?: boolean; self?: boolean },
   ): Promise<void> {
     if (self) {
-      console.log(`handle event: ${JSON.stringify(event)}`);
+      if (process.env.NODE_ENV === 'development') {
+        console.log(`handle event: ${JSON.stringify(event)}`);
+      }
       try {
         this.onEvent(event);
       } catch (e) {
@@ -308,11 +312,15 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
       }
     }
     if (local) {
-      console.log(`send local event: ${JSON.stringify(event)}`);
+      if (process.env.NODE_ENV === 'development') {
+        console.log(`send local event: ${JSON.stringify(event)}`);
+      }
       await this.broadcastLocal(event);
     }
     if (remote && this.remote) {
-      console.log(`send remote event: ${JSON.stringify(event)}`);
+      if (process.env.NODE_ENV === 'development') {
+        console.log(`send remote event: ${JSON.stringify(event)}`);
+      }
       await this.remote.send(event);
     }
   }

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -67,7 +67,7 @@ function basicClients(
 }
 
 describe('Remote sync', () => {
-  it('syncs one clients to a remote', async () => {
+  it('syncs one client to a remote', async () => {
     const remoteStore = newStore();
     const localStore = newStore(remoteStore);
     const client = makeClient('a', 'test', localStore);
@@ -184,6 +184,148 @@ describe('Remote sync', () => {
           "remoteConnect": "online",
           "remoteRead": "loading",
           "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "loading",
+          "remoteSave": "ready",
+        },
+      ]
+    `);
+  });
+
+  it('syncs two clients to a remote', async () => {
+    const remoteStore = newStore();
+    const localStore = newStore(remoteStore);
+    const client1 = makeClient('test', 'a', localStore);
+
+    const syncUpdates1: SyncStatus[] = [];
+    client1.subscribeSyncStatus((state) => syncUpdates1.push(state));
+
+    client1.updateState({}, 'initialize');
+    client1.updateState({ hello: 'world' }, 'add hello');
+
+    await timeout();
+
+    const client2 = makeClient('test', 'b', localStore);
+
+    const syncUpdates2: SyncStatus[] = [];
+    client2.subscribeSyncStatus((state) => syncUpdates2.push(state));
+
+    await timeout();
+
+    expect(syncUpdates1).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "localRead": "loading",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "loading",
+          "localSave": "pending",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "loading",
+          "localSave": "pending",
+          "remoteConnect": "connecting",
+          "remoteRead": "loading",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "pending",
+          "remoteConnect": "connecting",
+          "remoteRead": "loading",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "pending",
+          "remoteConnect": "connecting",
+          "remoteRead": "loading",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "pending",
+          "remoteConnect": "connecting",
+          "remoteRead": "loading",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "pending",
+          "remoteConnect": "online",
+          "remoteRead": "loading",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "pending",
+          "remoteConnect": "online",
+          "remoteRead": "loading",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "online",
+          "remoteRead": "loading",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "online",
+          "remoteRead": "loading",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "loading",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "loading",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "loading",
+          "remoteSave": "ready",
+        },
+      ]
+    `);
+    expect(syncUpdates2).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "localRead": "loading",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
         },
         Object {
           "localRead": "ready",


### PR DESCRIPTION
- when a local client connects, send the current remoteSave/Read/Connect state
- only include logging on NODE_ENV === 'development' (for now)