### PR TITLE
add migrate function to differ, add typechecking everywhere

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,6 +13,7 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn lint
       - run: yarn build-all
+      - run: yarn typecheck
       - run: yarn test-ci
         timeout-minutes: 5
       - run: yarn codecov

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test-ci": "CI=true wsrun --no-prefix --serial test-ci",
     "build-all": "wsrun --serial build",
     "watch-all": "wsrun --parallel watch",
+    "typecheck": "wsrun --serial tsc --noEmit",
     "lint": "eslint packages/*/src/**/*.ts",
     "bump-version": "node bump-version.mjs"
   },
@@ -22,19 +23,19 @@
   "peerDependencies": {},
   "devDependencies": {
     "@descript/jest-github-reporter": "^1.0.1",
-    "@types/jest": "27.0.1",
-    "@typescript-eslint/eslint-plugin": "4.31.2",
-    "@typescript-eslint/parser": "4.31.2",
+    "@types/jest": "27.0.2",
+    "@typescript-eslint/eslint-plugin": "5.1.0",
+    "@typescript-eslint/parser": "5.1.0",
     "codecov": "3.8.3",
-    "eslint": "7.32.0",
+    "eslint": "8.0.1",
     "eslint-config-prettier": "8.3.0",
     "fs-extra": "^10.0.0",
     "husky": "4.3.0",
     "prettier": "2.4.1",
     "pretty-quick": "3.1.1",
-    "ts-jest": "27.0.5",
+    "ts-jest": "27.0.7",
     "tslint-config-prettier": "1.18.0",
-    "typescript": "4.4.3",
+    "typescript": "4.4.4",
     "wsrun": "5.2.4"
   }
 }

