### PR TITLE
Lots of bug fixes, api refactoring, and new features 😬

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,6 +14,7 @@ jobs:
       - run: yarn lint
       - run: yarn build-all
       - run: yarn test-ci
+        timeout-minutes: 5
       - run: yarn codecov
         env:
           CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}

--- a/packages/example-broadcast-channel/package.json
+++ b/packages/example-broadcast-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-example-broadcast-channel",
-  "version": "0.9.1-rc.3",
+  "version": "0.10.0-rc.1",
   "private": true,
   "dependencies": {
     "broadcast-channel": "3.6.0",
@@ -13,10 +13,10 @@
     "react-scripts": "4.0.3",
     "textarea-caret": "^3.1.0",
     "trimerge": "1.3.0-alpha.15",
-    "trimerge-sync": "0.9.1-rc.3",
-    "trimerge-sync-basic-client": "0.9.1-rc.3",
-    "trimerge-sync-hash": "0.9.1-rc.3",
-    "trimerge-sync-indexed-db": "0.9.1-rc.3"
+    "trimerge-sync": "0.10.0-rc.1",
+    "trimerge-sync-basic-client": "0.10.0-rc.1",
+    "trimerge-sync-hash": "0.10.0-rc.1",
+    "trimerge-sync-indexed-db": "0.10.0-rc.1"
   },
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true FAST_REFRESH=false react-scripts start",

--- a/packages/example-broadcast-channel/package.json
+++ b/packages/example-broadcast-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-example-broadcast-channel",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.1-rc.3",
   "private": true,
   "dependencies": {
     "broadcast-channel": "3.6.0",
@@ -13,10 +13,10 @@
     "react-scripts": "4.0.3",
     "textarea-caret": "^3.1.0",
     "trimerge": "1.3.0-alpha.15",
-    "trimerge-sync": "0.9.1-rc.2",
-    "trimerge-sync-basic-client": "0.9.1-rc.2",
-    "trimerge-sync-hash": "0.9.1-rc.2",
-    "trimerge-sync-indexed-db": "0.9.1-rc.2"
+    "trimerge-sync": "0.9.1-rc.3",
+    "trimerge-sync-basic-client": "0.9.1-rc.3",
+    "trimerge-sync-hash": "0.9.1-rc.3",
+    "trimerge-sync-indexed-db": "0.9.1-rc.3"
   },
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true react-scripts start",

--- a/packages/example-broadcast-channel/package.json
+++ b/packages/example-broadcast-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-example-broadcast-channel",
-  "version": "0.9.1-rc.1",
+  "version": "0.9.1-rc.2",
   "private": true,
   "dependencies": {
     "broadcast-channel": "3.6.0",
@@ -13,10 +13,10 @@
     "react-scripts": "4.0.3",
     "textarea-caret": "^3.1.0",
     "trimerge": "1.3.0-alpha.15",
-    "trimerge-sync": "0.9.1-rc.1",
-    "trimerge-sync-basic-client": "0.9.1-rc.1",
-    "trimerge-sync-hash": "0.9.1-rc.1",
-    "trimerge-sync-indexed-db": "0.9.1-rc.1"
+    "trimerge-sync": "0.9.1-rc.2",
+    "trimerge-sync-basic-client": "0.9.1-rc.2",
+    "trimerge-sync-hash": "0.9.1-rc.2",
+    "trimerge-sync-indexed-db": "0.9.1-rc.2"
   },
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true react-scripts start",

--- a/packages/example-broadcast-channel/package.json
+++ b/packages/example-broadcast-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-example-broadcast-channel",
-  "version": "0.9.0",
+  "version": "0.9.1-rc.1",
   "private": true,
   "dependencies": {
     "broadcast-channel": "3.6.0",
@@ -13,10 +13,10 @@
     "react-scripts": "4.0.3",
     "textarea-caret": "^3.1.0",
     "trimerge": "1.3.0-alpha.15",
-    "trimerge-sync": "0.9.0",
-    "trimerge-sync-basic-client": "0.9.0",
-    "trimerge-sync-hash": "0.9.0",
-    "trimerge-sync-indexed-db": "0.9.0"
+    "trimerge-sync": "0.9.1-rc.1",
+    "trimerge-sync-basic-client": "0.9.1-rc.1",
+    "trimerge-sync-hash": "0.9.1-rc.1",
+    "trimerge-sync-indexed-db": "0.9.1-rc.1"
   },
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true react-scripts start",
@@ -25,9 +25,15 @@
     "test-ci": "SKIP_PREFLIGHT_CHECK=true react-scripts test --coverage --passWithNoTests",
     "eject": "react-scripts eject"
   },
