### PR TITLE
Track which nodes were inserted into indexeddb successfully

### DIFF
--- a/packages/trimerge-sync-basic-server/src/DocStore.ts
+++ b/packages/trimerge-sync-basic-server/src/DocStore.ts
@@ -11,7 +11,5 @@ export interface DocStore {
     nodes: readonly DiffNode<unknown, unknown>[],
   ): Promise<AckNodesEvent> | AckNodesEvent;
 
-  delete(): Promise<void>;
-
   close(): void;
 }

--- a/packages/trimerge-sync-basic-server/src/lib/SqliteDocStore.ts
+++ b/packages/trimerge-sync-basic-server/src/lib/SqliteDocStore.ts
@@ -117,10 +117,7 @@ export class SqliteDocStore implements DocStore {
     const refErrors: AckRefErrors = {};
     function invalidParentRef(
       node: DiffNode<unknown, unknown>,
-      key: keyof Pick<
-        DiffNode<unknown, unknown>,
-        'baseRef' | 'mergeRef' | 'mergeBaseRef'
-      >,
+      key: 'baseRef' | 'mergeRef' | 'mergeBaseRef',
     ) {
       const parentRef = node[key];
       if (parentRef && !knownRefs.has(parentRef)) {

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
@@ -1,6 +1,7 @@
 import { AbstractLocalStore } from '../AbstractLocalStore';
 import { MemoryBroadcastChannel } from './MemoryBroadcastChannel';
 import {
+  AckNodesEvent,
   DiffNode,
   GetRemoteFn,
   NodesEvent,
@@ -48,7 +49,7 @@ export class MemoryLocalStore<
   protected addNodes(
     nodes: DiffNode<EditMetadata, Delta>[],
     remoteSyncId?: string,
-  ): Promise<string> {
+  ): Promise<AckNodesEvent> {
     return this.store.addNodes(nodes, remoteSyncId);
   }
 

--- a/packages/trimerge-sync/src/testLib/MemoryRemote.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryRemote.ts
@@ -1,5 +1,6 @@
 import { MemoryBroadcastChannel } from './MemoryBroadcastChannel';
 import {
+  AckNodesEvent,
   DiffNode,
   ErrorCode,
   NodesEvent,
@@ -37,13 +38,9 @@ export class MemoryRemote<EditMetadata, Delta, PresenceState>
     switch (event.type) {
       case 'nodes':
         // FIXME: check for nodes with wrong userId
-        const syncId = await this.addNodes(event.nodes);
-        await this.onEvent({
-          type: 'ack',
-          refs: event.nodes.map(({ ref }) => ref),
-          syncId,
-        });
-        await this.broadcast({ ...event, syncId });
+        const ack = await this.addNodes(event.nodes);
+        await this.onEvent(ack);
+        await this.broadcast({ ...event, syncId: ack.syncId });
         break;
 
       case 'ready':
@@ -107,7 +104,7 @@ export class MemoryRemote<EditMetadata, Delta, PresenceState>
   }
   protected addNodes(
     nodes: readonly DiffNode<EditMetadata, Delta>[],
-  ): Promise<string> {
+  ): Promise<AckNodesEvent> {
     return this.store.addNodes(nodes);
   }
 

--- a/packages/trimerge-sync/src/testLib/MemoryStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryStore.ts
@@ -76,10 +76,12 @@ export class MemoryStore<EditMetadata, Delta, PresenceState> {
     return this.queue.add(async () => {
       this.nodes.push(...nodes);
       const refs = new Set<string>();
+      for (const { ref } of nodes) {
+        refs.add(ref);
+      }
       if (remoteSyncId !== undefined) {
         for (const { ref } of nodes) {
           this.syncedNodes.add(ref);
-          refs.add(ref);
         }
         this.lastRemoteSyncId = remoteSyncId;
       }

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -79,9 +79,12 @@ export type NodesEvent<EditMetadata, Delta, PresenceState> = {
 export type ReadyEvent = {
   type: 'ready';
 };
+export type AckNodeError = { message: string };
+export type AckRefErrors = Record<string, AckNodeError>;
 export type AckNodesEvent = {
   type: 'ack';
   refs: readonly string[];
+  refErrors?: AckRefErrors;
   syncId: string;
 };
 export type ClientJoinEvent<PresenceState> = {

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -79,7 +79,11 @@ export type NodesEvent<EditMetadata, Delta, PresenceState> = {
 export type ReadyEvent = {
   type: 'ready';
 };
-export type AckNodeError = { message: string };
+export type AckNodeErrorCode = 'invalid-node' | 'internal';
+export type AckNodeError = {
+  code: AckNodeErrorCode;
+  message: string;
+};
 export type AckRefErrors = Record<string, AckNodeError>;
 export type AckNodesEvent = {
   type: 'ack';


### PR DESCRIPTION
- trimerge-sync
  - add `refErrors` field to `AckNodesEvent`
  - `AbstractLocalStore.addNodes` now returns `AckNodesEvent`
- basic-server
  - SqliteDocStore: do not allow nodes added if they reference non-existent parents
  - remove `delete` from `DocStore` interface function (it only applied to `SqliteDocStore`)
- trimerge-sync-indexed-db
  - return `refErrors` now
  - check for node again after insert error (maybe fixes/silences DOMException?)