--- a/packages/example-broadcast-channel/src/AppState.ts
+++ b/packages/example-broadcast-channel/src/AppState.ts
@@ -29,7 +29,7 @@ export const defaultState = {
 };
 
 export const differ: Differ<SavedState, AppState, string, Delta> = {
-  migrate: (state) => state,
+  migrate: (state, editMetadata) => ({ state, editMetadata }),
   diff,
   patch: (priorOrNext, delta) => patch(priorOrNext, delta) ?? defaultState,
   computeRef,

--- a/packages/example-broadcast-channel/src/AppState.ts
+++ b/packages/example-broadcast-channel/src/AppState.ts
@@ -13,18 +13,23 @@ import { computeRef } from 'trimerge-sync-hash';
 import { currentTabId } from './lib/currentTabId';
 import { FocusPresenceState } from './lib/FocusPresenceState';
 
-export type AppState = {
+type AppStateV1 = {
   title: string;
   text: string;
   slider: number;
 };
+type SavedState = AppStateV1;
+
+export type AppState = AppStateV1;
+
 export const defaultState = {
   title: '',
   text: '',
   slider: 0,
 };
 
-export const differ: Differ<AppState, string, Delta> = {
+export const differ: Differ<SavedState, AppState, string, Delta> = {
+  migrate: (state) => state,
   diff,
   patch: (priorOrNext, delta) => patch(priorOrNext, delta) ?? defaultState,
   computeRef,
@@ -34,7 +39,7 @@ export const differ: Differ<AppState, string, Delta> = {
 const DEMO_DOC_ID = 'demo';
 const DEMO_USER_ID = 'local';
 export function useDemoAppState() {
-  return useTrimergeState<AppState, string, Delta>(
+  return useTrimergeState<SavedState, AppState, string, Delta>(
     DEMO_DOC_ID,
     DEMO_USER_ID,
     currentTabId,
@@ -52,15 +57,16 @@ export function useDemoAppDeleteDatabase() {
 }
 
 export function useDemoAppClientList() {
-  return useTrimergeClientList<AppState, string, Delta, FocusPresenceState>(
-    DEMO_DOC_ID,
-    DEMO_USER_ID,
-    currentTabId,
-    differ,
-  );
+  return useTrimergeClientList<
+    SavedState,
+    AppState,
+    string,
+    Delta,
+    FocusPresenceState
+  >(DEMO_DOC_ID, DEMO_USER_ID, currentTabId, differ);
 }
 export function useDemoAppSyncStatus() {
-  return useTrimergeSyncStatus<AppState, string, Delta>(
+  return useTrimergeSyncStatus<SavedState, AppState, string, Delta>(
     DEMO_DOC_ID,
     DEMO_USER_ID,
     currentTabId,
@@ -68,7 +74,7 @@ export function useDemoAppSyncStatus() {
   );
 }
 export function useDemoAppShutdown() {
-  return useTrimergeStateShutdown<AppState, string, Delta>(
+  return useTrimergeStateShutdown<SavedState, AppState, string, Delta>(
     DEMO_DOC_ID,
     DEMO_USER_ID,
     currentTabId,

--- a/packages/example-broadcast-channel/src/lib/trimergeDiffer.ts
+++ b/packages/example-broadcast-channel/src/lib/trimergeDiffer.ts
@@ -18,7 +18,7 @@ const trimergeObjects = combineMergers(
 );
 
 export const merge: MergeStateFn<any, string> = (base, left, right) => ({
-  value: trimergeObjects(base?.value, left.value, right.value),
+  state: trimergeObjects(base?.state, left.state, right.state),
   editMetadata: `merge`,
 });
 

--- a/packages/example-broadcast-channel/src/lib/trimergeHooks.ts
+++ b/packages/example-broadcast-channel/src/lib/trimergeHooks.ts
@@ -17,23 +17,23 @@ export type UpdatePresenceFn<PresenceState> = (
 
 const TRIMERGE_CLIENT_CACHE: Record<
   string,
-  TrimergeClient<any, any, any, any>
+  TrimergeClient<any, any, any, any, any>
 > = {};
 
-function getCachedTrimergeClient<State, EditMetadata, Delta, PresenceState>(
+function getCachedTrimergeClient<
+  SavedState,
+  State extends SavedState,
+  EditMetadata,
+  Delta,
+>(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<State, EditMetadata, Delta>,
+  differ: Differ<SavedState, State, EditMetadata, Delta>,
 ) {
   const key = `${docId}:${userId}:${clientId}`;
   if (!TRIMERGE_CLIENT_CACHE[key]) {
-    TRIMERGE_CLIENT_CACHE[key] = new TrimergeClient<
-      State,
-      EditMetadata,
-      Delta,
-      PresenceState
-    >(
+    TRIMERGE_CLIENT_CACHE[key] = new TrimergeClient(
       userId,
       clientId,
       createIndexedDbBackendFactory(docId, {
@@ -54,11 +54,16 @@ function getCachedTrimergeClient<State, EditMetadata, Delta, PresenceState>(
   return TRIMERGE_CLIENT_CACHE[key];
 }
 
-export function useTrimergeStateShutdown<State, EditMetadata, Delta>(
+export function useTrimergeStateShutdown<
+  SavedState,
+  State extends SavedState,
+  EditMetadata,
+  Delta,
+>(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<State, EditMetadata, Delta>,
+  differ: Differ<SavedState, State, EditMetadata, Delta>,
 ): void {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
 
@@ -70,11 +75,16 @@ export function useTrimergeStateShutdown<State, EditMetadata, Delta>(
   }, [client]);
 }
 
-export function useTrimergeDeleteDatabase<State, EditMetadata, Delta>(
+export function useTrimergeDeleteDatabase<
+  SavedState,
+  State extends SavedState,
+  EditMetadata,
+  Delta,
+>(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<State, EditMetadata, Delta>,
+  differ: Differ<SavedState, State, EditMetadata, Delta>,
 ): () => Promise<void> {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
 
@@ -87,11 +97,16 @@ export function useTrimergeDeleteDatabase<State, EditMetadata, Delta>(
   }, [client, docId]);
 }
 
-export function useTrimergeState<State, EditMetadata, Delta>(
+export function useTrimergeState<
+  SavedState,
+  State extends SavedState,
+  EditMetadata,
+  Delta,
+>(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<State, EditMetadata, Delta>,
+  differ: Differ<SavedState, State, EditMetadata, Delta>,
 ): [State, UpdateStateFn<State, EditMetadata>] {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
   const [state, setState] = useState(client.state);
@@ -104,7 +119,8 @@ export function useTrimergeState<State, EditMetadata, Delta>(
 }
 
 export function useTrimergeClientList<
-  State,
+  SavedState,
+  State extends SavedState,
   EditMetadata,
   Delta,
   PresenceState,
@@ -112,7 +128,7 @@ export function useTrimergeClientList<
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<State, EditMetadata, Delta>,
+  differ: Differ<SavedState, State, EditMetadata, Delta>,
 ): [ClientList<PresenceState>, UpdatePresenceFn<PresenceState>] {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
   const [clients, setClients] = useState(client.clients);
@@ -127,11 +143,16 @@ export function useTrimergeClientList<
   return [clients, updatePresenceState];
 }
 
-export function useTrimergeSyncStatus<State, EditMetadata, Delta>(
+export function useTrimergeSyncStatus<
+  SavedState,
+  State extends SavedState,
+  EditMetadata,
+  Delta,
+>(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<State, EditMetadata, Delta>,
+  differ: Differ<SavedState, State, EditMetadata, Delta>,
 ): SyncStatus {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
   const [status, setStatus] = useState(client.syncStatus);

--- a/packages/trimerge-sync-basic-client/package.json
+++ b/packages/trimerge-sync-basic-client/package.json
@@ -40,15 +40,15 @@
     "src/**/*"
   ],
   "devDependencies": {
-    "@rollup/plugin-commonjs": "20.0.0",
-    "@rollup/plugin-node-resolve": "13.0.4",
+    "@rollup/plugin-commonjs": "21.0.0",
+    "@rollup/plugin-node-resolve": "13.0.6",
     "jest": "27.0.6",
-    "rollup": "2.56.3",
+    "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge-sync": "0.11.1",
-    "ts-node": "^10.2.1",
+    "ts-node": "^10.3.0",
     "ts-node-dev": "^1.1.8",
-    "typescript": "4.4.3"
+    "typescript": "4.4.4"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/trimerge-sync-basic-server/package.json
+++ b/packages/trimerge-sync-basic-server/package.json
@@ -34,10 +34,10 @@
   },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {
-    "@types/ws": "^7.4.7",
+    "@types/ws": "^8.2.0",
     "fs-extra": "^10.0.0",
     "trimerge-sync": "0.11.1",
-    "ws": "^8.2.2"
+    "ws": "^8.2.3"
   },
   "files": [
     "dist/**/*",
@@ -47,18 +47,18 @@
     "better-sqlite3": "^7.4.1"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "20.0.0",
-    "@rollup/plugin-node-resolve": "13.0.4",
+    "@rollup/plugin-commonjs": "21.0.0",
+    "@rollup/plugin-node-resolve": "13.0.6",
     "@types/better-sqlite3": "^7.4.0",
-    "@types/fs-extra": "^9.0.12",
+    "@types/fs-extra": "^9.0.13",
     "better-sqlite3": "^7.4.3",
     "jest": "27.0.6",
-    "rollup": "2.56.3",
+    "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge-sync": "0.11.1",
-    "ts-node": "^10.2.1",
+    "ts-node": "^10.3.0",
     "ts-node-dev": "^1.1.8",
-    "typescript": "4.4.3"
+    "typescript": "4.4.4"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/trimerge-sync-basic-server/src/lib/connection.ts
+++ b/packages/trimerge-sync-basic-server/src/lib/connection.ts
@@ -23,11 +23,12 @@ export class Connection {
       this.logger.info('socket closed', {});
       this.queueExec(async () => this.onClosed());
     });
-    ws.on('message', (message) => {
-      if (typeof message !== 'string') {
+    ws.on('message', (data, isBinary) => {
+      if (isBinary) {
         this.closeWithCode(UnsupportedData, 'bad-request', 'unsupported data');
         return;
       }
+      const message = data.toString();
       if (message.length > 1_000_000) {
         this.closeWithCode(MessageTooBig, 'bad-request', 'payload too big');
         return;

--- a/packages/trimerge-sync-hash/package.json
+++ b/packages/trimerge-sync-hash/package.json
@@ -42,12 +42,12 @@
     "src/**/*"
   ],
   "devDependencies": {
-    "@rollup/plugin-commonjs": "20.0.0",
-    "@rollup/plugin-node-resolve": "13.0.4",
+    "@rollup/plugin-commonjs": "21.0.0",
+    "@rollup/plugin-node-resolve": "13.0.6",
     "jest": "27.0.6",
-    "rollup": "2.56.3",
+    "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
-    "typescript": "4.4.3"
+    "typescript": "4.4.4"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {
     "broadcast-channel": "^4.2.0",
-    "idb": "6.1.4"
+    "idb": "6.1.5"
   },
   "peerDependencies": {
     "trimerge-sync": "0.11.1"
@@ -46,18 +46,18 @@
     "src/**/*"
   ],
   "devDependencies": {
-    "@rollup/plugin-commonjs": "20.0.0",
-    "@rollup/plugin-node-resolve": "13.0.4",
-    "fake-indexeddb": "^3.1.3",
+    "@rollup/plugin-commonjs": "21.0.0",
+    "@rollup/plugin-node-resolve": "13.0.6",
+    "fake-indexeddb": "^3.1.4",
     "immer": "^9.0.6",
     "jest": "27.0.6",
     "jsondiffpatch": "^0.4.1",
-    "rollup": "2.56.3",
+    "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
     "trimerge-sync": "0.11.1",
     "trimerge-sync-hash": "0.11.1",
-    "typescript": "4.4.3"
+    "typescript": "4.4.4"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.test.ts
@@ -23,7 +23,7 @@ describe('merge', () => {
           "message": "merge",
           "ref": "(1+2)",
         },
-        "value": "hithere",
+        "state": "hithere",
       }
     `);
   });
@@ -40,7 +40,7 @@ describe('merge', () => {
           "message": "merge",
           "ref": "(2+3)",
         },
-        "value": "h thereello",
+        "state": "h thereello",
       }
     `);
   });

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.test.ts
@@ -14,8 +14,8 @@ describe('merge', () => {
     expect(
       merge(
         undefined,
-        { ref: '1', value: 'hi', editMetadata: '' },
-        { ref: '2', value: 'there', editMetadata: '' },
+        { ref: '1', state: 'hi', editMetadata: '' },
+        { ref: '2', state: 'there', editMetadata: '' },
       ),
     ).toMatchInlineSnapshot(`
       Object {
@@ -30,9 +30,9 @@ describe('merge', () => {
   it('merges with base', () => {
     expect(
       merge(
-        { ref: '1', value: 'hi', editMetadata: '' },
-        { ref: '2', value: 'hi there', editMetadata: '' },
-        { ref: '3', value: 'hello', editMetadata: '' },
+        { ref: '1', state: 'hi', editMetadata: '' },
+        { ref: '2', state: 'hi there', editMetadata: '' },
+        { ref: '3', state: 'hello', editMetadata: '' },
       ),
     ).toMatchInlineSnapshot(`
       Object {

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
@@ -46,10 +46,17 @@ export function computeRef(
 }
 
 type TestEditMetadata = string;
+type TestSavedState = any;
 type TestState = any;
 type TestPresenceState = any;
 
-export const differ: Differ<TestState, TestEditMetadata, TestPresenceState> = {
+export const differ: Differ<
+  TestSavedState,
+  TestState,
+  TestEditMetadata,
+  TestPresenceState
+> = {
+  migrate: (state) => state,
   diff,
   patch,
   computeRef,

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
@@ -17,11 +17,12 @@ const trimergeObjects = combineMergers(
   trimergeObject,
 );
 export const merge: MergeStateFn<any, any> = (base, left, right) => ({
-  value: trimergeObjects(base?.value, left.value, right.value),
+  state: trimergeObjects(base?.state, left.state, right.state),
   editMetadata: {
     ref: `(${left.ref}+${right.ref})`,
     message: `merge`,
   },
+  ephemeral: false,
 });
 export const jdp = create({ textDiff: { minLength: 20 } });
 

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
@@ -22,7 +22,7 @@ export const merge: MergeStateFn<any, any> = (base, left, right) => ({
     ref: `(${left.ref}+${right.ref})`,
     message: `merge`,
   },
-  ephemeral: false,
+  lazy: false,
 });
 export const jdp = create({ textDiff: { minLength: 20 } });
 

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
@@ -22,7 +22,6 @@ export const merge: MergeStateFn<any, any> = (base, left, right) => ({
     ref: `(${left.ref}+${right.ref})`,
     message: `merge`,
   },
-  lazy: false,
 });
 export const jdp = create({ textDiff: { minLength: 20 } });
 

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
@@ -57,7 +57,7 @@ export const differ: Differ<
   TestEditMetadata,
   TestPresenceState
 > = {
-  migrate: (state) => state,
+  migrate: (state, editMetadata) => ({ state, editMetadata }),
   diff,
   patch,
   computeRef,

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
@@ -19,7 +19,7 @@ function makeTestClient(
   storeId: string,
   getRemote?: GetRemoteFn<any, any, any>,
 ) {
-  return new TrimergeClient<any, any, any, any>(
+  return new TrimergeClient(
     userId,
     clientId,
     createIndexedDbBackendFactory(docId, {

--- a/packages/trimerge-sync/package.json
+++ b/packages/trimerge-sync/package.json
@@ -44,18 +44,18 @@
     "src/**/*"
   ],
   "devDependencies": {
-    "@rollup/plugin-commonjs": "20.0.0",
-    "@rollup/plugin-node-resolve": "13.0.4",
+    "@rollup/plugin-commonjs": "21.0.0",
+    "@rollup/plugin-node-resolve": "13.0.6",
     "codecov": "3.8.3",
     "immer": "^9.0.6",
     "jest": "27.0.6",
     "jsondiffpatch": "^0.4.1",
     "project-name-generator": "^2.1.9",
-    "rollup": "2.56.3",
+    "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
     "trimerge-sync-hash": "0.11.1",
-    "typescript": "4.4.3"
+    "typescript": "4.4.4"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -44,6 +44,7 @@ describe('TrimergeClient', () => {
     client.updateState('hello2', 'hi');
     client.updateState('hello3', 'hi');
     await timeout(100);
+    expect(() => client.getCommit('xxx')).toThrowError(`unknown ref "xxx"`);
   });
 
   it('handles event with invalid baseRef', async () => {

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -7,7 +7,7 @@ import { migrate } from './testLib/MergeUtils';
 const differ: Differ<any, any, any, any> = {
   migrate,
   diff: () => null,
-  merge: () => ({ value: undefined, editMetadata: undefined }),
+  merge: () => ({ state: undefined, editMetadata: undefined }),
   patch: () => null,
   computeRef: () => 'hash',
 };

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -2,8 +2,10 @@ import { TrimergeClient } from './TrimergeClient';
 import { timeout } from './lib/Timeout';
 import { OnEventFn, SyncEvent } from './types';
 import { Differ } from './differ';
+import { migrate } from './testLib/MergeUtils';
 
-const differ: Differ<any, any, any> = {
+const differ: Differ<any, any, any, any> = {
+  migrate,
   diff: () => null,
   merge: () => ({ value: undefined, editMetadata: undefined }),
   patch: () => null,
@@ -11,11 +13,11 @@ const differ: Differ<any, any, any> = {
 };
 
 function makeTrimergeClient(): {
-  client: TrimergeClient<any, any, any, any>;
+  client: TrimergeClient<any, any, any, any, any>;
   onEvent: OnEventFn<any, any, any>;
 } {
   let onEvent: OnEventFn<any, any, any> | undefined;
-  const client = new TrimergeClient<any, any, any, any>(
+  const client = new TrimergeClient(
     '',
     '',
     (userId, clientId, _onEvent) => {

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -237,17 +237,15 @@ export class TrimergeClient<
   private migrateCommit(
     commit: CommitState<SavedState, EditMetadata>,
   ): CommitState<State, EditMetadata> {
-    const migrated = this.differ.migrate(commit);
-    if (commit === migrated) {
-      return migrated;
-    }
-    const ref = this.addNewCommit(
-      migrated.state,
-      migrated.editMetadata,
-      true,
-      commit,
+    const { state, editMetadata } = this.differ.migrate(
+      commit.state,
+      commit.editMetadata,
     );
-    return { ref, ...migrated };
+    if (commit.state === state) {
+      return { ...commit, state };
+    }
+    const ref = this.addNewCommit(state, editMetadata, true, commit);
+    return { ref, state, editMetadata };
   }
 
   private mergeHeads() {

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -354,8 +354,23 @@ export class TrimergeClient<
         this.lazyCommits.set(commit.ref, commit);
         break;
       case 'local':
+        this.promoteLazyCommit(baseRef);
+        this.promoteLazyCommit(mergeRef);
         this.unsyncedCommits.push(commit);
         break;
+    }
+  }
+
+  private promoteLazyCommit(ref?: string) {
+    if (!ref) {
+      return;
+    }
+    const commit = this.lazyCommits.get(ref);
+    if (commit) {
+      this.promoteLazyCommit(commit.baseRef);
+      this.promoteLazyCommit(commit.mergeRef);
+      this.lazyCommits.delete(ref);
+      this.unsyncedCommits.push(commit);
     }
   }
 

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -14,7 +14,13 @@ import { getFullId } from './util';
 import { OnChangeFn, SubscriberList } from './lib/SubscriberList';
 import { timeout } from './lib/Timeout';
 
-export class TrimergeClient<State, EditMetadata, Delta, PresenceState> {
+export class TrimergeClient<
+  SavedState,
+  State extends SavedState,
+  EditMetadata,
+  Delta,
+  PresenceState,
+> {
   private current?: CommitStateRef<State, EditMetadata>;
   private lastLocalSyncId: string | undefined;
 
@@ -59,7 +65,7 @@ export class TrimergeClient<State, EditMetadata, Delta, PresenceState> {
       Delta,
       PresenceState
     >,
-    private readonly differ: Differ<State, EditMetadata, Delta>,
+    private readonly differ: Differ<SavedState, State, EditMetadata, Delta>,
     private readonly bufferMs: number,
   ) {
     this.selfFullId = getFullId(userId, clientId);

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -2,16 +2,23 @@ import { Delta } from 'jsondiffpatch';
 import { TrimergeClient } from './TrimergeClient';
 import { Differ } from './differ';
 import { MemoryStore } from './testLib/MemoryStore';
-import { computeRef, diff, merge, patch } from './testLib/MergeUtils';
+import { computeRef, diff, merge, migrate, patch } from './testLib/MergeUtils';
 import { getBasicGraph } from './testLib/GraphVisualizers';
 import { ClientInfo } from './types';
 import { timeout } from './lib/Timeout';
 
 type TestEditMetadata = string;
+type TestSavedState = any;
 type TestState = any;
 type TestPresenceState = any;
 
-const differ: Differ<TestState, TestEditMetadata, TestPresenceState> = {
+const differ: Differ<
+  TestSavedState,
+  TestState,
+  TestEditMetadata,
+  TestPresenceState
+> = {
+  migrate,
   diff,
   patch,
   computeRef,
@@ -25,13 +32,20 @@ function newStore() {
 function makeClient(
   userId: string,
   store: MemoryStore<TestEditMetadata, Delta, TestPresenceState>,
-): TrimergeClient<TestState, TestEditMetadata, Delta, TestPresenceState> {
+): TrimergeClient<
+  TestSavedState,
+  TestState,
+  TestEditMetadata,
+  Delta,
+  TestPresenceState
+> {
   return new TrimergeClient(userId, 'test', store.getLocalStore, differ, 0);
 }
 
 function basicGraph(
   store: MemoryStore<TestEditMetadata, Delta, TestPresenceState>,
   client1: TrimergeClient<
+    TestSavedState,
     TestState,
     TestEditMetadata,
     Delta,
@@ -46,7 +60,13 @@ function basicGraph(
 }
 
 function sortedClients(
-  client: TrimergeClient<TestState, TestEditMetadata, Delta, TestPresenceState>,
+  client: TrimergeClient<
+    TestSavedState,
+    TestState,
+    TestEditMetadata,
+    Delta,
+    TestPresenceState
+  >,
 ) {
   return Array.from(client.clients).sort(clientSort);
 }

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -55,7 +55,7 @@ function basicGraph(
   return getBasicGraph(
     store.getCommits(),
     (commit) => commit.editMetadata,
-    (commit) => client1.getCommitState(commit.ref).value,
+    (commit) => client1.getCommitState(commit.ref).state,
   );
 }
 

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -141,6 +141,25 @@ describe('TrimergeClient: 2 users', () => {
     `);
     unsub();
   });
+  it('updates presence', async () => {
+    const store = newStore();
+    const client = makeClient('a', store);
+
+    client.updateState({ hello: 'world' }, 'init');
+    client.updatePresence('blah');
+    await timeout();
+    expect(sortedClients(client)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "clientId": "test",
+    "ref": "4AC3Kqag",
+    "self": true,
+    "state": "blah",
+    "userId": "a",
+  },
+]
+`);
+  });
 
   it('edit syncs across two clients', async () => {
     const store = newStore();

--- a/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
@@ -57,7 +57,7 @@ function basicGraph(
   return getBasicGraph(
     store.getCommits(),
     (commit) => commit.editMetadata.message,
-    (commit) => clientA.getCommitState(commit.ref).value,
+    (commit) => clientA.getCommitState(commit.ref).state,
   );
 }
 

--- a/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
@@ -2,14 +2,21 @@ import { Delta } from 'jsondiffpatch';
 import { TrimergeClient } from './TrimergeClient';
 import { Differ } from './differ';
 import { MemoryStore } from './testLib/MemoryStore';
-import { diff, merge, patch } from './testLib/MergeUtils';
+import { diff, merge, migrate, patch } from './testLib/MergeUtils';
 import { getBasicGraph } from './testLib/GraphVisualizers';
 
 type TestEditMetadata = { ref: string; message: string };
+type TestSavedState = any;
 type TestState = any;
 type TestPresenceState = any;
 
-const differ: Differ<TestState, TestEditMetadata, TestPresenceState> = {
+const differ: Differ<
+  TestSavedState,
+  TestState,
+  TestEditMetadata,
+  TestPresenceState
+> = {
+  migrate,
   diff,
   patch,
   computeRef: (baseRef, mergeRef, delta, editMetadata) => editMetadata.ref,
@@ -23,7 +30,13 @@ function newStore() {
 function makeClient(
   userId: string,
   store: MemoryStore<TestEditMetadata, Delta, TestPresenceState>,
-): TrimergeClient<TestState, TestEditMetadata, Delta, TestPresenceState> {
+): TrimergeClient<
+  TestSavedState,
+  TestState,
+  TestEditMetadata,
+  Delta,
+  TestPresenceState
+> {
   return new TrimergeClient(userId, 'test', store.getLocalStore, differ, 0);
 }
 
@@ -34,6 +47,7 @@ function timeout() {
 function basicGraph(
   store: MemoryStore<TestEditMetadata, Delta, TestPresenceState>,
   clientA: TrimergeClient<
+    TestSavedState,
     TestState,
     TestEditMetadata,
     Delta,

--- a/packages/trimerge-sync/src/TrimergeClient_Fuzz.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Fuzz.test.ts
@@ -2,15 +2,22 @@ import { Delta } from 'jsondiffpatch';
 import { TrimergeClient } from './TrimergeClient';
 import { Differ } from './differ';
 import { MemoryStore } from './testLib/MemoryStore';
-import { computeRef, diff, merge, patch } from './testLib/MergeUtils';
+import { computeRef, diff, merge, migrate, patch } from './testLib/MergeUtils';
 import { getBasicGraph } from './testLib/GraphVisualizers';
 import { timeout } from './lib/Timeout';
 
 type TestEditMetadata = any;
+type TestSavedState = any;
 type TestState = any;
 type TestPresenceState = any;
 
-const differ: Differ<TestState, TestEditMetadata, TestPresenceState> = {
+const differ: Differ<
+  TestSavedState,
+  TestState,
+  TestEditMetadata,
+  TestPresenceState
+> = {
+  migrate,
   diff,
   patch,
   computeRef,
@@ -24,7 +31,13 @@ function newStore() {
 function makeClient(
   userId: string,
   store: MemoryStore<TestEditMetadata, Delta, TestPresenceState>,
-): TrimergeClient<TestState, TestEditMetadata, Delta, TestPresenceState> {
+): TrimergeClient<
+  TestSavedState,
+  TestState,
+  TestEditMetadata,
+  Delta,
+  TestPresenceState
+> {
   return new TrimergeClient(userId, 'test', store.getLocalStore, differ, 0);
 }
 

--- a/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
@@ -1,0 +1,139 @@
+import { Delta } from 'jsondiffpatch';
+import { TrimergeClient } from './TrimergeClient';
+import { MemoryStore } from './testLib/MemoryStore';
+import { computeRef, diff, merge, patch } from './testLib/MergeUtils';
+import { getBasicGraph } from './testLib/GraphVisualizers';
+import { timeout } from './lib/Timeout';
+
+type TestEditMetadata = string;
+type DocV1 = { v: 1; field: number };
+type DocV2 = { v: 2; field: string };
+type TestPresenceState = any;
+
+function newStore() {
+  return new MemoryStore<TestEditMetadata, Delta, TestPresenceState>();
+}
+
+function makeClientV1(
+  userId: string,
+  store: MemoryStore<TestEditMetadata, Delta, TestPresenceState>,
+): TrimergeClient<DocV1, DocV1, TestEditMetadata, Delta, TestPresenceState> {
+  return new TrimergeClient(
+    userId,
+    'test',
+    store.getLocalStore,
+    {
+      migrate: (state, editMetadata) => ({ state, editMetadata }),
+      diff,
+      patch: (priorOrNext, delta) => patch(priorOrNext as any, delta),
+      computeRef,
+      merge,
+    },
+    0,
+  );
+}
+function makeClientV2(
+  userId: string,
+  store: MemoryStore<TestEditMetadata, Delta, TestPresenceState>,
+): TrimergeClient<
+  DocV1 | DocV2,
+  DocV2,
+  TestEditMetadata,
+  Delta,
+  TestPresenceState
+> {
+  return new TrimergeClient(
+    userId,
+    'test',
+    store.getLocalStore,
+    {
+      migrate: (state, editMetadata) => {
+        switch (state.v) {
+          case 1:
+            return {
+              state: { v: 2, field: String(state.field) },
+              editMetadata: 'migrated to v2',
+            };
+          case 2:
+            return { state, editMetadata };
+        }
+      },
+      diff,
+      patch: (priorOrNext, delta) => patch(priorOrNext as any, delta),
+      computeRef,
+      merge,
+    },
+    0,
+  );
+}
+
+function basicGraph(
+  store: MemoryStore<TestEditMetadata, Delta, TestPresenceState>,
+  client1: TrimergeClient<any, any, any, any, any>,
+) {
+  return getBasicGraph(
+    store.getCommits(),
+    (commit) => commit.editMetadata,
+    (commit) => client1.getCommitState(commit.ref).state,
+  );
+}
+
+describe('TrimergeClient: Migration', () => {
+  it('migrates from one version to another', async () => {
+    const store = newStore();
+
+    const client1 = makeClientV1('a', store);
+    client1.updateState({ v: 1, field: 123 }, 'initialize');
+    expect(client1.state).toEqual({ v: 1, field: 123 });
+
+    await timeout();
+
+    expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "graph": "undefined -> Z-zhYWBg",
+    "step": "User a: initialize",
+    "value": Object {
+      "field": 123,
+      "v": 1,
+    },
+  },
+]
+`);
+
+    const client2 = makeClientV2('a', store);
+
+    await timeout();
+
+    expect(client2.state).toEqual({ v: 2, field: '123' });
+
+    expect(basicGraph(store, client2)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "graph": "undefined -> Z-zhYWBg",
+    "step": "User a: initialize",
+    "value": Object {
+      "field": 123,
+      "v": 1,
+    },
+  },
+]
+`);
+
+    client2.updateState({ v: 2, field: '456' }, 'update field');
+    expect(client2.state).toEqual({ v: 2, field: '456' });
+
+    expect(basicGraph(store, client2)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "graph": "undefined -> Z-zhYWBg",
+    "step": "User a: initialize",
+    "value": Object {
+      "field": 123,
+      "v": 1,
+    },
+  },
+]
+`);
+  });
+});

--- a/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
@@ -123,6 +123,8 @@ Array [
     client2.updateState({ v: 2, field: '456' }, 'update field');
     expect(client2.state).toEqual({ v: 2, field: '456' });
 
+    await timeout();
+
     expect(basicGraph(store, client2)).toMatchInlineSnapshot(`
 Array [
   Object {
@@ -131,6 +133,22 @@ Array [
     "value": Object {
       "field": 123,
       "v": 1,
+    },
+  },
+  Object {
+    "graph": "Z-zhYWBg -> wjdpLZeO",
+    "step": "User a: migrated to v2",
+    "value": Object {
+      "field": "123",
+      "v": 2,
+    },
+  },
+  Object {
+    "graph": "wjdpLZeO -> UzG9E1u9",
+    "step": "User a: update field",
+    "value": Object {
+      "field": "456",
+      "v": 2,
     },
   },
 ]

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -78,7 +78,7 @@ function basicGraph(
   return getBasicGraph(
     store.getCommits(),
     (commit) => commit.editMetadata,
-    (commit) => client1.getCommitState(commit.ref).value,
+    (commit) => client1.getCommitState(commit.ref).state,
   );
 }
 

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -1,4 +1,4 @@
-import { computeRef, diff, merge, patch } from './testLib/MergeUtils';
+import { computeRef, diff, merge, migrate, patch } from './testLib/MergeUtils';
 import { Differ } from './differ';
 import { MemoryStore } from './testLib/MemoryStore';
 import { Delta } from 'jsondiffpatch';
@@ -9,10 +9,17 @@ import { timeout } from './lib/Timeout';
 import { resetAll } from './testLib/MemoryBroadcastChannel';
 
 type TestEditMetadata = string;
+type TestSavedState = any;
 type TestState = any;
 type TestPresenceState = any;
 
-const differ: Differ<TestState, TestEditMetadata, TestPresenceState> = {
+const differ: Differ<
+  TestSavedState,
+  TestState,
+  TestEditMetadata,
+  TestPresenceState
+> = {
+  migrate,
   diff,
   patch,
   computeRef,
@@ -48,13 +55,20 @@ function makeClient(
   userId: string,
   clientId: string,
   store: MemoryStore<TestEditMetadata, Delta, TestPresenceState>,
-): TrimergeClient<TestState, TestEditMetadata, Delta, TestPresenceState> {
+): TrimergeClient<
+  TestSavedState,
+  TestState,
+  TestEditMetadata,
+  Delta,
+  TestPresenceState
+> {
   return new TrimergeClient(userId, clientId, store.getLocalStore, differ, 0);
 }
 
 function basicGraph(
   store: MemoryStore<TestEditMetadata, Delta, TestPresenceState>,
   client1: TrimergeClient<
+    TestSavedState,
     TestState,
     TestEditMetadata,
     Delta,
@@ -70,6 +84,7 @@ function basicGraph(
 
 function basicClients(
   client1: TrimergeClient<
+    TestSavedState,
     TestState,
     TestEditMetadata,
     Delta,

--- a/packages/trimerge-sync/src/differ.test.ts
+++ b/packages/trimerge-sync/src/differ.test.ts
@@ -2,32 +2,41 @@ import { MigrateStateFn } from './differ';
 
 describe('migrate type tests', () => {
   it('migrates', () => {
-    type DocV1 = { version: 1 };
-    type DocV2 = { version: 2 };
+    type DocV1 = { version: 1; a: number };
+    type DocV2 = { version: 2; b: number };
     type SavedState = DocV1 | DocV2;
     type State = DocV2;
-    const migrate: MigrateStateFn<SavedState, State> = (state) => {
+    const migrate: MigrateStateFn<SavedState, State, string> = (
+      state,
+      editMetadata,
+    ) => {
       switch (state.version) {
         case 1:
-          return { ...state, version: 2 };
+          return { state: { version: 2, b: state.a }, editMetadata: 'migrate' };
         case 2:
-          return state;
+          // Up to date
+          return { state, editMetadata };
       }
     };
-    const v1Doc: DocV1 = { version: 1 };
-    const v2Doc: DocV2 = { version: 2 };
-    expect(migrate(v1Doc)).toEqual(v2Doc);
-    expect(migrate(v2Doc)).toBe(v2Doc);
+    const v1Doc: DocV1 = { version: 1, a: 12 };
+    const v2Doc: DocV2 = { version: 2, b: 12 };
+    expect(migrate(v1Doc, 'v1')).toEqual({
+      state: v2Doc,
+      editMetadata: 'migrate',
+    });
+    expect(migrate(v2Doc, 'v2').state).toBe(v2Doc);
 
     // @ts-expect-error invalid initial doc type
     expect(migrate({})).toBeUndefined();
   });
+
   it('valid type', () => {
     type SavedState = { version: number };
     type State = { version: 2 };
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    type Migrate = MigrateStateFn<SavedState, State>;
+    type Migrate = MigrateStateFn<SavedState, State, any>;
   });
+
   it('invalid type', () => {
     type DocV1 = { version: 1 };
     type DocV2 = { version: 2 };
@@ -35,6 +44,6 @@ describe('migrate type tests', () => {
     type State = DocV2;
     // @ts-expect-error State needs to be assignable to SavedState
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    type Migrate = MigrateStateFn<SavedState, State>;
+    type Migrate = MigrateStateFn<SavedState, State, any>;
   });
 });

--- a/packages/trimerge-sync/src/differ.test.ts
+++ b/packages/trimerge-sync/src/differ.test.ts
@@ -1,0 +1,40 @@
+import { MigrateStateFn } from './differ';
+
+describe('migrate type tests', () => {
+  it('migrates', () => {
+    type DocV1 = { version: 1 };
+    type DocV2 = { version: 2 };
+    type SavedState = DocV1 | DocV2;
+    type State = DocV2;
+    const migrate: MigrateStateFn<SavedState, State> = (state) => {
+      switch (state.version) {
+        case 1:
+          return { ...state, version: 2 };
+        case 2:
+          return state;
+      }
+    };
+    const v1Doc: DocV1 = { version: 1 };
+    const v2Doc: DocV2 = { version: 2 };
+    expect(migrate(v1Doc)).toEqual(v2Doc);
+    expect(migrate(v2Doc)).toBe(v2Doc);
+
+    // @ts-expect-error invalid initial doc type
+    expect(migrate({})).toBeUndefined();
+  });
+  it('valid type', () => {
+    type SavedState = { version: number };
+    type State = { version: 2 };
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type Migrate = MigrateStateFn<SavedState, State>;
+  });
+  it('invalid type', () => {
+    type DocV1 = { version: 1 };
+    type DocV2 = { version: 2 };
+    type SavedState = DocV1;
+    type State = DocV2;
+    // @ts-expect-error State needs to be assignable to SavedState
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type Migrate = MigrateStateFn<SavedState, State>;
+  });
+});

--- a/packages/trimerge-sync/src/differ.ts
+++ b/packages/trimerge-sync/src/differ.ts
@@ -29,7 +29,18 @@ export type MergeStateFn<State, EditMetadata> = (
   right: CommitStateRef<State, EditMetadata>,
 ) => CommitState<State, EditMetadata>;
 
-export interface Differ<State, EditMetadata, Delta> {
+export type MigrateStateFn<SavedState, State extends SavedState> = (
+  state: SavedState | State,
+) => State;
+
+export interface Differ<
+  SavedState,
+  State extends SavedState,
+  EditMetadata,
+  Delta,
+> {
+  readonly migrate: MigrateStateFn<SavedState, State>;
+
   /** Calculate the ref string for a given edit */
   readonly computeRef: ComputeRefFn<Delta, EditMetadata>;
 

--- a/packages/trimerge-sync/src/differ.ts
+++ b/packages/trimerge-sync/src/differ.ts
@@ -5,33 +5,41 @@ export type ComputeRefFn<Delta, EditMetadata> = (
   editMetadata: EditMetadata,
 ) => string;
 
-export type DiffFn<State, Delta> = (
-  prior: State | undefined,
-  state: State,
+export type DiffFn<SavedState, Delta> = (
+  prior: SavedState | undefined,
+  state: SavedState,
 ) => Delta | undefined;
 
-export type PatchFn<State, Delta> = (
-  priorOrNext: State | undefined,
+export type PatchFn<SavedState, Delta> = (
+  priorOrNext: SavedState | undefined,
   delta: Delta | undefined,
-) => State;
+) => SavedState;
 
-export type CommitState<State, EditMetadata> = {
-  value: State;
+export type StateAndMetadata<State, EditMetadata> = {
+  state: State;
   editMetadata: EditMetadata;
 };
-export type CommitStateRef<State, EditMetadata> = {
+export type CommitState<State, EditMetadata> = {
   ref: string;
-} & CommitState<State, EditMetadata>;
+} & StateAndMetadata<State, EditMetadata>;
+
+export type MergeResult<State, EditMetadata> = {
+  lazy?: boolean;
+} & StateAndMetadata<State, EditMetadata>;
 
 export type MergeStateFn<State, EditMetadata> = (
-  base: CommitStateRef<State, EditMetadata> | undefined,
-  left: CommitStateRef<State, EditMetadata>,
-  right: CommitStateRef<State, EditMetadata>,
-) => CommitState<State, EditMetadata>;
+  base: CommitState<State, EditMetadata> | undefined,
+  left: CommitState<State, EditMetadata>,
+  right: CommitState<State, EditMetadata>,
+) => MergeResult<State, EditMetadata>;
 
-export type MigrateStateFn<SavedState, State extends SavedState> = (
-  state: SavedState | State,
-) => State;
+export type MigrateStateFn<
+  SavedState,
+  State extends SavedState,
+  EditMetadata,
+> = (
+  state: CommitState<SavedState, EditMetadata>,
+) => CommitState<State, EditMetadata> | StateAndMetadata<State, EditMetadata>;
 
 export interface Differ<
   SavedState,
@@ -39,15 +47,15 @@ export interface Differ<
   EditMetadata,
   Delta,
 > {
-  readonly migrate: MigrateStateFn<SavedState, State>;
+  readonly migrate: MigrateStateFn<SavedState, State, EditMetadata>;
 
   /** Calculate the ref string for a given edit */
   readonly computeRef: ComputeRefFn<Delta, EditMetadata>;
 
   /** Computed the difference between two States */
-  readonly diff: DiffFn<State, Delta>;
+  readonly diff: DiffFn<SavedState, Delta>;
   /** Apply a patch from one state to another */
-  readonly patch: PatchFn<State, Delta>;
+  readonly patch: PatchFn<SavedState, Delta>;
 
   /** Trimerge three states */
   readonly merge: MergeStateFn<State, EditMetadata>;

--- a/packages/trimerge-sync/src/differ.ts
+++ b/packages/trimerge-sync/src/differ.ts
@@ -38,8 +38,9 @@ export type MigrateStateFn<
   State extends SavedState,
   EditMetadata,
 > = (
-  state: CommitState<SavedState, EditMetadata>,
-) => CommitState<State, EditMetadata> | StateAndMetadata<State, EditMetadata>;
+  state: SavedState,
+  editMetadata: EditMetadata,
+) => StateAndMetadata<State, EditMetadata>;
 
 export interface Differ<
   SavedState,

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
@@ -2,15 +2,22 @@ import { Delta } from 'jsondiffpatch';
 import { TrimergeClient } from '../TrimergeClient';
 import { Differ } from '../differ';
 import { MemoryStore } from './MemoryStore';
-import { computeRef, diff, merge, patch } from './MergeUtils';
+import { computeRef, diff, merge, migrate, patch } from './MergeUtils';
 import { getBasicGraph, getDotGraph } from './GraphVisualizers';
 import { timeout } from '../lib/Timeout';
 
 type TestEditMetadata = string;
+type TestSavedState = any;
 type TestState = any;
 type TestPresenceState = any;
 
-const differ: Differ<TestState, TestEditMetadata, TestPresenceState> = {
+const differ: Differ<
+  TestSavedState,
+  TestState,
+  TestEditMetadata,
+  TestPresenceState
+> = {
+  migrate,
   diff,
   patch,
   computeRef,
@@ -24,13 +31,20 @@ function newStore() {
 function makeClient(
   userId: string,
   store: MemoryStore<TestEditMetadata, Delta, TestPresenceState>,
-): TrimergeClient<TestState, TestEditMetadata, Delta, TestPresenceState> {
+): TrimergeClient<
+  TestSavedState,
+  TestState,
+  TestEditMetadata,
+  Delta,
+  TestPresenceState
+> {
   return new TrimergeClient(userId, 'test', store.getLocalStore, differ, 0);
 }
 
 function basicGraph(
   store: MemoryStore<TestEditMetadata, Delta, TestPresenceState>,
   client1: TrimergeClient<
+    TestSavedState,
     TestState,
     TestEditMetadata,
     Delta,
@@ -47,6 +61,7 @@ function basicGraph(
 function dotGraph(
   store: MemoryStore<TestEditMetadata, Delta, TestPresenceState>,
   client1: TrimergeClient<
+    TestSavedState,
     TestState,
     TestEditMetadata,
     Delta,

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
@@ -54,7 +54,7 @@ function basicGraph(
   return getBasicGraph(
     store.getCommits(),
     (commit) => commit.editMetadata,
-    (commit) => client1.getCommitState(commit.ref).value,
+    (commit) => client1.getCommitState(commit.ref).state,
   );
 }
 
@@ -70,7 +70,7 @@ function dotGraph(
 ) {
   return getDotGraph(
     store.getCommits(),
-    (commit) => client1.getCommitState(commit.ref).value,
+    (commit) => client1.getCommitState(commit.ref).state,
     (commit) => commit.editMetadata,
   );
 }

--- a/packages/trimerge-sync/src/testLib/MergeUtils.test.ts
+++ b/packages/trimerge-sync/src/testLib/MergeUtils.test.ts
@@ -1,4 +1,4 @@
-import { diff, patch } from './MergeUtils';
+import { diff, migrate, patch } from './MergeUtils';
 
 const A = { a: '1' };
 const B = { a: '2', b: true };
@@ -17,5 +17,12 @@ describe('patch', () => {
   });
   it('patches immutably', () => {
     expect(patch(A, undefined)).toBe(A);
+  });
+});
+
+describe('migrate', () => {
+  it('does nothing', () => {
+    const x = {};
+    expect(migrate(x)).toBe(x);
   });
 });

--- a/packages/trimerge-sync/src/testLib/MergeUtils.test.ts
+++ b/packages/trimerge-sync/src/testLib/MergeUtils.test.ts
@@ -23,6 +23,6 @@ describe('patch', () => {
 describe('migrate', () => {
   it('does nothing', () => {
     const x = {};
-    expect(migrate(x)).toBe(x);
+    expect(migrate(x, '').state).toBe(x);
   });
 });

--- a/packages/trimerge-sync/src/testLib/MergeUtils.ts
+++ b/packages/trimerge-sync/src/testLib/MergeUtils.ts
@@ -35,6 +35,11 @@ export function diff<T>(left: T, right: T) {
   return jdp.diff(left, right);
 }
 
+// Simple no-op migration for unit tests
+export function migrate<State>(state: State): State {
+  return state;
+}
+
 export function computeRef(
   baseRef: string | undefined,
   mergeRef: string | undefined,

--- a/packages/trimerge-sync/src/testLib/MergeUtils.ts
+++ b/packages/trimerge-sync/src/testLib/MergeUtils.ts
@@ -16,7 +16,7 @@ const trimergeObjects = combineMergers(
   trimergeObject,
 );
 export const merge: MergeStateFn<any, any> = (base, left, right) => ({
-  value: trimergeObjects(base?.value, left.value, right.value),
+  state: trimergeObjects(base?.state, left.state, right.state),
   editMetadata: {
     ref: `(${left.ref}+${right.ref})`,
     message: `merge`,

--- a/packages/trimerge-sync/src/testLib/MergeUtils.ts
+++ b/packages/trimerge-sync/src/testLib/MergeUtils.ts
@@ -6,7 +6,7 @@ import {
   trimergeString,
 } from 'trimerge';
 import { create, Delta } from 'jsondiffpatch';
-import { MergeStateFn } from '../differ';
+import { MergeStateFn, StateAndMetadata } from '../differ';
 import { produce } from 'immer';
 import { computeRef as computeShaRef } from 'trimerge-sync-hash';
 
@@ -36,8 +36,11 @@ export function diff<T>(left: T, right: T) {
 }
 
 // Simple no-op migration for unit tests
-export function migrate<State>(state: State): State {
-  return state;
+export function migrate<State, EditMetadata>(
+  state: State,
+  editMetadata: EditMetadata,
+): StateAndMetadata<State, EditMetadata> {
+  return { state, editMetadata };
 }
 
 export function computeRef(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,10 +1360,10 @@
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
   integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
 
-"@cspotcode/source-map-support@0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz#118511f316e2e87ee4294761868e254d3da47960"
-  integrity sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
@@ -1413,6 +1413,21 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@eslint/eslintrc@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.3.tgz#41f08c597025605f672251dcc4e8be66b5ed7366"
+  integrity sha512-DHI1wDPoKCBPoLZA3qDR91+3te/wDSc1YhKg3jR8NxKKRJq2hwHwcWv31cSwSYvIBrmbENoYMWcenW8uproQqg==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.3.2"
+    espree "^9.0.0"
+    globals "^13.9.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -1449,6 +1464,15 @@
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
   integrity sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==
+  dependencies:
+    "@humanwhocodes/object-schema" "^1.2.0"
+    debug "^4.1.1"
+    minimatch "^3.0.4"
+
+"@humanwhocodes/config-array@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.6.0.tgz#b5621fdb3b32309d2d16575456cbc277fa8f021a"
+  integrity sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.0"
     debug "^4.1.1"
@@ -1876,10 +1900,10 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@rollup/plugin-commonjs@20.0.0":
-  version "20.0.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-20.0.0.tgz#3246872dcbcb18a54aaa6277a8c7d7f1b155b745"
-  integrity sha512-5K0g5W2Ol8hAcTHqcTBHiA7M58tfmYi1o9KxeJuuRNpGaTa5iLjcyemBitCBcKXaHamOBBEH2dGom6v6Unmqjg==
+"@rollup/plugin-commonjs@21.0.0":
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.0.tgz#b9e4342855ea20b5528f4587b9a90f642196a502"
+  integrity sha512-XDQimjHl0kNotAV5lLo34XoygaI0teqiKGJ100B3iCU8+15YscJPeqk2KqkqD3NIe1H8ZTUo5lYjUFZyEgASTw==
   dependencies:
     "@rollup/pluginutils" "^3.1.0"
     commondir "^1.0.1"
@@ -1889,10 +1913,10 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
-"@rollup/plugin-node-resolve@13.0.4":
-  version "13.0.4"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.4.tgz#b10222f4145a019740acb7738402130d848660c0"
-  integrity sha512-eYq4TFy40O8hjeDs+sIxEH/jc9lyuI2k9DM557WN6rO5OpnC2qXMBNj4IKH1oHrnAazL49C5p0tgP0/VpqJ+/w==
+"@rollup/plugin-node-resolve@13.0.6":
+  version "13.0.6"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.6.tgz#29629070bb767567be8157f575cfa8f2b8e9ef77"
+  integrity sha512-sFsPDMPd4gMqnh2gS0uIxELnoRUp5kBl5knxD2EO0778G1oOJv4G1vyT2cpWz75OU2jDVcXhjVUuTAczGyFNKA==
   dependencies:
     "@rollup/pluginutils" "^3.1.0"
     "@types/resolve" "1.17.1"
@@ -2215,10 +2239,10 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/fs-extra@^9.0.12":
-  version "9.0.12"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.12.tgz#9b8f27973df8a7a3920e8461517ebf8a7d4fdfaf"
-  integrity sha512-I+bsBr67CurCGnSenZZ7v94gd3tc3+Aj2taxMT4yu4ABLuOgOjeFxX3dokG24ztSRg5tnT00sL8BszO7gSMoIw==
+"@types/fs-extra@^9.0.13":
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
+  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
   dependencies:
     "@types/node" "*"
 
@@ -2285,10 +2309,23 @@
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
 
+"@types/jest@27.0.2":
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.2.tgz#ac383c4d4aaddd29bbf2b916d8d105c304a5fcd7"
+  integrity sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==
+  dependencies:
+    jest-diff "^27.0.0"
+    pretty-format "^27.0.0"
+
 "@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6", "@types/json-schema@^7.0.7":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+
+"@types/json-schema@^7.0.9":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -2352,16 +2389,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "17.0.14"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.14.tgz#f0629761ca02945c4e8fea99b8177f4c5c61fb0f"
-  integrity sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17.0.22":
+"@types/react@*", "@types/react@^17.0.22":
   version "17.0.22"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.22.tgz#c80d1d0e87fe953bae3ab273bef451dea1a6291b"
   integrity sha512-kq/BMeaAVLJM6Pynh8C2rnr/drCK+/5ksH0ch9asz+8FW3DscYCIEFtCeYTFeIx/ubvOsMXmRfy7qEJ76gM96A==
@@ -2454,10 +2482,10 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
-"@types/ws@^7.4.7":
-  version "7.4.7"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
-  integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
+"@types/ws@^8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.2.0.tgz#75faefbe2328f3b833cb8dc640658328990d04f3"
+  integrity sha512-cyeefcUCgJlEk+hk2h3N+MqKKsPViQgF5boi9TTHSK+PoR9KWBb/C5ccPcDyAqgsbAYHTwulch725DV84+pSpg==
   dependencies:
     "@types/node" "*"
 
@@ -2487,7 +2515,21 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@4.31.2", "@typescript-eslint/eslint-plugin@^4.31.2":
+"@typescript-eslint/eslint-plugin@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.1.0.tgz#381c188dfab12f7a2c7b6a8ba2402d6273eadeaa"
+  integrity sha512-bekODL3Tqf36Yz8u+ilha4zGxL9mdB6LIsIoMAvvC5FAuWo4NpZYXtCbv7B2CeR1LhI/lLtLk+q4tbtxuoVuCg==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "5.1.0"
+    "@typescript-eslint/scope-manager" "5.1.0"
+    debug "^4.3.2"
+    functional-red-black-tree "^1.0.1"
+    ignore "^5.1.8"
+    regexpp "^3.2.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/eslint-plugin@^4.31.2":
   version "4.31.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.31.2.tgz#9f41efaee32cdab7ace94b15bd19b756dd099b0a"
   integrity sha512-w63SCQ4bIwWN/+3FxzpnWrDjQRXVEGiTt9tJTRptRXeFvdZc/wLiz3FQUwNQ2CVoRGI6KUWMNUj/pk63noUfcA==
@@ -2538,6 +2580,18 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
+"@typescript-eslint/experimental-utils@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.1.0.tgz#918a1a3d30404cc1f8edcfdf0df200804ef90d31"
+  integrity sha512-ovE9qUiZMOMgxQAESZsdBT+EXIfx/YUYAbwGUI6V03amFdOOxI9c6kitkgRvLkJaLusgMZ2xBhss+tQ0Y1HWxA==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.1.0"
+    "@typescript-eslint/types" "5.1.0"
+    "@typescript-eslint/typescript-estree" "5.1.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
 "@typescript-eslint/experimental-utils@^3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz#e179ffc81a80ebcae2ea04e0332f8b251345a686"
@@ -2549,7 +2603,17 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@4.31.2", "@typescript-eslint/parser@^4.31.2":
+"@typescript-eslint/parser@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.1.0.tgz#6c7f837d210d2bc0a811e7ea742af414f4e00908"
+  integrity sha512-vx1P+mhCtYw3+bRHmbalq/VKP2Y3gnzNgxGxfEWc6OFpuEL7iQdAeq11Ke3Rhy8NjgB+AHsIWEwni3e+Y7djKA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.1.0"
+    "@typescript-eslint/types" "5.1.0"
+    "@typescript-eslint/typescript-estree" "5.1.0"
+    debug "^4.3.2"
+
+"@typescript-eslint/parser@^4.31.2":
   version "4.31.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.31.2.tgz#54aa75986e3302d91eff2bbbaa6ecfa8084e9c34"
   integrity sha512-EcdO0E7M/sv23S/rLvenHkb58l3XhuSZzKf6DBvLgHqOYdL6YFMYVtreGFWirxaU2mS1GYDby3Lyxco7X5+Vjw==
@@ -2585,6 +2649,14 @@
     "@typescript-eslint/types" "4.31.2"
     "@typescript-eslint/visitor-keys" "4.31.2"
 
+"@typescript-eslint/scope-manager@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.1.0.tgz#6f1f26ad66a8f71bbb33b635e74fec43f76b44df"
+  integrity sha512-yYlyVjvn5lvwCL37i4hPsa1s0ORsjkauhTqbb8MnpvUs7xykmcjGqwlNZ2Q5QpoqkJ1odlM2bqHqJwa28qV6Tw==
+  dependencies:
+    "@typescript-eslint/types" "5.1.0"
+    "@typescript-eslint/visitor-keys" "5.1.0"
+
 "@typescript-eslint/types@3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
@@ -2599,6 +2671,11 @@
   version "4.31.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.31.2.tgz#2aea7177d6d744521a168ed4668eddbd912dfadf"
   integrity sha512-kWiTTBCTKEdBGrZKwFvOlGNcAsKGJSBc8xLvSjSppFO88AqGxGNYtF36EuEYG6XZ9vT0xX8RNiHbQUKglbSi1w==
+
+"@typescript-eslint/types@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.1.0.tgz#a8a75ddfc611660de6be17d3ad950302385607a9"
+  integrity sha512-sEwNINVxcB4ZgC6Fe6rUyMlvsB2jvVdgxjZEjQUQVlaSPMNamDOwO6/TB98kFt4sYYfNhdhTPBEQqNQZjMMswA==
 
 "@typescript-eslint/typescript-estree@3.10.1":
   version "3.10.1"
@@ -2640,6 +2717,19 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.1.0.tgz#132aea34372df09decda961cb42457433aa6e83d"
+  integrity sha512-SSz+l9YrIIsW4s0ZqaEfnjl156XQ4VRmJsbA0ZE1XkXrD3cRpzuZSVCyqeCMR3EBjF27IisWakbBDGhGNIOvfQ==
+  dependencies:
+    "@typescript-eslint/types" "5.1.0"
+    "@typescript-eslint/visitor-keys" "5.1.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/visitor-keys@3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz#cd4274773e3eb63b2e870ac602274487ecd1e931"
@@ -2662,6 +2752,14 @@
   dependencies:
     "@typescript-eslint/types" "4.31.2"
     eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.1.0.tgz#e01a01b27eb173092705ae983aa1451bd1842630"
+  integrity sha512-uqNXepKBg81JVwjuqAxYrXa1Ql/YDzM+8g/pS+TCPxba0wZttl8m5DkrasbfnmJGHs4lQ2jTbcZ5azGhI7kK+w==
+  dependencies:
+    "@typescript-eslint/types" "5.1.0"
+    eslint-visitor-keys "^3.0.0"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -2869,7 +2967,7 @@ acorn@^8.2.4:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.4.1.tgz#56c36251fc7cabc7096adc18f05afe814321a28c"
   integrity sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==
 
-acorn@^8.4.1:
+acorn@^8.4.1, acorn@^8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
   integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
@@ -3048,6 +3146,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 argv@0.0.2:
   version "0.0.2"
@@ -4809,7 +4912,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4:
+debug@4, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -5641,6 +5744,14 @@ eslint-scope@^5.0.0, eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
+eslint-scope@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-6.0.0.tgz#9cf45b13c5ac8f3d4c50f46a5121f61b3e318978"
+  integrity sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
+
 eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
@@ -5665,6 +5776,11 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
+eslint-visitor-keys@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz#e32e99c6cdc2eb063f204eda5db67bfe58bb4186"
+  integrity sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==
+
 eslint-webpack-plugin@^2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/eslint-webpack-plugin/-/eslint-webpack-plugin-2.5.2.tgz#4ee17577d6392bf72048080a1678d6237183db81"
@@ -5676,37 +5792,36 @@ eslint-webpack-plugin@^2.5.2:
     micromatch "^4.0.2"
     schema-utils "^3.0.0"
 
-eslint@7.32.0, eslint@^7.32.0:
-  version "7.32.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.32.0.tgz#c6d328a14be3fb08c8d1d21e12c02fdb7a2a812d"
-  integrity sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==
+eslint@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.0.1.tgz#3610e7fe4a05c2154669515ca60835a76a19f700"
+  integrity sha512-LsgcwZgQ72vZ+SMp4K6pAnk2yFDWL7Ti4pJaRvsZ0Hsw2h8ZjUIW38a9AFn2cZXdBMlScMFYYgsSp4ttFI/0bA==
   dependencies:
-    "@babel/code-frame" "7.12.11"
-    "@eslint/eslintrc" "^0.4.3"
-    "@humanwhocodes/config-array" "^0.5.0"
+    "@eslint/eslintrc" "^1.0.3"
+    "@humanwhocodes/config-array" "^0.6.0"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
-    debug "^4.0.1"
+    debug "^4.3.2"
     doctrine "^3.0.0"
     enquirer "^2.3.5"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^2.1.0"
-    eslint-visitor-keys "^2.0.0"
-    espree "^7.3.1"
+    eslint-scope "^6.0.0"
+    eslint-utils "^3.0.0"
+    eslint-visitor-keys "^3.0.0"
+    espree "^9.0.0"
     esquery "^1.4.0"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
     file-entry-cache "^6.0.1"
     functional-red-black-tree "^1.0.1"
-    glob-parent "^5.1.2"
+    glob-parent "^6.0.1"
     globals "^13.6.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     is-glob "^4.0.0"
-    js-yaml "^3.13.1"
+    js-yaml "^4.1.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
     lodash.merge "^4.6.2"
@@ -5714,11 +5829,10 @@ eslint@7.32.0, eslint@^7.32.0:
     natural-compare "^1.4.0"
     optionator "^0.9.1"
     progress "^2.0.0"
-    regexpp "^3.1.0"
+    regexpp "^3.2.0"
     semver "^7.2.1"
     strip-ansi "^6.0.0"
     strip-json-comments "^3.1.0"
-    table "^6.0.9"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
@@ -5765,6 +5879,52 @@ eslint@^7.11.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
+eslint@^7.32.0:
+  version "7.32.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.32.0.tgz#c6d328a14be3fb08c8d1d21e12c02fdb7a2a812d"
+  integrity sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==
+  dependencies:
+    "@babel/code-frame" "7.12.11"
+    "@eslint/eslintrc" "^0.4.3"
+    "@humanwhocodes/config-array" "^0.5.0"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    enquirer "^2.3.5"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^2.0.0"
+    espree "^7.3.1"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.1.2"
+    globals "^13.6.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.0.4"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    progress "^2.0.0"
+    regexpp "^3.1.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.0"
+    strip-json-comments "^3.1.0"
+    table "^6.0.9"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
@@ -5773,6 +5933,15 @@ espree@^7.3.0, espree@^7.3.1:
     acorn "^7.4.0"
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^1.3.0"
+
+espree@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.0.0.tgz#e90a2965698228502e771c7a58489b1a9d107090"
+  integrity sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==
+  dependencies:
+    acorn "^8.5.0"
+    acorn-jsx "^5.3.1"
+    eslint-visitor-keys "^3.0.0"
 
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
@@ -6035,13 +6204,12 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fake-indexeddb@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-3.1.3.tgz#76d59146a6b994b9bb50ac9949cbd96ad6cca760"
-  integrity sha512-kpWYPIUGmxW8Q7xG7ampGL63fU/kYNukrIyy9KFj3+KVlFbE/SmvWebzWXBiCMeR0cPK6ufDoGC7MFkPhPLH9w==
+fake-indexeddb@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-3.1.4.tgz#39644c3fb4b64e28fca64a6ccf18f265827e18e7"
+  integrity sha512-kweAGUKgo/NLHZpyMcgYk2ihDrWQcpzwZ3Y2Ag6/Wo3h8F/ts0onw0nTEth8YjWzzBY+sxSSKFn69vc7xcK0Qg==
   dependencies:
     realistic-structured-clone "^2.0.1"
-    setimmediate "^1.0.5"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -6497,6 +6665,13 @@ glob-parent@^5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
+
 glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -6572,6 +6747,18 @@ globby@^11.0.3:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
   integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
+globby@^11.0.4:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -6960,10 +7147,10 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
-idb@6.1.4:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/idb/-/idb-6.1.4.tgz#ec77519fe2591be616eaf3bbdedc3662bb558a99"
-  integrity sha512-DshI5yxIB3NYc47cPpfipYX8MSIgQPqVR+WoaGI9EDq6cnLGgGYR1fp6z8/Bq9vMS8Jq1bS3eWUgXpFO5+ypSA==
+idb@6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/idb/-/idb-6.1.5.tgz#dbc53e7adf1ac7c59f9b2bf56e00b4ea4fce8c7b"
+  integrity sha512-IJtugpKkiVXQn5Y+LteyBCNk1N8xpGV3wWZk9EVtZWH8DYkjBn0bX1XnGP9RkyZF0sAcywa6unHqSWKe7q4LGw==
 
 identity-obj-proxy@3.0.0:
   version "3.0.0"
@@ -6994,7 +7181,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.4:
+ignore@^5.1.4, ignore@^5.1.8:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
@@ -7349,6 +7536,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-glob@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
@@ -8488,6 +8682,13 @@ js-yaml@3.14.1, js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -8839,7 +9040,7 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash.memoize@^4.1.2:
+lodash.memoize@4.x, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
@@ -11438,6 +11639,11 @@ regexpp@^3.0.0, regexpp@^3.1.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
+regexpp@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
+  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
+
 regexpu-core@^4.7.1:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.7.1.tgz#2dea5a9a07233298fbf0db91fa9abc4c6e0f8ad6"
@@ -11734,10 +11940,10 @@ rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@2.56.3:
-  version "2.56.3"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.56.3.tgz#b63edadd9851b0d618a6d0e6af8201955a77aeff"
-  integrity sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==
+rollup@2.58.0:
+  version "2.58.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.58.0.tgz#a643983365e7bf7f5b7c62a8331b983b7c4c67fb"
+  integrity sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -11994,7 +12200,7 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4, setimmediate@^1.0.5:
+setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -13017,6 +13223,20 @@ ts-jest@27.0.5:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-jest@27.0.7:
+  version "27.0.7"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.0.7.tgz#fb7c8c8cb5526ab371bc1b23d06e745652cca2d0"
+  integrity sha512-O41shibMqzdafpuP+CkrOL7ykbmLh+FqQrXEmV9CydQ5JBk0Sj0uAEF5TNNe94fZWKm3yYvWa/IbyV4Yg1zK2Q==
+  dependencies:
+    bs-logger "0.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^27.0.0"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
+
 ts-node-dev@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ts-node-dev/-/ts-node-dev-1.1.8.tgz#95520d8ab9d45fffa854d6668e2f8f9286241066"
@@ -13033,12 +13253,12 @@ ts-node-dev@^1.1.8:
     ts-node "^9.0.0"
     tsconfig "^7.0.0"
 
-ts-node@^10.2.1:
-  version "10.2.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.2.1.tgz#4cc93bea0a7aba2179497e65bb08ddfc198b3ab5"
-  integrity sha512-hCnyOyuGmD5wHleOQX6NIjJtYVIO8bPP8F2acWkB4W06wdlkgyvJtubO/I9NkI88hCFECbsEgoLc0VNkYmcSfw==
+ts-node@^10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.3.0.tgz#a797f2ed3ff50c9a5d814ce400437cb0c1c048b4"
+  integrity sha512-RYIy3i8IgpFH45AX4fQHExrT8BxDeKTdC83QFJkNzkvt8uFB6QJ8XMyhynYiKMLxt9a7yuXaDBZNOYS3XjDcYw==
   dependencies:
-    "@cspotcode/source-map-support" "0.6.1"
+    "@cspotcode/source-map-support" "0.7.0"
     "@tsconfig/node10" "^1.0.7"
     "@tsconfig/node12" "^1.0.7"
     "@tsconfig/node14" "^1.0.0"
@@ -13212,6 +13432,11 @@ typescript@4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
   integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+
+typescript@4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 typeson-registry@^1.0.0-alpha.20:
   version "1.0.0-alpha.39"
@@ -14004,10 +14229,10 @@ ws@^7.4.5:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
   integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
 
-ws@^8.2.2:
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.2.tgz#ca684330c6dd6076a737250ed81ac1606cb0a63e"
-  integrity sha512-Q6B6H2oc8QY3llc3cB8kVmQ6pnJWVQbP7Q5algTcIxx7YEpc0oU4NBVHlztA7Ekzfhw2r0rPducMUiCGWKQRzw==
+ws@^8.2.3:
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"
+  integrity sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==
 
 wsrun@5.2.4:
   version "5.2.4"


### PR DESCRIPTION
- misc housecleaning
  - update deps
  - update typescript
  - run type checking on all files (including tests) in CI
  - conform to updated `ws` type definitions
- split `State` generic type into `SavedState` (all versions of a doc) and `State extends SavedState` (the latest version of the doc)
  - update all generic types to distinctly use SavedState or State as appropriate
- add `migrate` function to Differ + unit tests
- add initial support for `lazy` commits used for migrations (they do not get synced until a change is made on top of them)
- rename `Value` to `State` in a few places to be more consistent