-  "eslintConfig": { "extends": "react-app" },
+  "eslintConfig": {
+    "extends": "react-app"
+  },
   "browserslist": {
-    "production": [">0.2%", "not dead", "not op_mini all"],
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",

--- a/packages/example-broadcast-channel/package.json
+++ b/packages/example-broadcast-channel/package.json
@@ -19,7 +19,7 @@
     "trimerge-sync-indexed-db": "0.9.1-rc.3"
   },
   "scripts": {
-    "start": "SKIP_PREFLIGHT_CHECK=true react-scripts start",
+    "start": "SKIP_PREFLIGHT_CHECK=true FAST_REFRESH=false react-scripts start",
     "build": "SKIP_PREFLIGHT_CHECK=true react-scripts build",
     "test": "SKIP_PREFLIGHT_CHECK=true react-scripts test",
     "test-ci": "SKIP_PREFLIGHT_CHECK=true react-scripts test --coverage --passWithNoTests",

--- a/packages/example-broadcast-channel/package.json
+++ b/packages/example-broadcast-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-example-broadcast-channel",
-  "version": "0.10.0-rc.1",
+  "version": "0.10.0-rc.2",
   "private": true,
   "dependencies": {
     "broadcast-channel": "3.6.0",
@@ -13,10 +13,10 @@
     "react-scripts": "4.0.3",
     "textarea-caret": "^3.1.0",
     "trimerge": "1.3.0-alpha.15",
-    "trimerge-sync": "0.10.0-rc.1",
-    "trimerge-sync-basic-client": "0.10.0-rc.1",
-    "trimerge-sync-hash": "0.10.0-rc.1",
-    "trimerge-sync-indexed-db": "0.10.0-rc.1"
+    "trimerge-sync": "0.10.0-rc.2",
+    "trimerge-sync-basic-client": "0.10.0-rc.2",
+    "trimerge-sync-hash": "0.10.0-rc.2",
+    "trimerge-sync-indexed-db": "0.10.0-rc.2"
   },
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true FAST_REFRESH=false react-scripts start",

--- a/packages/example-broadcast-channel/src/lib/currentTabId.ts
+++ b/packages/example-broadcast-channel/src/lib/currentTabId.ts
@@ -1,14 +1,15 @@
-import generate from 'project-name-generator';
+import { randomId } from './randomId';
 
 // Based on https://stackoverflow.com/a/61415444
 const STORAGE_KEY = 'tabIdStorageKey';
+
 function initTabId() {
   const sessionId = sessionStorage.getItem(STORAGE_KEY);
   if (sessionId) {
     sessionStorage.removeItem(STORAGE_KEY);
     return sessionId;
   }
-  return generate({ words: 3, alliterative: true }).dashed;
+  return randomId();
 }
 
 export const currentTabId = initTabId();

--- a/packages/example-broadcast-channel/src/lib/randomId.ts
+++ b/packages/example-broadcast-channel/src/lib/randomId.ts
@@ -1,0 +1,5 @@
+import generate from 'project-name-generator';
+
+export function randomId() {
+  return generate({ words: 3, alliterative: true }).dashed;
+}

--- a/packages/example-broadcast-channel/src/lib/trimergeHooks.ts
+++ b/packages/example-broadcast-channel/src/lib/trimergeHooks.ts
@@ -5,6 +5,7 @@ import {
   deleteDocDatabase,
 } from 'trimerge-sync-indexed-db';
 import { WebsocketRemote } from 'trimerge-sync-basic-client';
+import { randomId } from './randomId';
 
 export type UpdateStateFn<State, EditMetadata> = (
   newState: State,
@@ -35,16 +36,17 @@ function getCachedTrimergeClient<State, EditMetadata, Delta, PresenceState>(
     >(
       userId,
       clientId,
-      createIndexedDbBackendFactory(
-        docId,
-        (userId, lastSyncId, onEvent) =>
+      createIndexedDbBackendFactory(docId, {
+        getRemote: (userId, lastSyncId, onEvent) =>
           new WebsocketRemote(
             { userId, readonly: false },
             lastSyncId,
             onEvent,
             `ws://localhost:4444/${encodeURIComponent(docId)}`,
           ),
-      ),
+        localIdGenerator: randomId,
+        remoteId: 'localhost',
+      }),
       differ,
       100,
     );

--- a/packages/trimerge-sync-basic-client/package.json
+++ b/packages/trimerge-sync-basic-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-client",
-  "version": "0.9.1-rc.3",
+  "version": "0.10.0-rc.1",
   "description": "basic websocket client for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -45,7 +45,7 @@
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.9.1-rc.3",
+    "trimerge-sync": "0.10.0-rc.1",
     "ts-node": "^10.0.0",
     "ts-node-dev": "^1.1.6",
     "typescript": "4.3.2"

--- a/packages/trimerge-sync-basic-client/package.json
+++ b/packages/trimerge-sync-basic-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-client",
-  "version": "0.9.1-rc.1",
+  "version": "0.9.1-rc.2",
   "description": "basic websocket client for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -45,7 +45,7 @@
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.9.1-rc.1",
+    "trimerge-sync": "0.9.1-rc.2",
     "ts-node": "^10.0.0",
     "ts-node-dev": "^1.1.6",
     "typescript": "4.3.2"

--- a/packages/trimerge-sync-basic-client/package.json
+++ b/packages/trimerge-sync-basic-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-client",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.1-rc.3",
   "description": "basic websocket client for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -45,7 +45,7 @@
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.9.1-rc.2",
+    "trimerge-sync": "0.9.1-rc.3",
     "ts-node": "^10.0.0",
     "ts-node-dev": "^1.1.6",
     "typescript": "4.3.2"

--- a/packages/trimerge-sync-basic-client/package.json
+++ b/packages/trimerge-sync-basic-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-client",
-  "version": "0.10.0-rc.1",
+  "version": "0.10.0-rc.2",
   "description": "basic websocket client for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -45,7 +45,7 @@
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.10.0-rc.1",
+    "trimerge-sync": "0.10.0-rc.2",
     "ts-node": "^10.0.0",
     "ts-node-dev": "^1.1.6",
     "typescript": "4.3.2"

--- a/packages/trimerge-sync-basic-client/package.json
+++ b/packages/trimerge-sync-basic-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-client",
-  "version": "0.9.0",
+  "version": "0.9.1-rc.1",
   "description": "basic websocket client for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -18,23 +18,34 @@
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {},
-  "files": ["dist/**/*", "src/**/*"],
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
   "devDependencies": {
     "@rollup/plugin-commonjs": "19.0.0",
     "@rollup/plugin-node-resolve": "13.0.0",
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.9.0",
+    "trimerge-sync": "0.9.1-rc.1",
     "ts-node": "^10.0.0",
     "ts-node-dev": "^1.1.6",
     "typescript": "4.3.2"
@@ -42,6 +53,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }

--- a/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
+++ b/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
@@ -14,6 +14,11 @@ export class WebsocketRemote<EditMetadata, Delta, PresenceState>
     this.socket = new WebSocket(websocketUrl);
     onEvent({ type: 'remote-state', connect: 'connecting' });
     this.socket.onopen = () => {
+      if (!this.socket) {
+        console.warn(`[TRIMERGE-SYNC] Connected, but already shutdown...`);
+        return;
+      }
+      console.log(`[TRIMERGE-SYNC] Connected to ${websocketUrl}`);
       onEvent({ type: 'remote-state', connect: 'online' });
       const events = this.bufferedEvents;
       this.bufferedEvents = [];
@@ -47,7 +52,9 @@ export class WebsocketRemote<EditMetadata, Delta, PresenceState>
     console.log(
       `[TRIMERGE-SYNC] Shutting down websocket ${this.socket.url}...`,
     );
-    this.socket.close(1000, 'shutdown');
+    if (this.socket.readyState !== WebSocket.CLOSED) {
+      this.socket.close(1000, 'shutdown');
+    }
     this.socket = undefined;
     this.onEvent({
       type: 'remote-state',

--- a/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
+++ b/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
@@ -1,4 +1,10 @@
-import type { ErrorCode, OnEventFn, Remote, SyncEvent } from 'trimerge-sync';
+import type {
+  ErrorCode,
+  OnEventFn,
+  Remote,
+  RemoteSyncInfo,
+  SyncEvent,
+} from 'trimerge-sync';
 
 export class WebsocketRemote<EditMetadata, Delta, PresenceState>
   implements Remote<EditMetadata, Delta, PresenceState> {
@@ -6,7 +12,7 @@ export class WebsocketRemote<EditMetadata, Delta, PresenceState>
   private bufferedEvents: SyncEvent<EditMetadata, Delta, PresenceState>[] = [];
   constructor(
     auth: unknown,
-    lastSyncId: string | undefined,
+    { localStoreId, lastSyncCursor }: RemoteSyncInfo,
     private readonly onEvent: OnEventFn<EditMetadata, Delta, PresenceState>,
     websocketUrl: string,
   ) {
@@ -31,7 +37,13 @@ export class WebsocketRemote<EditMetadata, Delta, PresenceState>
     this.socket.onmessage = (event) => {
       onEvent(JSON.parse(event.data));
     };
-    this.send({ type: 'init', lastSyncId, auth });
+    this.send({
+      type: 'init',
+      version: 1,
+      localStoreId,
+      lastSyncCursor,
+      auth,
+    });
   }
 
   send(event: SyncEvent<EditMetadata, Delta, PresenceState>): void {

--- a/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
+++ b/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
@@ -10,6 +10,7 @@ export class WebsocketRemote<EditMetadata, Delta, PresenceState>
     private readonly onEvent: OnEventFn<EditMetadata, Delta, PresenceState>,
     websocketUrl: string,
   ) {
+    console.log(`[TRIMERGE-SYNC] Connecting to ${websocketUrl}...`);
     this.socket = new WebSocket(websocketUrl);
     onEvent({ type: 'remote-state', connect: 'connecting' });
     this.socket.onopen = () => {
@@ -43,6 +44,9 @@ export class WebsocketRemote<EditMetadata, Delta, PresenceState>
     if (!this.socket) {
       return;
     }
+    console.log(
+      `[TRIMERGE-SYNC] Shutting down websocket ${this.socket.url}...`,
+    );
     this.socket.close(1000, 'shutdown');
     this.socket = undefined;
     this.onEvent({

--- a/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
+++ b/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
@@ -61,10 +61,10 @@ export class WebsocketRemote<EditMetadata, Delta, PresenceState>
     if (!this.socket) {
       return;
     }
-    console.log(
-      `[TRIMERGE-SYNC] Shutting down websocket ${this.socket.url}...`,
-    );
     if (this.socket.readyState !== WebSocket.CLOSED) {
+      console.log(
+        `[TRIMERGE-SYNC] Shutting down websocket ${this.socket.url}...`,
+      );
       this.socket.close(1000, 'shutdown');
     }
     this.socket = undefined;

--- a/packages/trimerge-sync-basic-server/package.json
+++ b/packages/trimerge-sync-basic-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-server",
-  "version": "0.9.1-rc.1",
+  "version": "0.9.1-rc.2",
   "description": "basic websocket server for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@types/ws": "^7.4.4",
     "fs-extra": "^10.0.0",
-    "trimerge-sync": "0.9.1-rc.1",
+    "trimerge-sync": "0.9.1-rc.2",
     "ws": "^7.4.6"
   },
   "files": [
@@ -55,7 +55,7 @@
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.9.1-rc.1",
+    "trimerge-sync": "0.9.1-rc.2",
     "ts-node": "^10.0.0",
     "ts-node-dev": "^1.1.6",
     "typescript": "4.3.2"

--- a/packages/trimerge-sync-basic-server/package.json
+++ b/packages/trimerge-sync-basic-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-server",
-  "version": "0.9.0",
+  "version": "0.9.1-rc.1",
   "description": "basic websocket server for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -17,22 +17,35 @@
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {
     "@types/ws": "^7.4.4",
     "fs-extra": "^10.0.0",
-    "trimerge-sync": "0.9.0",
+    "trimerge-sync": "0.9.1-rc.1",
     "ws": "^7.4.6"
   },
-  "files": ["dist/**/*", "src/**/*"],
-  "peerDependencies": { "better-sqlite3": "^7.4.1" },
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
+  "peerDependencies": {
+    "better-sqlite3": "^7.4.1"
+  },
   "devDependencies": {
     "@rollup/plugin-commonjs": "19.0.0",
     "@rollup/plugin-node-resolve": "13.0.0",
@@ -42,7 +55,7 @@
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.9.0",
+    "trimerge-sync": "0.9.1-rc.1",
     "ts-node": "^10.0.0",
     "ts-node-dev": "^1.1.6",
     "typescript": "4.3.2"
@@ -50,6 +63,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }

--- a/packages/trimerge-sync-basic-server/package.json
+++ b/packages/trimerge-sync-basic-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-server",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.1-rc.3",
   "description": "basic websocket server for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@types/ws": "^7.4.4",
     "fs-extra": "^10.0.0",
-    "trimerge-sync": "0.9.1-rc.2",
+    "trimerge-sync": "0.9.1-rc.3",
     "ws": "^7.4.6"
   },
   "files": [
@@ -55,7 +55,7 @@
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.9.1-rc.2",
+    "trimerge-sync": "0.9.1-rc.3",
     "ts-node": "^10.0.0",
     "ts-node-dev": "^1.1.6",
     "typescript": "4.3.2"

--- a/packages/trimerge-sync-basic-server/package.json
+++ b/packages/trimerge-sync-basic-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-server",
-  "version": "0.10.0-rc.1",
+  "version": "0.10.0-rc.2",
   "description": "basic websocket server for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@types/ws": "^7.4.4",
     "fs-extra": "^10.0.0",
-    "trimerge-sync": "0.10.0-rc.1",
+    "trimerge-sync": "0.10.0-rc.2",
     "ws": "^7.4.6"
   },
   "files": [
@@ -55,7 +55,7 @@
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.10.0-rc.1",
+    "trimerge-sync": "0.10.0-rc.2",
     "ts-node": "^10.0.0",
     "ts-node-dev": "^1.1.6",
     "typescript": "4.3.2"

--- a/packages/trimerge-sync-basic-server/package.json
+++ b/packages/trimerge-sync-basic-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-server",
-  "version": "0.9.1-rc.3",
+  "version": "0.10.0-rc.1",
   "description": "basic websocket server for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@types/ws": "^7.4.4",
     "fs-extra": "^10.0.0",
-    "trimerge-sync": "0.9.1-rc.3",
+    "trimerge-sync": "0.10.0-rc.1",
     "ws": "^7.4.6"
   },
   "files": [
@@ -55,7 +55,7 @@
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.9.1-rc.3",
+    "trimerge-sync": "0.10.0-rc.1",
     "ts-node": "^10.0.0",
     "ts-node-dev": "^1.1.6",
     "typescript": "4.3.2"

--- a/packages/trimerge-sync-basic-server/src/lib/SqliteDocStore.ts
+++ b/packages/trimerge-sync-basic-server/src/lib/SqliteDocStore.ts
@@ -58,10 +58,10 @@ export class SqliteDocStore implements DocStore {
     const stmt =
       lastSyncId === undefined
         ? this.db.prepare(
-            `SELECT * FROM nodes ORDER BY remoteSyncId, remoteSyncIndex`,
+            `SELECT * FROM nodes ORDER BY remoteSyncId, remoteSyncIndex LIMIT 100`,
           )
         : this.db.prepare(
-            `SELECT * FROM nodes WHERE remoteSyncId > @lastSyncId ORDER BY remoteSyncId, remoteSyncIndex`,
+            `SELECT * FROM nodes WHERE remoteSyncId > @lastSyncId ORDER BY remoteSyncId, remoteSyncIndex LIMIT 100`,
           );
 
     const sqliteNodes: SqliteNodeType[] = stmt.all({ lastSyncId });

--- a/packages/trimerge-sync-basic-server/src/lib/SqliteDocStore.ts
+++ b/packages/trimerge-sync-basic-server/src/lib/SqliteDocStore.ts
@@ -58,10 +58,10 @@ export class SqliteDocStore implements DocStore {
     const stmt =
       lastSyncId === undefined
         ? this.db.prepare(
-            `SELECT * FROM nodes ORDER BY remoteSyncId, remoteSyncIndex LIMIT 100`,
+            `SELECT * FROM nodes ORDER BY remoteSyncId, remoteSyncIndex`,
           )
         : this.db.prepare(
-            `SELECT * FROM nodes WHERE remoteSyncId > @lastSyncId ORDER BY remoteSyncId, remoteSyncIndex LIMIT 100`,
+            `SELECT * FROM nodes WHERE remoteSyncId > @lastSyncId ORDER BY remoteSyncId, remoteSyncIndex`,
           );
 
     const sqliteNodes: SqliteNodeType[] = stmt.all({ lastSyncId });

--- a/packages/trimerge-sync-basic-server/src/lib/connection.ts
+++ b/packages/trimerge-sync-basic-server/src/lib/connection.ts
@@ -16,7 +16,7 @@ export class Connection {
     private readonly liveDoc: LiveDoc,
     private readonly authenticate: AuthenticateFn,
     private readonly onClose: () => void,
-    private readonly logger: Logger,
+    public readonly logger: Logger,
   ) {
     ws.on('close', () => {
       this.logger.info('socket closed', {});
@@ -42,6 +42,7 @@ export class Connection {
       this.logger.debug(`--> received ${message}`, {});
       this.queue.add(() => this.onMessage(message));
     });
+    ws.on('error', onClose);
   }
 
   private async sendInitialEvents(

--- a/packages/trimerge-sync-basic-server/src/lib/connection.ts
+++ b/packages/trimerge-sync-basic-server/src/lib/connection.ts
@@ -49,6 +49,7 @@ export class Connection {
   private async sendInitialEvents(
     lastSyncId: string | undefined,
   ): Promise<void> {
+    // Call store multiple times so that it can do paging if desired
     while (true) {
       const event = await this.liveDoc.store.getNodesEvent(lastSyncId);
       if (event.nodes.length === 0) {
@@ -182,7 +183,7 @@ export class Connection {
     this.liveDoc.broadcast(this, message);
   }
 
-  public receiveBroadcast(message: string, from: Connection) {
+  public receiveBroadcast(from: Connection, message: string) {
     if (from === this) {
       return;
     }

--- a/packages/trimerge-sync-basic-server/src/lib/connection.ts
+++ b/packages/trimerge-sync-basic-server/src/lib/connection.ts
@@ -49,9 +49,13 @@ export class Connection {
   private async sendInitialEvents(
     lastSyncId: string | undefined,
   ): Promise<void> {
-    const event = await this.liveDoc.store.getNodesEvent(lastSyncId);
-    if (event.nodes.length > 0) {
+    while (true) {
+      const event = await this.liveDoc.store.getNodesEvent(lastSyncId);
+      if (event.nodes.length === 0) {
+        break;
+      }
       this.sendEvent(event);
+      lastSyncId = event.syncId;
     }
     this.sendEvent({ type: 'ready' });
   }

--- a/packages/trimerge-sync-basic-server/src/lib/docs.ts
+++ b/packages/trimerge-sync-basic-server/src/lib/docs.ts
@@ -12,9 +12,7 @@ export class LiveDoc {
   }
 
   remove(conn: Connection): void {
-    if (!this.connections.delete(conn)) {
-      throw new Error('could not remove connection');
-    }
+    this.connections.delete(conn);
   }
 
   isEmpty(): boolean {
@@ -23,9 +21,7 @@ export class LiveDoc {
 
   broadcast(from: Connection, message: string) {
     for (const conn of this.connections) {
-      if (conn !== from) {
-        conn.send(message);
-      }
+      conn.receiveBroadcast(message, from);
     }
   }
 
@@ -35,7 +31,21 @@ export class LiveDoc {
 
   async addNodes(
     event: NodesEvent<unknown, unknown, unknown>,
-  ): Promise<AckNodesEvent> {
-    return this.store.add(event.nodes);
+  ): Promise<{
+    nodes: NodesEvent<unknown, unknown, unknown>;
+    ack: AckNodesEvent;
+  }> {
+    const ack = await this.store.add(event.nodes);
+    const acks = new Set(ack.refs);
+    return {
+      nodes: {
+        type: 'nodes',
+        // Only broadcast the acknowledged nodes
+        nodes: event.nodes.filter(({ ref }) => acks.has(ref)),
+        syncId: ack.syncId,
+        clientInfo: event.clientInfo,
+      },
+      ack,
+    };
   }
 }

--- a/packages/trimerge-sync-basic-server/src/lib/docs.ts
+++ b/packages/trimerge-sync-basic-server/src/lib/docs.ts
@@ -12,7 +12,9 @@ export class LiveDoc {
   }
 
   remove(conn: Connection): void {
-    this.connections.delete(conn);
+    if (!this.connections.delete(conn)) {
+      throw new Error('could not remove connection');
+    }
   }
 
   isEmpty(): boolean {

--- a/packages/trimerge-sync-basic-server/src/lib/docs.ts
+++ b/packages/trimerge-sync-basic-server/src/lib/docs.ts
@@ -21,7 +21,7 @@ export class LiveDoc {
 
   broadcast(from: Connection, message: string) {
     for (const conn of this.connections) {
-      conn.receiveBroadcast(message, from);
+      conn.receiveBroadcast(from, message);
     }
   }
 

--- a/packages/trimerge-sync-basic-server/src/sample-server.ts
+++ b/packages/trimerge-sync-basic-server/src/sample-server.ts
@@ -16,13 +16,13 @@ function isFakeAuth(auth: unknown): auth is FakeAuth {
 function makeLogger(sharedParams: Record<string, any>): Logger {
   return {
     debug(message, params): void {
-      console.log(message, { ...params, ...sharedParams });
+      console.log('[debug]', message, { ...params, ...sharedParams });
     },
     info(message, params): void {
-      console.info(message, { ...params, ...sharedParams });
+      console.info('[info]', message, { ...params, ...sharedParams });
     },
     warn(message, params): void {
-      console.warn(message, { ...params, ...sharedParams });
+      console.warn('[warn]', message, { ...params, ...sharedParams });
     },
   };
 }

--- a/packages/trimerge-sync-basic-server/src/server.ts
+++ b/packages/trimerge-sync-basic-server/src/server.ts
@@ -37,6 +37,16 @@ export class BasicServer {
             remotePort: req.socket.remotePort,
             remoteFamily: req.socket.remoteFamily,
           });
+          ws.on('error', (e) => {
+            logger.warn(`connection error`, {
+              docId,
+              message: String(e),
+              remoteAddress: req.socket.remoteAddress,
+              remotePort: req.socket.remotePort,
+              remoteFamily: req.socket.remoteFamily,
+            });
+            ws.close();
+          });
           const liveDoc =
             this.liveDocs.get(docId) ?? new LiveDoc(this.makeDocStore(docId));
           this.liveDocs.set(docId, liveDoc);
@@ -46,6 +56,7 @@ export class BasicServer {
             liveDoc,
             this.authenticate,
             () => {
+              conn.logger.debug(`removing connection`);
               liveDoc.remove(conn);
               if (liveDoc.isEmpty()) {
                 liveDoc.close();

--- a/packages/trimerge-sync-hash/package.json
+++ b/packages/trimerge-sync-hash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-hash",
-  "version": "0.10.0-rc.1",
+  "version": "0.10.0-rc.2",
   "description": "SHA-256 based hash generator for use with trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",

--- a/packages/trimerge-sync-hash/package.json
+++ b/packages/trimerge-sync-hash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-hash",
-  "version": "0.9.1-rc.3",
+  "version": "0.10.0-rc.1",
   "description": "SHA-256 based hash generator for use with trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",

--- a/packages/trimerge-sync-hash/package.json
+++ b/packages/trimerge-sync-hash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-hash",
-  "version": "0.9.1-rc.1",
+  "version": "0.9.1-rc.2",
   "description": "SHA-256 based hash generator for use with trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",

--- a/packages/trimerge-sync-hash/package.json
+++ b/packages/trimerge-sync-hash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-hash",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.1-rc.3",
   "description": "SHA-256 based hash generator for use with trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",

--- a/packages/trimerge-sync-hash/package.json
+++ b/packages/trimerge-sync-hash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-hash",
-  "version": "0.9.0",
+  "version": "0.9.1-rc.1",
   "description": "SHA-256 based hash generator for use with trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -18,16 +18,29 @@
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
-  "dependencies": { "jssha": "^3.2.0" },
-  "files": ["dist/**/*", "src/**/*"],
+  "dependencies": {
+    "jssha": "^3.2.0"
+  },
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
   "devDependencies": {
     "@rollup/plugin-commonjs": "19.0.0",
     "@rollup/plugin-node-resolve": "13.0.0",
@@ -39,6 +52,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }

--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-indexed-db",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.1-rc.3",
   "description": "indexed-db backend for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -39,7 +39,7 @@
     "idb": "6.1.2"
   },
   "peerDependencies": {
-    "trimerge-sync": "0.9.1-rc.2"
+    "trimerge-sync": "0.9.1-rc.3"
   },
   "files": [
     "dist/**/*",
@@ -52,7 +52,7 @@
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.9.1-rc.2",
+    "trimerge-sync": "0.9.1-rc.3",
     "typescript": "4.3.2"
   },
   "jest": {

--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-indexed-db",
-  "version": "0.10.0-rc.1",
+  "version": "0.10.0-rc.2",
   "description": "indexed-db backend for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -39,7 +39,7 @@
     "idb": "6.1.2"
   },
   "peerDependencies": {
-    "trimerge-sync": "0.10.0-rc.1"
+    "trimerge-sync": "0.10.0-rc.2"
   },
   "files": [
     "dist/**/*",
@@ -52,7 +52,7 @@
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.10.0-rc.1",
+    "trimerge-sync": "0.10.0-rc.2",
     "typescript": "4.3.2"
   },
   "jest": {

--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-indexed-db",
-  "version": "0.9.0",
+  "version": "0.9.1-rc.1",
   "description": "indexed-db backend for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -18,17 +18,33 @@
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
-  "dependencies": { "broadcast-channel": "^3.6.0", "idb": "6.1.2" },
-  "peerDependencies": { "trimerge-sync": "0.9.0" },
-  "files": ["dist/**/*", "src/**/*"],
+  "dependencies": {
+    "broadcast-channel": "^3.6.0",
+    "idb": "6.1.2"
+  },
+  "peerDependencies": {
+    "trimerge-sync": "0.9.1-rc.1"
+  },
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
   "devDependencies": {
     "@rollup/plugin-commonjs": "19.0.0",
     "@rollup/plugin-node-resolve": "13.0.0",
@@ -36,12 +52,18 @@
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.9.0",
+    "trimerge-sync": "0.9.1-rc.1",
     "typescript": "4.3.2"
   },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }

--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-indexed-db",
-  "version": "0.9.1-rc.3",
+  "version": "0.10.0-rc.1",
   "description": "indexed-db backend for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -39,7 +39,7 @@
     "idb": "6.1.2"
   },
   "peerDependencies": {
-    "trimerge-sync": "0.9.1-rc.3"
+    "trimerge-sync": "0.10.0-rc.1"
   },
   "files": [
     "dist/**/*",
@@ -52,7 +52,7 @@
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.9.1-rc.3",
+    "trimerge-sync": "0.10.0-rc.1",
     "typescript": "4.3.2"
   },
   "jest": {

--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-indexed-db",
-  "version": "0.9.1-rc.1",
+  "version": "0.9.1-rc.2",
   "description": "indexed-db backend for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -39,7 +39,7 @@
     "idb": "6.1.2"
   },
   "peerDependencies": {
-    "trimerge-sync": "0.9.1-rc.1"
+    "trimerge-sync": "0.9.1-rc.2"
   },
   "files": [
     "dist/**/*",
@@ -52,7 +52,7 @@
     "jest": "26.6.3",
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.9.1-rc.1",
+    "trimerge-sync": "0.9.1-rc.2",
     "typescript": "4.3.2"
   },
   "jest": {

--- a/packages/trimerge-sync-indexed-db/rollup.config.js
+++ b/packages/trimerge-sync-indexed-db/rollup.config.js
@@ -6,7 +6,7 @@ import typescript from 'rollup-plugin-typescript2';
 
 export default {
   input: 'src/index.ts',
-  external: ['broadcast-channel', 'idb'],
+  external: ['broadcast-channel', 'idb', 'trimerge-sync'],
   plugins: [
     commonjs(),
     resolve({ browser: true }),

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
@@ -11,6 +11,7 @@ import {
 } from 'trimerge-sync';
 import { DBSchema, deleteDB, IDBPDatabase, openDB, StoreValue } from 'idb';
 import { BroadcastChannel, LeaderElector } from 'broadcast-channel';
+import { NetworkSettings } from 'trimerge-sync/dist/AbstractLocalStore';
 
 function getSyncCounter(
   nodes: StoreValue<TrimergeSyncDbSchema, 'nodes'>[],
@@ -69,9 +70,10 @@ class IndexedDbBackend<
     clientId: string,
     onEvent: OnEventFn<EditMetadata, Delta, PresenceState>,
     getRemote?: GetRemoteFn<EditMetadata, Delta, PresenceState>,
+    networkSettings?: Partial<NetworkSettings>,
     private readonly remoteId: string = 'origin',
   ) {
-    super(userId, clientId, onEvent, getRemote);
+    super(userId, clientId, onEvent, getRemote, networkSettings);
     const dbName = getDatabaseName(docId);
     console.log(`[TRIMERGE-SYNC] new IndexedDbBackend(${dbName})`);
     this.dbName = dbName;

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
@@ -1,17 +1,18 @@
-import {
-  AbstractLocalStore,
+import type {
   AckNodesEvent,
   AckRefErrors,
   BroadcastEvent,
   DiffNode,
   GetLocalStoreFn,
   GetRemoteFn,
+  NetworkSettings,
   NodesEvent,
   OnEventFn,
+  RemoteSyncInfo,
 } from 'trimerge-sync';
+import { AbstractLocalStore } from 'trimerge-sync';
 import { DBSchema, deleteDB, IDBPDatabase, openDB, StoreValue } from 'idb';
 import { BroadcastChannel, LeaderElector } from 'broadcast-channel';
-import { NetworkSettings } from 'trimerge-sync/dist/AbstractLocalStore';
 
 function getSyncCounter(
   nodes: StoreValue<TrimergeSyncDbSchema, 'nodes'>[],
@@ -32,16 +33,24 @@ function toSyncNumber(syncId: string | undefined): number {
   return syncId === undefined ? 0 : parseInt(syncId, 36);
 }
 
+type LocalIdGeneratorFn = () => Promise<string> | string;
+export type IndexedDbBackendOptions<EditMetadata, Delta, PresenceState> = {
+  getRemote?: GetRemoteFn<EditMetadata, Delta, PresenceState>;
+  networkSettings?: Partial<NetworkSettings>;
+  remoteId?: string;
+  localIdGenerator: LocalIdGeneratorFn;
+};
+
 export function createIndexedDbBackendFactory<
   EditMetadata,
   Delta,
   PresenceState
 >(
   docId: string,
-  getRemote?: GetRemoteFn<EditMetadata, Delta, PresenceState>,
+  options: IndexedDbBackendOptions<EditMetadata, Delta, PresenceState>,
 ): GetLocalStoreFn<EditMetadata, Delta, PresenceState> {
   return (userId, clientId, onEvent) =>
-    new IndexedDbBackend(docId, userId, clientId, onEvent, getRemote);
+    new IndexedDbBackend(docId, userId, clientId, onEvent, options);
 }
 
 function getDatabaseName(docId: string): string {
@@ -63,17 +72,24 @@ class IndexedDbBackend<
     BroadcastEvent<EditMetadata, Delta, PresenceState>
   >;
   private leaderElector: LeaderElector | undefined;
+  private remoteId: string;
+  private localIdGenerator: LocalIdGeneratorFn;
 
   public constructor(
     private readonly docId: string,
     userId: string,
     clientId: string,
     onEvent: OnEventFn<EditMetadata, Delta, PresenceState>,
-    getRemote?: GetRemoteFn<EditMetadata, Delta, PresenceState>,
-    networkSettings?: Partial<NetworkSettings>,
-    private readonly remoteId: string = 'origin',
+    {
+      getRemote,
+      networkSettings,
+      remoteId = 'origin',
+      localIdGenerator,
+    }: IndexedDbBackendOptions<EditMetadata, Delta, PresenceState>,
   ) {
     super(userId, clientId, onEvent, getRemote, networkSettings);
+    this.remoteId = remoteId;
+    this.localIdGenerator = localIdGenerator;
     const dbName = getDatabaseName(docId);
     console.log(`[TRIMERGE-SYNC] new IndexedDbBackend(${dbName})`);
     this.dbName = dbName;
@@ -106,37 +122,44 @@ class IndexedDbBackend<
 
   protected async acknowledgeRemoteNodes(
     refs: readonly string[],
-    remoteSyncId: string,
+    remoteSyncCursor: string,
   ): Promise<void> {
     const db = await this.db;
     for (const ref of refs) {
       const node = await db.get('nodes', ref);
       if (node && !node.remoteSyncId) {
-        node.remoteSyncId = remoteSyncId;
+        node.remoteSyncId = remoteSyncCursor;
         await db.put('nodes', node);
       }
     }
-    await this.updateLastRemoteSyncId(remoteSyncId);
+    await this.upsertRemoteSyncInfo(remoteSyncCursor);
   }
 
-  protected async getLastRemoteSyncId(): Promise<string | undefined> {
-    const db = await this.db;
-    const remote = await db.get('remotes', this.remoteId);
-    const lastSyncId = remote?.lastSyncId;
-    if (lastSyncId) {
-      return String(lastSyncId);
-    }
-    return undefined;
+  protected async getRemoteSyncInfo(): Promise<RemoteSyncInfo> {
+    return this.upsertRemoteSyncInfo();
   }
 
-  protected async updateLastRemoteSyncId(lastSyncId: string): Promise<void> {
+  protected async upsertRemoteSyncInfo(
+    syncCursor?: string,
+  ): Promise<RemoteSyncInfo> {
     const db = await this.db;
     const tx = db.transaction(['remotes'], 'readwrite');
     const remotes = tx.objectStore('remotes');
     const remote = (await remotes.get(this.remoteId)) ?? {};
-    remote.lastSyncId = lastSyncId;
-    await remotes.put(remote, this.remoteId);
+    let changed = false;
+    if (!remote.localStoreId) {
+      remote.localStoreId = await this.localIdGenerator();
+      changed = true;
+    }
+    if (syncCursor !== undefined && remote.lastSyncCursor !== syncCursor) {
+      remote.lastSyncCursor = syncCursor;
+      changed = true;
+    }
+    if (changed) {
+      await remotes.put(remote, this.remoteId);
+    }
     await tx.done;
+    return remote as RemoteSyncInfo;
   }
 
   private async connect(
@@ -157,7 +180,7 @@ class IndexedDbBackend<
 
   protected async addNodes(
     nodes: readonly DiffNode<EditMetadata, Delta>[],
-    lastSyncId: string | undefined,
+    lastSyncCursor: string | undefined,
   ): Promise<AckNodesEvent> {
     const db = await this.db;
     const tx = db.transaction(['heads', 'nodes'], 'readwrite');
@@ -226,8 +249,8 @@ class IndexedDbBackend<
       promises.push(headsDb.put({ ref }));
     }
 
-    if (lastSyncId) {
-      await this.updateLastRemoteSyncId(lastSyncId);
+    if (lastSyncCursor) {
+      await this.upsertRemoteSyncInfo(lastSyncCursor);
     }
 
     await Promise.all(promises);
@@ -298,7 +321,8 @@ interface TrimergeSyncDbSchema extends DBSchema {
   remotes: {
     key: string;
     value: {
-      lastSyncId?: string;
+      localStoreId?: string;
+      lastSyncCursor?: string;
     };
   };
 }

--- a/packages/trimerge-sync/package.json
+++ b/packages/trimerge-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync",
-  "version": "0.9.1-rc.1",
+  "version": "0.9.1-rc.2",
   "description": "distributed data sync using trimerge",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -59,7 +59,7 @@
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
-    "trimerge-sync-hash": "0.9.1-rc.1",
+    "trimerge-sync-hash": "0.9.1-rc.2",
     "typescript": "4.3.2"
   },
   "jest": {

--- a/packages/trimerge-sync/package.json
+++ b/packages/trimerge-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.1-rc.3",
   "description": "distributed data sync using trimerge",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -59,7 +59,7 @@
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
-    "trimerge-sync-hash": "0.9.1-rc.2",
+    "trimerge-sync-hash": "0.9.1-rc.3",
     "typescript": "4.3.2"
   },
   "jest": {

--- a/packages/trimerge-sync/package.json
+++ b/packages/trimerge-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync",
-  "version": "0.10.0-rc.1",
+  "version": "0.10.0-rc.2",
   "description": "distributed data sync using trimerge",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -59,7 +59,7 @@
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
-    "trimerge-sync-hash": "0.10.0-rc.1",
+    "trimerge-sync-hash": "0.10.0-rc.2",
     "typescript": "4.3.2"
   },
   "jest": {

--- a/packages/trimerge-sync/package.json
+++ b/packages/trimerge-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync",
-  "version": "0.9.1-rc.3",
+  "version": "0.10.0-rc.1",
   "description": "distributed data sync using trimerge",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -59,7 +59,7 @@
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
-    "trimerge-sync-hash": "0.9.1-rc.3",
+    "trimerge-sync-hash": "0.10.0-rc.1",
     "typescript": "4.3.2"
   },
   "jest": {

--- a/packages/trimerge-sync/package.json
+++ b/packages/trimerge-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync",
-  "version": "0.9.0",
+  "version": "0.9.1-rc.1",
   "description": "distributed data sync using trimerge",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -14,22 +14,35 @@
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "rm -rf dist/ && npm run build"
   },
-  "engines": { "node": ">=6" },
+  "engines": {
+    "node": ">=6"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {},
   "peerDependencies": {},
-  "files": ["dist/**/*", "src/**/*"],
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
   "devDependencies": {
     "@rollup/plugin-commonjs": "19.0.0",
     "@rollup/plugin-node-resolve": "13.0.0",
@@ -46,12 +59,18 @@
     "rollup": "2.51.1",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
-    "trimerge-sync-hash": "0.9.0",
+    "trimerge-sync-hash": "0.9.1-rc.1",
     "typescript": "4.3.2"
   },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }

--- a/packages/trimerge-sync/src/AbstractLocalStore.test.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.test.ts
@@ -1,5 +1,5 @@
 import { AbstractLocalStore } from './AbstractLocalStore';
-import { AckNodesEvent, NodesEvent, OnEventFn } from './types';
+import { AckNodesEvent, NodesEvent, OnEventFn, RemoteSyncInfo } from './types';
 
 class MockLocalStore extends AbstractLocalStore<unknown, unknown, unknown> {
   constructor(onEvent: OnEventFn<unknown, unknown, unknown> = () => undefined) {
@@ -14,11 +14,11 @@ class MockLocalStore extends AbstractLocalStore<unknown, unknown, unknown> {
   }
 
   async broadcastLocal(): Promise<void> {
-    return Promise.resolve(undefined);
+    //
   }
 
-  async getRemoteSyncInfo(): Promise<string | undefined> {
-    return Promise.resolve(undefined);
+  async getRemoteSyncInfo(): Promise<RemoteSyncInfo> {
+    return { localStoreId: '', lastSyncCursor: undefined };
   }
 
   async *getLocalNodes(): AsyncIterableIterator<

--- a/packages/trimerge-sync/src/AbstractLocalStore.test.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.test.ts
@@ -17,7 +17,7 @@ class MockLocalStore extends AbstractLocalStore<unknown, unknown, unknown> {
     return Promise.resolve(undefined);
   }
 
-  async getLastRemoteSyncId(): Promise<string | undefined> {
+  async getRemoteSyncInfo(): Promise<string | undefined> {
     return Promise.resolve(undefined);
   }
 

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -344,7 +344,8 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
       try {
         this.onEvent(event);
       } catch (e) {
-        console.error(`local error handling event`, e);
+        console.error(`[TRIMERGE-SYNC] local error handling event`, e);
+        void this.shutdown();
         throw e;
       }
     }
@@ -374,7 +375,11 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
             void this.closeRemote();
           }
         },
-        (event) => this.broadcastLocal({ event, remoteOrigin: false }),
+        (event) => {
+          this.broadcastLocal({ event, remoteOrigin: false }).catch(
+            this.handleAsError('internal'),
+          );
+        },
         networkSettings,
       );
     }

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -34,7 +34,7 @@ const DEFAULT_SETTINGS: NetworkSettings = {
   initialDelayMs: 1_000,
   reconnectBackoffMultiplier: 2,
   maxReconnectDelayMs: 30_000,
-  electionTimeoutMs: 200,
+  electionTimeoutMs: 1_000,
   heartbeatMs: 1_000,
   heartbeatTimeoutMs: 2_500,
 };
@@ -69,9 +69,9 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
       Delta,
       PresenceState
     >,
-    reconnectSettings: Partial<NetworkSettings> = {},
+    networkSettings: Partial<NetworkSettings> = {},
   ) {
-    this.networkSettings = { ...DEFAULT_SETTINGS, ...reconnectSettings };
+    this.networkSettings = { ...DEFAULT_SETTINGS, ...networkSettings };
     this.reconnectDelayMs = this.networkSettings.initialDelayMs;
   }
 
@@ -369,8 +369,10 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
         this.clientId,
         (isLeader) => {
           if (isLeader) {
+            console.log(`[TRIMERGE-SYNC] Became leader, connecting...`);
             void this.connectRemote(getRemote);
           } else {
+            console.warn(`[TRIMERGE-SYNC] Demoted as leader, disconnecting...`);
             void this.closeRemote();
           }
         },

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -282,15 +282,12 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
         connect: 'connecting',
         read: 'loading',
       });
-      this.remote = getRemote(
-        this.userId,
-        await this.getRemoteSyncInfo(),
-        (event) => {
-          this.remoteQueue
-            .add(() => this.processEvent(event, 'remote'))
-            .catch(this.handleAsError('internal'));
-        },
-      );
+      const remoteSyncInfo = await this.getRemoteSyncInfo();
+      this.remote = await getRemote(this.userId, remoteSyncInfo, (event) => {
+        this.remoteQueue
+          .add(() => this.processEvent(event, 'remote'))
+          .catch(this.handleAsError('internal'));
+      });
       let saving = false;
       for await (const event of this.getNodesForRemote()) {
         for (const { ref } of event.nodes) {

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -10,6 +10,7 @@ import {
   OnEventFn,
   Remote,
   RemoteStateEvent,
+  RemoteSyncInfo,
   SyncEvent,
 } from './types';
 import { PromiseQueue } from './lib/PromiseQueue';
@@ -100,7 +101,7 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
     remoteSyncId: string,
   ): Promise<void>;
 
-  protected abstract getLastRemoteSyncId(): Promise<string | undefined>;
+  protected abstract getRemoteSyncInfo(): Promise<RemoteSyncInfo>;
 
   private get clientInfo(): ClientInfo<PresenceState> {
     const { userId, clientId } = this;
@@ -293,7 +294,7 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, PresenceState>
       });
       this.remote = getRemote(
         this.userId,
-        await this.getLastRemoteSyncId(),
+        await this.getRemoteSyncInfo(),
         (event) => {
           this.remoteQueue
             .add(() => this.processEvent(event, 'remote'))

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -270,9 +270,15 @@ export class TrimergeClient<State, EditMetadata, Delta, PresenceState> {
     const { ref, baseRef, mergeRef } = node;
     this.nodes.set(ref, node);
     if (baseRef !== undefined) {
+      if (!this.nodes.has(baseRef)) {
+        throw new Error('unknown baseRef node');
+      }
       this.headRefs.delete(baseRef);
     }
     if (mergeRef !== undefined) {
+      if (!this.nodes.has(mergeRef)) {
+        throw new Error('unknown mergeRef node');
+      }
       this.headRefs.delete(mergeRef);
     }
     this.headRefs.add(ref);

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -266,18 +266,27 @@ export class TrimergeClient<State, EditMetadata, Delta, PresenceState> {
     return true;
   }
 
-  private addNode(node: DiffNode<EditMetadata, Delta>, local: boolean): void {
+  private addNode(
+    node: DiffNode<EditMetadata, Delta>,
+    createdLocally: boolean,
+  ): void {
     const { ref, baseRef, mergeRef } = node;
+    if (this.nodes.has(ref)) {
+      console.warn(
+        `[TRIMERGE-SYNC] skipping add node ${ref}, base ${baseRef}, merge ${mergeRef} (createdLocally=${createdLocally})`,
+      );
+      return;
+    }
     this.nodes.set(ref, node);
     if (baseRef !== undefined) {
       if (!this.nodes.has(baseRef)) {
-        throw new Error('unknown baseRef node');
+        throw new Error(`unknown baseRef node ${baseRef}`);
       }
       this.headRefs.delete(baseRef);
     }
     if (mergeRef !== undefined) {
       if (!this.nodes.has(mergeRef)) {
-        throw new Error('unknown mergeRef node');
+        throw new Error(`unknown mergeRef node ${mergeRef}`);
       }
       this.headRefs.delete(mergeRef);
     }
@@ -286,7 +295,7 @@ export class TrimergeClient<State, EditMetadata, Delta, PresenceState> {
     if (currentRef === node.baseRef || currentRef === node.mergeRef) {
       this.current = this.getNodeState(node.ref);
     }
-    if (local) {
+    if (createdLocally) {
       this.unsyncedNodes.push(node);
     }
   }

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -39,7 +39,7 @@ function basicGraph(
   >,
 ) {
   return getBasicGraph(
-    store,
+    store.getNodes(),
     (node) => node.editMetadata,
     (node) => client1.getNodeState(node.ref).value,
   );

--- a/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
@@ -41,7 +41,7 @@ function basicGraph(
   >,
 ) {
   return getBasicGraph(
-    store,
+    store.getNodes(),
     (node) => node.editMetadata.message,
     (node) => clientA.getNodeState(node.ref).value,
   );

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -60,7 +60,7 @@ function basicGraph(
   >,
 ) {
   return getBasicGraph(
-    store,
+    store.getNodes(),
     (node) => node.editMetadata,
     (node) => client1.getNodeState(node.ref).value,
   );

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -629,6 +629,13 @@ describe('Remote sync', () => {
         },
         Object {
           "localRead": "ready",
+          "localSave": "pending",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
           "localSave": "saving",
           "remoteConnect": "offline",
           "remoteRead": "offline",
@@ -647,13 +654,6 @@ describe('Remote sync', () => {
           "remoteConnect": "offline",
           "remoteRead": "offline",
           "remoteSave": "pending",
-        },
-        Object {
-          "localRead": "ready",
-          "localSave": "ready",
-          "remoteConnect": "offline",
-          "remoteRead": "offline",
-          "remoteSave": "saving",
         },
         Object {
           "localRead": "ready",

--- a/packages/trimerge-sync/src/lib/LeaderManager.test.ts
+++ b/packages/trimerge-sync/src/lib/LeaderManager.test.ts
@@ -34,7 +34,7 @@ function makeLeaderManager(
     (event) => channel.postMessage(event),
     {
       electionTimeoutMs: 0,
-      heartbeatMs: 10,
+      heartbeatIntervalMs: 10,
       heartbeatTimeoutMs: 50,
     },
   );

--- a/packages/trimerge-sync/src/lib/LeaderManager.ts
+++ b/packages/trimerge-sync/src/lib/LeaderManager.ts
@@ -90,9 +90,7 @@ export class LeaderManager {
     this.cancelElection();
     const { clientId } = this;
     const isLeader = leaderId === clientId;
-    if (leaderId !== this.currentLeaderId) {
-      this.currentLeaderId = leaderId;
-    }
+    this.currentLeaderId = leaderId;
     if (this.isLeader !== isLeader) {
       this.isLeader = isLeader;
       this.onLeaderChange(isLeader);

--- a/packages/trimerge-sync/src/lib/LeaderManager.ts
+++ b/packages/trimerge-sync/src/lib/LeaderManager.ts
@@ -10,10 +10,10 @@ export type LeaderSettings = Readonly<{
   heartbeatTimeoutMs: number;
 }>;
 
-const DEFAULT_SETTINGS: LeaderSettings = {
+export const DEFAULT_LEADER_SETTINGS: LeaderSettings = {
   electionTimeoutMs: 1_000,
   heartbeatIntervalMs: 2_000,
-  heartbeatTimeoutMs: 5_000,
+  heartbeatTimeoutMs: 8_000,
 };
 
 /**
@@ -53,7 +53,7 @@ export class LeaderManager {
      * A callback for when this class needs to broadcast messages to other clients
      */
     private readonly broadcastEvent: (event: LeaderEvent) => void,
-    private readonly settings: LeaderSettings = DEFAULT_SETTINGS,
+    private readonly settings: LeaderSettings = DEFAULT_LEADER_SETTINGS,
   ) {
     this.elect();
   }

--- a/packages/trimerge-sync/src/lib/LeaderManager.ts
+++ b/packages/trimerge-sync/src/lib/LeaderManager.ts
@@ -124,6 +124,7 @@ export class LeaderManager {
     const { clientId } = this;
     this.broadcastEvent({ type: 'leader', action: 'current', clientId });
   }
+
   private onHeartbeatTimeout() {
     this.heartbeatTimeout = undefined;
     console.warn(`[TRIMERGE-SYNC] leader timeout`);

--- a/packages/trimerge-sync/src/lib/LeaderManager.ts
+++ b/packages/trimerge-sync/src/lib/LeaderManager.ts
@@ -83,7 +83,6 @@ export class LeaderManager {
   }
   private finishElection() {
     this.electionTimeout = undefined;
-    console.log(`[LEADER] election over…`, Array.from(this.potentialLeaders));
     this.setLeader(getSortedMin(this.potentialLeaders));
   }
 
@@ -160,9 +159,15 @@ export class LeaderManager {
         if (this.isLeader) {
           // This will happen if there's a disconnect/messages are delayed
           if (otherClientId < clientId) {
+            console.warn(
+              `[TRIMERGE-SYNC] multiple leaders detected, deferring...`,
+            );
             this.setLeader(undefined);
+          } else {
+            console.warn(
+              `[TRIMERGE-SYNC] multiple leaders detected, staying...`,
+            );
           }
-          console.warn(`[TRIMERGE-SYNC] multiple leaders detected`);
           this.elect();
         } else {
           this.setLeader(otherClientId);

--- a/packages/trimerge-sync/src/lib/LeaderManager.ts
+++ b/packages/trimerge-sync/src/lib/LeaderManager.ts
@@ -89,8 +89,8 @@ export class LeaderManager {
   private setLeader(leaderId: string | undefined) {
     this.cancelElection();
     const { clientId } = this;
-    const isLeader = leaderId === clientId;
     this.currentLeaderId = leaderId;
+    const isLeader = leaderId === clientId;
     if (this.isLeader !== isLeader) {
       this.isLeader = isLeader;
       this.onLeaderChange(isLeader);

--- a/packages/trimerge-sync/src/merge-nodes.test.ts
+++ b/packages/trimerge-sync/src/merge-nodes.test.ts
@@ -37,7 +37,7 @@ describe('mergeHeadNodes()', () => {
     expect(mergeFn.mock.calls).toEqual([[undefined, 'bar3', 'foo3', 4]]);
   });
 
-  it('find no common parent for  three nodes', () => {
+  it('find no common parent for three nodes', () => {
     const getNode = makeGetNodeFn([
       { ref: 'foo' },
       { ref: 'bar' },
@@ -53,6 +53,30 @@ describe('mergeHeadNodes()', () => {
     ]);
   });
 
+  it('basic merge', () => {
+    const getNode = makeGetNodeFn([
+      { ref: 'root' },
+      { ref: 'foo', baseRef: 'root' },
+      { ref: 'bar', baseRef: 'root' },
+    ]);
+    const mergeFn = jest.fn(basicMerge);
+    expect(mergeHeadNodes(['foo', 'bar'], getNode, mergeFn)).toEqual(
+      '(root:bar+foo)',
+    );
+    expect(mergeFn.mock.calls).toEqual([['root', 'bar', 'foo', 1]]);
+  });
+  it('invalid merge with base as merge', () => {
+    const getNode = makeGetNodeFn([
+      { ref: 'root' },
+      { ref: 'foo', baseRef: 'root' },
+    ]);
+    const mergeFn = jest.fn(basicMerge);
+    expect(() =>
+      mergeHeadNodes(['root', 'foo'], getNode, mergeFn),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"unexpected merge with base === left/right"`,
+    );
+  });
   it('find common parent on v split', () => {
     const getNode = makeGetNodeFn([
       { ref: 'root' },

--- a/packages/trimerge-sync/src/merge-nodes.ts
+++ b/packages/trimerge-sync/src/merge-nodes.ts
@@ -44,6 +44,9 @@ export function mergeHeadNodes<N extends MergableNode>(
     const b = visitors[j];
     const aRef = a.ref;
     const bRef = b.ref;
+    if (baseRef === aRef || baseRef === bRef) {
+      throw new Error('unexpected merge with base === left/right');
+    }
     const ref =
       aRef < bRef
         ? merge(baseRef, aRef, bRef, depth)

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
@@ -38,7 +38,7 @@ function basicGraph(
   >,
 ) {
   return getBasicGraph(
-    store,
+    store.getNodes(),
     (node) => node.editMetadata,
     (node) => client1.getNodeState(node.ref).value,
   );
@@ -54,7 +54,7 @@ function dotGraph(
   >,
 ) {
   return getDotGraph(
-    store,
+    store.getNodes(),
     (node) => client1.getNodeState(node.ref).value,
     (node) => node.editMetadata,
   );

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.ts
@@ -1,4 +1,3 @@
-import { MemoryStore } from './MemoryStore';
 import { DiffNode } from '../types';
 
 type BasicGraphItem = {

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.ts
@@ -1,34 +1,43 @@
 import { MemoryStore } from './MemoryStore';
 import { DiffNode } from '../types';
 
+type BasicGraphItem = {
+  graph: string;
+  step: string;
+  value: any;
+};
 export function getBasicGraph<EditMetadata>(
-  store: MemoryStore<EditMetadata, any, any>,
-  getEditLabel: (node: DiffNode<EditMetadata, any>) => string,
-  getValue: (node: DiffNode<EditMetadata, any>) => any,
-) {
-  return store.getNodes().map((node) => {
+  nodes: Iterable<DiffNode<EditMetadata, unknown>>,
+  getEditLabel: (node: DiffNode<EditMetadata, unknown>) => string,
+  getValue: (node: DiffNode<EditMetadata, unknown>) => any,
+): BasicGraphItem[] {
+  const result = [];
+  for (const node of nodes) {
     const { ref, baseRef, mergeBaseRef, mergeRef, userId } = node;
     if (mergeRef) {
-      return {
+      result.push({
         graph: `(${baseRef} + ${mergeRef}) w/ base=${mergeBaseRef} -> ${ref}`,
         step: `User ${userId}: merge`,
         value: getValue(node),
-      };
+      });
+    } else {
+      result.push({
+        graph: `${baseRef} -> ${ref}`,
+        step: `User ${userId}: ${getEditLabel(node)}`,
+        value: getValue(node),
+      });
     }
-    return {
-      graph: `${baseRef} -> ${ref}`,
-      step: `User ${userId}: ${getEditLabel(node)}`,
-      value: getValue(node),
-    };
-  });
+  }
+  return result;
 }
+
 export function getDotGraph<EditMetadata>(
-  store: MemoryStore<EditMetadata, any, any>,
+  nodes: Iterable<DiffNode<EditMetadata, unknown>>,
   getEditLabel: (node: DiffNode<EditMetadata, any>) => string,
   getValue: (node: DiffNode<EditMetadata, any>) => string,
 ): string {
   const lines: string[] = ['digraph {'];
-  for (const node of store.getNodes()) {
+  for (const node of nodes) {
     lines.push(
       `"${node.ref}" [shape=${
         node.mergeRef ? 'rectangle' : 'ellipse'

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
@@ -1,4 +1,5 @@
 import { MemoryStore } from './MemoryStore';
+import { timeout } from '../lib/Timeout';
 
 describe('MemoryLocalStore', () => {
   it('can be shutdown twice', async () => {
@@ -22,6 +23,10 @@ describe('MemoryLocalStore', () => {
       ],
       undefined,
     );
+
+    // Let everything flush out first
+    await timeout();
+
     expect(fn.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -30,8 +35,43 @@ describe('MemoryLocalStore', () => {
             "type": "remote-state",
           },
         ],
+        Array [
+          Object {
+            "nodes": Array [
+              Object {
+                "clientId": "test",
+                "editMetadata": undefined,
+                "ref": "test1",
+                "userId": "test",
+              },
+            ],
+            "syncId": "0",
+            "type": "nodes",
+          },
+        ],
+        Array [
+          Object {
+            "refs": Array [
+              "test1",
+            ],
+            "syncId": "1",
+            "type": "ack",
+          },
+        ],
+        Array [
+          Object {
+            "type": "ready",
+          },
+        ],
+        Array [
+          Object {
+            "save": "saving",
+            "type": "remote-state",
+          },
+        ],
       ]
     `);
+
     await local.shutdown();
     local.update(
       [
@@ -49,6 +89,40 @@ describe('MemoryLocalStore', () => {
         Array [
           Object {
             "save": "pending",
+            "type": "remote-state",
+          },
+        ],
+        Array [
+          Object {
+            "nodes": Array [
+              Object {
+                "clientId": "test",
+                "editMetadata": undefined,
+                "ref": "test1",
+                "userId": "test",
+              },
+            ],
+            "syncId": "0",
+            "type": "nodes",
+          },
+        ],
+        Array [
+          Object {
+            "refs": Array [
+              "test1",
+            ],
+            "syncId": "1",
+            "type": "ack",
+          },
+        ],
+        Array [
+          Object {
+            "type": "ready",
+          },
+        ],
+        Array [
+          Object {
+            "save": "saving",
             "type": "remote-state",
           },
         ],

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
@@ -6,6 +6,7 @@ import {
   GetRemoteFn,
   NodesEvent,
   OnEventFn,
+  RemoteSyncInfo,
 } from '../types';
 import { MemoryStore } from './MemoryStore';
 
@@ -76,8 +77,8 @@ export class MemoryLocalStore<
     yield await this.store.getNodesEventForRemote();
   }
 
-  protected getLastRemoteSyncId(): Promise<string | undefined> {
-    return this.store.getLastRemoteSyncId();
+  protected getRemoteSyncInfo(): Promise<RemoteSyncInfo> {
+    return this.store.getRemoteSyncInfo();
   }
 
   async shutdown(): Promise<void> {

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
@@ -31,7 +31,7 @@ export class MemoryLocalStore<
       reconnectBackoffMultiplier: 1,
       maxReconnectDelayMs: 0,
       electionTimeoutMs: 0,
-      heartbeatMs: 10,
+      heartbeatIntervalMs: 10,
       heartbeatTimeoutMs: 50,
     });
     this.channel = new MemoryBroadcastChannel(

--- a/packages/trimerge-sync/src/testLib/MemoryStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryStore.ts
@@ -129,7 +129,7 @@ export class MemoryStore<EditMetadata, Delta, PresenceState> {
   getRemoteSyncInfo(): Promise<RemoteSyncInfo> {
     return this.queue.add(async () => ({
       localStoreId: this.localStoreId,
-      lastRemoteSyncCursor: this.lastRemoteSyncCursor,
+      lastSyncCursor: this.lastRemoteSyncCursor,
     }));
   }
 

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -64,11 +64,20 @@ export type ClientList<
   PresenceState
 > = readonly LocalClientInfo<PresenceState>[];
 
-export type AuthEvent = {
-  type: 'init';
-  lastSyncId: string | undefined;
-  auth: unknown;
-};
+export type InitEvent =
+  | {
+      type: 'init';
+      version?: undefined;
+      lastSyncId: string | undefined;
+      auth: unknown;
+    }
+  | {
+      type: 'init';
+      version: 1;
+      localStoreId: string;
+      lastSyncCursor: string | undefined;
+      auth: unknown;
+    };
 
 export type NodesEvent<EditMetadata, Delta, PresenceState> = {
   type: 'nodes';
@@ -124,7 +133,7 @@ export type LeaderEvent = {
   clientId: string;
 };
 export type SyncEvent<EditMetadata, Delta, PresenceState> = Readonly<
-  | AuthEvent
+  | InitEvent
   | NodesEvent<EditMetadata, Delta, PresenceState>
   | ReadyEvent
   | LeaderEvent
@@ -146,9 +155,14 @@ export type GetLocalStoreFn<EditMetadata, Delta, PresenceState> = (
   onEvent: OnEventFn<EditMetadata, Delta, PresenceState>,
 ) => LocalStore<EditMetadata, Delta, PresenceState>;
 
+export type RemoteSyncInfo = {
+  localStoreId: string;
+  lastSyncCursor: string | undefined;
+};
+
 export type GetRemoteFn<EditMetadata, Delta, PresenceState> = (
   userId: string,
-  lastSyncId: string | undefined,
+  remoteSyncInfo: RemoteSyncInfo,
   onEvent: OnEventFn<EditMetadata, Delta, PresenceState>,
 ) => Remote<EditMetadata, Delta, PresenceState>;
 

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -164,7 +164,9 @@ export type GetRemoteFn<EditMetadata, Delta, PresenceState> = (
   userId: string,
   remoteSyncInfo: RemoteSyncInfo,
   onEvent: OnEventFn<EditMetadata, Delta, PresenceState>,
-) => Remote<EditMetadata, Delta, PresenceState>;
+) =>
+  | Remote<EditMetadata, Delta, PresenceState>
+  | Promise<Remote<EditMetadata, Delta, PresenceState>>;
 
 export interface LocalStore<EditMetadata, Delta, PresenceState> {
   update(


### PR DESCRIPTION
- rename `reconnectSettings` to `networkSettings`
- expose `networkSettings` in trimerge-indexed-db
- increase default election timeout
- add connection logging to basic WebSocket client
- ensure closeRemote() logic is queued in remoteQueue (deadlock bug)
- add localStoreId used in AbstractLocalStore/trimerge-indexed-db
- rename syncId to syncCursor (in most places)
- basic-server:
  - do not broadcast events to other connections on same store id
  - only broadcast 'nodes' that have been acknowledged by store
  - tweak logging format in sample-server
- expose more options in createIndexedDbBackendFactory
- disable fast refresh on example app (currently breaks things)
- do not add nodes twice in TrimergeClient (bug 1)
- AbstractLocalStorage bugs:
  - track remote-via-local as remoteOrigin events (bug 2)
  - do not redispatch nodes events (bug 3)
- allow GetRemoteFn to return a promise to a remote