### PR TITLE
make TrimergeClient sync

### DIFF
--- a/packages/example-broadcast-channel/src/lib/trimergeHooks.ts
+++ b/packages/example-broadcast-channel/src/lib/trimergeHooks.ts
@@ -46,7 +46,6 @@ function getCachedTrimergeClient<
         remoteId: 'localhost',
       }),
       differ,
-      100,
     );
   }
   return TRIMERGE_CLIENT_CACHE[key];

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
@@ -143,23 +143,6 @@ Object {
 Object {
   "commits": Array [
     Object {
-      "baseRef": "JvrfzM9e",
-      "delta": Array [
-        "hello there",
-        "oh hello there",
-      ],
-      "mergeBaseRef": "GhP0VPg5",
-      "mergeRef": "Rofed6go",
-      "metadata": Object {
-        "message": "merge",
-        "ref": "(JvrfzM9e+Rofed6go)",
-      },
-      "ref": "3vmxbFmH",
-      "remoteSyncId": "",
-      "syncId": 5,
-      "userId": "test",
-    },
-    Object {
       "baseRef": "W04IBhus",
       "delta": Array [
         "hello",
@@ -209,7 +192,10 @@ Object {
   ],
   "heads": Array [
     Object {
-      "ref": "3vmxbFmH",
+      "ref": "JvrfzM9e",
+    },
+    Object {
+      "ref": "Rofed6go",
     },
   ],
   "remotes": Array [],

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
@@ -35,7 +35,6 @@ function makeTestClient(
       },
     }),
     differ,
-    0,
   );
 }
 

--- a/packages/trimerge-sync/src/AbstractLocalStore.test.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.test.ts
@@ -64,16 +64,6 @@ describe('AbstractLocalStore', () => {
     const fn = jest.fn();
     const store = new MockLocalStore(fn);
     await store.update([], undefined);
-    expect(fn.mock.calls).toMatchInlineSnapshot(`
-Array [
-  Array [
-    Object {
-      "refs": Array [],
-      "syncId": "",
-      "type": "ack",
-    },
-  ],
-]
-`);
+    expect(fn.mock.calls).toMatchInlineSnapshot(`Array []`);
   });
 });

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -3,16 +3,16 @@ import {
   ClientInfo,
   ClientPresenceRef,
   Commit,
+  CommitAck,
+  CommitsEvent,
   ErrorCode,
   GetRemoteFn,
   LocalStore,
-  CommitsEvent,
   OnEventFn,
   Remote,
   RemoteStateEvent,
   RemoteSyncInfo,
   SyncEvent,
-  CommitAck,
 } from './types';
 import { PromiseQueue } from './lib/PromiseQueue';
 import {

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -229,9 +229,11 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, Presence>
     event,
     remoteOrigin,
   }: BroadcastEvent<EditMetadata, Delta, Presence>): void => {
-    this.processEvent(event, remoteOrigin ? 'remote-via-local' : 'local').catch(
-      this.handleAsError('network'),
-    );
+    this.localQueue
+      .add(() =>
+        this.processEvent(event, remoteOrigin ? 'remote-via-local' : 'local'),
+      )
+      .catch(this.handleAsError('network'));
   };
 
   async shutdown(): Promise<void> {

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -29,7 +29,6 @@ function makeTrimergeClient(): {
       };
     },
     differ,
-    0,
   );
   if (!onEvent) {
     throw new Error('could not get onEvent');

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -318,8 +318,8 @@ export class TrimergeClient<
     this.syncStateSubs.emitChange();
   }
   private addHead(
-    { ref, baseRef, mergeRef }: CommitRefs,
     headRefs: Set<string>,
+    { ref, baseRef, mergeRef }: CommitRefs,
   ): void {
     if (baseRef !== undefined) {
       if (!this.commits.has(baseRef)) {
@@ -342,9 +342,10 @@ export class TrimergeClient<
   ): void {
     const { ref, baseRef, mergeRef } = asCommitRefs(commit);
     if (this.commits.has(ref)) {
-      // Promote temp commit
       if (type === 'external') {
+        // Promote temp commit
         this.promoteTempCommit(ref);
+        // TODO: upsert commit metadata
       } else {
         console.warn(
           `[TRIMERGE-SYNC] skipping add commit ${ref}, base ${baseRef}, merge ${mergeRef} (type=${type})`,
@@ -370,7 +371,7 @@ export class TrimergeClient<
     }
 
     this.commits.set(ref, commit);
-    this.addHead(asCommitRefs(commit), this.allHeadRefs);
+    this.addHead(this.allHeadRefs, commit);
     const currentRef = this.lastSavedDoc?.ref;
     if (currentRef === baseRef || currentRef === mergeRef) {
       this.lastSavedDoc = this.getCommitDoc(commit.ref);
@@ -390,7 +391,7 @@ export class TrimergeClient<
         break;
     }
     if (type !== 'temp') {
-      this.addHead(commit, this.nonTempHeadRefs);
+      this.addHead(this.nonTempHeadRefs, commit);
     }
   }
 
@@ -403,7 +404,7 @@ export class TrimergeClient<
       const { baseRef, mergeRef } = asCommitRefs(commit);
       this.promoteTempCommit(baseRef);
       this.promoteTempCommit(mergeRef);
-      this.addHead(commit, this.nonTempHeadRefs);
+      this.addHead(this.nonTempHeadRefs, commit);
       this.tempCommits.delete(ref);
       this.unsyncedCommits.push(commit);
     }

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -288,8 +288,8 @@ export class TrimergeClient<
     this.clientListSubs.emitChange();
   }
   private sync(): void {
-    if (this.unsyncedCommits.length > 0 || this.newPresence !== undefined) {
-      const commits = this.unsyncedCommits;
+    const commits = this.unsyncedCommits;
+    if (commits.length > 0 || this.newPresence !== undefined) {
       this.unsyncedCommits = [];
       this.updateSyncState({ localSave: 'saving' });
       this.store.update(commits, this.newPresence);

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -267,7 +267,7 @@ export class TrimergeClient<
         const {
           doc,
           editMetadata,
-          lazy = false,
+          lazy = true,
         } = this.differ.merge(base, left, right);
         return this.addNewCommit(
           doc,

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -34,7 +34,7 @@ function makeClient(
   Delta,
   TestPresence
 > {
-  return new TrimergeClient(userId, 'test', store.getLocalStore, differ, 0);
+  return new TrimergeClient(userId, 'test', store.getLocalStore, differ);
 }
 
 function basicGraph(
@@ -580,35 +580,35 @@ Array [
     unsubscribeFn();
 
     expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "graph": "undefined -> DuQe--Vh",
-          "step": "User a: initialize",
-          "value": Object {},
-        },
-        Object {
-          "graph": "DuQe--Vh -> u0wBto6f",
-          "step": "User a: add hello",
-          "value": Object {
-            "hello": "world",
-          },
-        },
-        Object {
-          "graph": "u0wBto6f -> YYUSBDXS",
-          "step": "User a: change hello",
-          "value": Object {
-            "hello": "vorld",
-          },
-        },
-        Object {
-          "graph": "YYUSBDXS -> iSZbPHuf",
-          "step": "User a: change hello again",
-          "value": Object {
-            "hello": "there",
-          },
-        },
-      ]
-    `);
+Array [
+  Object {
+    "graph": "DuQe--Vh -> u0wBto6f",
+    "step": "User a: add hello",
+    "value": Object {
+      "hello": "world",
+    },
+  },
+  Object {
+    "graph": "u0wBto6f -> YYUSBDXS",
+    "step": "User a: change hello",
+    "value": Object {
+      "hello": "vorld",
+    },
+  },
+  Object {
+    "graph": "undefined -> DuQe--Vh",
+    "step": "User a: initialize",
+    "value": Object {},
+  },
+  Object {
+    "graph": "YYUSBDXS -> iSZbPHuf",
+    "step": "User a: change hello again",
+    "value": Object {
+      "hello": "there",
+    },
+  },
+]
+`);
 
     expect(subscribeFn.mock.calls).toEqual([
       [undefined],
@@ -662,209 +662,209 @@ Array [
     await timeout();
 
     expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "graph": "undefined -> DuQe--Vh",
-          "step": "User a: initialize",
-          "value": Object {},
-        },
-        Object {
-          "graph": "DuQe--Vh -> u0wBto6f",
-          "step": "User a: add hello",
-          "value": Object {
-            "hello": "world",
-          },
-        },
-        Object {
-          "graph": "u0wBto6f -> VS2jghNi",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. t",
-          },
-        },
-        Object {
-          "graph": "VS2jghNi -> 0fvI2ESx",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. th",
-          },
-        },
-        Object {
-          "graph": "0fvI2ESx -> Jz2-R6rz",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. thi",
-          },
-        },
-        Object {
-          "graph": "Jz2-R6rz -> -bTKiTst",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this",
-          },
-        },
-        Object {
-          "graph": "-bTKiTst -> GaWb8t2f",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this ",
-          },
-        },
-        Object {
-          "graph": "GaWb8t2f -> 9J_xBqJ4",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this i",
-          },
-        },
-        Object {
-          "graph": "9J_xBqJ4 -> SYH3X4jm",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is",
-          },
-        },
-        Object {
-          "graph": "SYH3X4jm -> Nl0PNGuX",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is ",
-          },
-        },
-        Object {
-          "graph": "Nl0PNGuX -> vlZhl6Vh",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a",
-          },
-        },
-        Object {
-          "graph": "vlZhl6Vh -> YxT5Gm6R",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a t",
-          },
-        },
-        Object {
-          "graph": "YxT5Gm6R -> F0g2iLQv",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a te",
-          },
-        },
-        Object {
-          "graph": "F0g2iLQv -> vKey2nks",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a tes",
-          },
-        },
-        Object {
-          "graph": "vKey2nks -> C9Ub6hg6",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test",
-          },
-        },
-        Object {
-          "graph": "C9Ub6hg6 -> ObcwRxBk",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test ",
-          },
-        },
-        Object {
-          "graph": "ObcwRxBk -> Y8mdIN_L",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test o",
-          },
-        },
-        Object {
-          "graph": "Y8mdIN_L -> L000b_2W",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test of",
-          },
-        },
-        Object {
-          "graph": "L000b_2W -> tYpujZ6D",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test of ",
-          },
-        },
-        Object {
-          "graph": "tYpujZ6D -> -SKX2OVN",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test of c",
-          },
-        },
-        Object {
-          "graph": "-SKX2OVN -> ffe6ZCmD",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test of ch",
-          },
-        },
-        Object {
-          "graph": "ffe6ZCmD -> 8PtNr3hx",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test of cha",
-          },
-        },
-        Object {
-          "graph": "8PtNr3hx -> oLFFrO2p",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test of char",
-          },
-        },
-        Object {
-          "graph": "oLFFrO2p -> 8Xt-akSw",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test of chara",
-          },
-        },
-        Object {
-          "graph": "8Xt-akSw -> UU5J3Qq2",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test of charac",
-          },
-        },
-        Object {
-          "graph": "UU5J3Qq2 -> Oo2NTgQE",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test of charact",
-          },
-        },
-        Object {
-          "graph": "Oo2NTgQE -> ci7d46HK",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test of characte",
-          },
-        },
-        Object {
-          "graph": "ci7d46HK -> 7_amDpeg",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test of character",
-          },
-        },
-        Object {
-          "graph": "7_amDpeg -> dKj2TVjC",
-          "step": "User a: typing",
-          "value": Object {
-            "hello": "world. this is a test of character.",
-          },
-        },
-      ]
-    `);
+Array [
+  Object {
+    "graph": "DuQe--Vh -> u0wBto6f",
+    "step": "User a: add hello",
+    "value": Object {
+      "hello": "world",
+    },
+  },
+  Object {
+    "graph": "u0wBto6f -> VS2jghNi",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. t",
+    },
+  },
+  Object {
+    "graph": "VS2jghNi -> 0fvI2ESx",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. th",
+    },
+  },
+  Object {
+    "graph": "0fvI2ESx -> Jz2-R6rz",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. thi",
+    },
+  },
+  Object {
+    "graph": "Jz2-R6rz -> -bTKiTst",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this",
+    },
+  },
+  Object {
+    "graph": "-bTKiTst -> GaWb8t2f",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this ",
+    },
+  },
+  Object {
+    "graph": "GaWb8t2f -> 9J_xBqJ4",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this i",
+    },
+  },
+  Object {
+    "graph": "9J_xBqJ4 -> SYH3X4jm",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is",
+    },
+  },
+  Object {
+    "graph": "SYH3X4jm -> Nl0PNGuX",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is ",
+    },
+  },
+  Object {
+    "graph": "Nl0PNGuX -> vlZhl6Vh",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a",
+    },
+  },
+  Object {
+    "graph": "vlZhl6Vh -> YxT5Gm6R",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a t",
+    },
+  },
+  Object {
+    "graph": "YxT5Gm6R -> F0g2iLQv",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a te",
+    },
+  },
+  Object {
+    "graph": "F0g2iLQv -> vKey2nks",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a tes",
+    },
+  },
+  Object {
+    "graph": "vKey2nks -> C9Ub6hg6",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test",
+    },
+  },
+  Object {
+    "graph": "C9Ub6hg6 -> ObcwRxBk",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test ",
+    },
+  },
+  Object {
+    "graph": "ObcwRxBk -> Y8mdIN_L",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test o",
+    },
+  },
+  Object {
+    "graph": "Y8mdIN_L -> L000b_2W",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test of",
+    },
+  },
+  Object {
+    "graph": "L000b_2W -> tYpujZ6D",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test of ",
+    },
+  },
+  Object {
+    "graph": "tYpujZ6D -> -SKX2OVN",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test of c",
+    },
+  },
+  Object {
+    "graph": "-SKX2OVN -> ffe6ZCmD",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test of ch",
+    },
+  },
+  Object {
+    "graph": "ffe6ZCmD -> 8PtNr3hx",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test of cha",
+    },
+  },
+  Object {
+    "graph": "8PtNr3hx -> oLFFrO2p",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test of char",
+    },
+  },
+  Object {
+    "graph": "oLFFrO2p -> 8Xt-akSw",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test of chara",
+    },
+  },
+  Object {
+    "graph": "8Xt-akSw -> UU5J3Qq2",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test of charac",
+    },
+  },
+  Object {
+    "graph": "UU5J3Qq2 -> Oo2NTgQE",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test of charact",
+    },
+  },
+  Object {
+    "graph": "Oo2NTgQE -> ci7d46HK",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test of characte",
+    },
+  },
+  Object {
+    "graph": "ci7d46HK -> 7_amDpeg",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test of character",
+    },
+  },
+  Object {
+    "graph": "7_amDpeg -> dKj2TVjC",
+    "step": "User a: typing",
+    "value": Object {
+      "hello": "world. this is a test of character.",
+    },
+  },
+  Object {
+    "graph": "undefined -> DuQe--Vh",
+    "step": "User a: initialize",
+    "value": Object {},
+  },
+]
+`);
   });
 });

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -491,50 +491,42 @@ Array [
     await client2.shutdown();
 
     expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "graph": "undefined -> DuQe--Vh",
-          "step": "User a: initialize",
-          "value": Object {},
-        },
-        Object {
-          "graph": "DuQe--Vh -> u0wBto6f",
-          "step": "User a: add hello",
-          "value": Object {
-            "hello": "world",
-          },
-        },
-        Object {
-          "graph": "u0wBto6f -> YYUSBDXS",
-          "step": "User a: change hello",
-          "value": Object {
-            "hello": "vorld",
-          },
-        },
-        Object {
-          "graph": "DuQe--Vh -> SU0_JahJ",
-          "step": "User b: add world",
-          "value": Object {
-            "world": "world",
-          },
-        },
-        Object {
-          "graph": "SU0_JahJ -> ZiYUF2m8",
-          "step": "User b: change world",
-          "value": Object {
-            "world": "vorld",
-          },
-        },
-        Object {
-          "graph": "(YYUSBDXS + ZiYUF2m8) w/ base=DuQe--Vh -> kT9Dv92V",
-          "step": "User b: merge",
-          "value": Object {
-            "hello": "vorld",
-            "world": "vorld",
-          },
-        },
-      ]
-    `);
+Array [
+  Object {
+    "graph": "undefined -> DuQe--Vh",
+    "step": "User a: initialize",
+    "value": Object {},
+  },
+  Object {
+    "graph": "DuQe--Vh -> u0wBto6f",
+    "step": "User a: add hello",
+    "value": Object {
+      "hello": "world",
+    },
+  },
+  Object {
+    "graph": "DuQe--Vh -> SU0_JahJ",
+    "step": "User b: add world",
+    "value": Object {
+      "world": "world",
+    },
+  },
+  Object {
+    "graph": "u0wBto6f -> YYUSBDXS",
+    "step": "User a: change hello",
+    "value": Object {
+      "hello": "vorld",
+    },
+  },
+  Object {
+    "graph": "SU0_JahJ -> ZiYUF2m8",
+    "step": "User b: change world",
+    "value": Object {
+      "world": "vorld",
+    },
+  },
+]
+`);
   });
 
   it('sync up when second client comes in later', async () => {
@@ -608,6 +600,11 @@ Array [
     expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
 Array [
   Object {
+    "graph": "undefined -> DuQe--Vh",
+    "step": "User a: initialize",
+    "value": Object {},
+  },
+  Object {
     "graph": "DuQe--Vh -> u0wBto6f",
     "step": "User a: add hello",
     "value": Object {
@@ -620,11 +617,6 @@ Array [
     "value": Object {
       "hello": "vorld",
     },
-  },
-  Object {
-    "graph": "undefined -> DuQe--Vh",
-    "step": "User a: initialize",
-    "value": Object {},
   },
   Object {
     "graph": "YYUSBDXS -> iSZbPHuf",
@@ -689,6 +681,11 @@ Array [
 
     expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
 Array [
+  Object {
+    "graph": "undefined -> DuQe--Vh",
+    "step": "User a: initialize",
+    "value": Object {},
+  },
   Object {
     "graph": "DuQe--Vh -> u0wBto6f",
     "step": "User a: add hello",
@@ -884,11 +881,6 @@ Array [
     "value": Object {
       "hello": "world. this is a test of character.",
     },
-  },
-  Object {
-    "graph": "undefined -> DuQe--Vh",
-    "step": "User a: initialize",
-    "value": Object {},
   },
 ]
 `);

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -250,67 +250,90 @@ Array [
     await timeout();
 
     // Client2 is updated now
-    expect(sortedClients(client1)).toEqual([
-      {
-        clientId: 'test',
-        ref: undefined,
-        self: true,
-        state: undefined,
-        userId: 'a',
-      },
-      {
-        clientId: 'test',
-        ref: undefined,
-        state: undefined,
-        userId: 'b',
-      },
-    ]);
-    expect(sortedClients(client2)).toEqual([
-      {
-        clientId: 'test',
-        ref: undefined,
-        state: undefined,
-        userId: 'a',
-      },
-      {
-        clientId: 'test',
-        ref: undefined,
-        self: true,
-        state: undefined,
-        userId: 'b',
-      },
-    ]);
+    expect(sortedClients(client1)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "clientId": "test",
+    "presence": undefined,
+    "ref": undefined,
+    "self": true,
+    "userId": "a",
+  },
+  Object {
+    "clientId": "test",
+    "presence": undefined,
+    "ref": undefined,
+    "userId": "b",
+  },
+]
+`);
+    expect(sortedClients(client2)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "clientId": "test",
+    "presence": undefined,
+    "ref": undefined,
+    "userId": "a",
+  },
+  Object {
+    "clientId": "test",
+    "presence": undefined,
+    "ref": undefined,
+    "self": true,
+    "userId": "b",
+  },
+]
+`);
 
-    expect(client1Sub.mock.calls).toEqual([
-      [
-        [
-          {
-            clientId: 'test',
-            ref: undefined,
-            self: true,
-            state: undefined,
-            userId: 'a',
-          },
-        ],
-      ],
-      [
-        [
-          {
-            clientId: 'test',
-            ref: undefined,
-            self: true,
-            state: undefined,
-            userId: 'a',
-          },
-          {
-            clientId: 'test',
-            ref: undefined,
-            state: undefined,
-            userId: 'b',
-          },
-        ],
-      ],
-    ]);
+    expect(client1Sub.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    Array [
+      Object {
+        "clientId": "test",
+        "presence": undefined,
+        "ref": undefined,
+        "self": true,
+        "userId": "a",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "test",
+        "presence": undefined,
+        "ref": undefined,
+        "self": true,
+        "userId": "a",
+      },
+      Object {
+        "clientId": "test",
+        "presence": undefined,
+        "ref": undefined,
+        "userId": "b",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "test",
+        "presence": undefined,
+        "ref": undefined,
+        "self": true,
+        "userId": "a",
+      },
+      Object {
+        "clientId": "test",
+        "presence": undefined,
+        "ref": undefined,
+        "userId": "b",
+      },
+    ],
+  ],
+]
+`);
     client1Unsub();
   });
 

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -88,6 +88,32 @@ describe('TrimergeClient: 2 users', () => {
     client.updateDoc({ hello: 'vorld' }, 'change hello');
 
     expect(client.doc).toEqual({ hello: 'vorld' });
+
+    await timeout();
+
+    expect(basicGraph(store, client)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "graph": "undefined -> DuQe--Vh",
+    "step": "User a: initialize",
+    "value": Object {},
+  },
+  Object {
+    "graph": "DuQe--Vh -> u0wBto6f",
+    "step": "User a: add hello",
+    "value": Object {
+      "hello": "world",
+    },
+  },
+  Object {
+    "graph": "u0wBto6f -> YYUSBDXS",
+    "step": "User a: change hello",
+    "value": Object {
+      "hello": "vorld",
+    },
+  },
+]
+`);
   });
 
   it('tracks non-edits', async () => {

--- a/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
@@ -113,34 +113,6 @@ Array [
       "text": "c",
     },
   },
-  Object {
-    "graph": "((a1+b1) + c1) w/ base=ROOT -> ((a1+b1)+c1)",
-    "step": "User a: merge",
-    "value": Object {
-      "text": "abc",
-    },
-  },
-  Object {
-    "graph": "((a1+c1) + b1) w/ base=ROOT -> ((a1+c1)+b1)",
-    "step": "User c: merge",
-    "value": Object {
-      "text": "acb",
-    },
-  },
-  Object {
-    "graph": "(a1 + b1) w/ base=ROOT -> (a1+b1)",
-    "step": "User b: merge",
-    "value": Object {
-      "text": "ab",
-    },
-  },
-  Object {
-    "graph": "(a1 + c1) w/ base=ROOT -> (a1+c1)",
-    "step": "User c: merge",
-    "value": Object {
-      "text": "ac",
-    },
-  },
 ]
 `);
 
@@ -192,52 +164,68 @@ Array [
     await timeout();
 
     expect(basicGraph(store, clientA)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "graph": "undefined -> a1",
-          "step": "User a: add hello",
-          "value": Object {
-            "hello": "world",
-          },
-        },
-        Object {
-          "graph": "a1 -> a2",
-          "step": "User a: change hello",
-          "value": Object {
-            "hello": "vorld",
-          },
-        },
-        Object {
-          "graph": "undefined -> b1",
-          "step": "User b: add world",
-          "value": Object {
-            "world": "world",
-          },
-        },
-        Object {
-          "graph": "b1 -> b2",
-          "step": "User b: change world",
-          "value": Object {
-            "world": "vorld",
-          },
-        },
-        Object {
-          "graph": "(a2 + b2) w/ base=undefined -> (a2+b2)",
-          "step": "User b: merge",
-          "value": Object {
-            "hello": "vorld",
-            "world": "vorld",
-          },
-        },
-        Object {
-          "graph": "(a2+b2) -> c1",
-          "step": "User c: change hello",
-          "value": Object {
-            "hello": "world",
-            "world": "vorld",
-          },
-        },
-      ]
-    `);
+Array [
+  Object {
+    "graph": "undefined -> a1",
+    "step": "User a: add hello",
+    "value": Object {
+      "hello": "world",
+    },
+  },
+  Object {
+    "graph": "undefined -> b1",
+    "step": "User b: add world",
+    "value": Object {
+      "world": "world",
+    },
+  },
+  Object {
+    "graph": "a1 -> a2",
+    "step": "User a: change hello",
+    "value": Object {
+      "hello": "vorld",
+    },
+  },
+  Object {
+    "graph": "b1 -> b2",
+    "step": "User b: change world",
+    "value": Object {
+      "world": "vorld",
+    },
+  },
+  Object {
+    "graph": "(a1 + b1) w/ base=undefined -> (a1+b1)",
+    "step": "User c: merge",
+    "value": Object {
+      "hello": "world",
+      "world": "world",
+    },
+  },
+  Object {
+    "graph": "((a1+b1) + a2) w/ base=a1 -> ((a1+b1)+a2)",
+    "step": "User c: merge",
+    "value": Object {
+      "hello": "vorld",
+      "world": "world",
+    },
+  },
+  Object {
+    "graph": "(((a1+b1)+a2) + b2) w/ base=b1 -> (((a1+b1)+a2)+b2)",
+    "step": "User c: merge",
+    "value": Object {
+      "hello": "vorld",
+      "world": "vorld",
+    },
+  },
+  Object {
+    "graph": "(((a1+b1)+a2)+b2) -> c1",
+    "step": "User c: change hello",
+    "value": Object {
+      "hello": "world",
+      "world": "vorld",
+    },
+  },
+]
+`);
   });
 });

--- a/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
@@ -32,7 +32,7 @@ function makeClient(
   Delta,
   TestPresence
 > {
-  return new TrimergeClient(userId, 'test', store.getLocalStore, differ, 0);
+  return new TrimergeClient(userId, 'test', store.getLocalStore, differ);
 }
 
 function timeout() {
@@ -84,58 +84,65 @@ describe('TrimergeClient: 3 users', () => {
     await timeout();
 
     expect(basicGraph(store, clientA)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "graph": "undefined -> ROOT",
-          "step": "User a: init",
-          "value": Object {
-            "text": "",
-          },
-        },
-        Object {
-          "graph": "ROOT -> a1",
-          "step": "User a: set text",
-          "value": Object {
-            "text": "a",
-          },
-        },
-        Object {
-          "graph": "ROOT -> b1",
-          "step": "User b: set text",
-          "value": Object {
-            "text": "b",
-          },
-        },
-        Object {
-          "graph": "(a1 + b1) w/ base=ROOT -> (a1+b1)",
-          "step": "User b: merge",
-          "value": Object {
-            "text": "ab",
-          },
-        },
-        Object {
-          "graph": "ROOT -> c1",
-          "step": "User c: set text",
-          "value": Object {
-            "text": "c",
-          },
-        },
-        Object {
-          "graph": "(a1 + c1) w/ base=ROOT -> (a1+c1)",
-          "step": "User c: merge",
-          "value": Object {
-            "text": "ac",
-          },
-        },
-        Object {
-          "graph": "((a1+b1) + (a1+c1)) w/ base=a1 -> ((a1+b1)+(a1+c1))",
-          "step": "User c: merge",
-          "value": Object {
-            "text": "abc",
-          },
-        },
-      ]
-    `);
+Array [
+  Object {
+    "graph": "undefined -> ROOT",
+    "step": "User a: init",
+    "value": Object {
+      "text": "",
+    },
+  },
+  Object {
+    "graph": "ROOT -> a1",
+    "step": "User a: set text",
+    "value": Object {
+      "text": "a",
+    },
+  },
+  Object {
+    "graph": "ROOT -> b1",
+    "step": "User b: set text",
+    "value": Object {
+      "text": "b",
+    },
+  },
+  Object {
+    "graph": "ROOT -> c1",
+    "step": "User c: set text",
+    "value": Object {
+      "text": "c",
+    },
+  },
+  Object {
+    "graph": "((a1+b1) + c1) w/ base=ROOT -> ((a1+b1)+c1)",
+    "step": "User a: merge",
+    "value": Object {
+      "text": "abc",
+    },
+  },
+  Object {
+    "graph": "((a1+c1) + b1) w/ base=ROOT -> ((a1+c1)+b1)",
+    "step": "User c: merge",
+    "value": Object {
+      "text": "acb",
+    },
+  },
+  Object {
+    "graph": "(a1 + b1) w/ base=ROOT -> (a1+b1)",
+    "step": "User b: merge",
+    "value": Object {
+      "text": "ab",
+    },
+  },
+  Object {
+    "graph": "(a1 + c1) w/ base=ROOT -> (a1+c1)",
+    "step": "User c: merge",
+    "value": Object {
+      "text": "ac",
+    },
+  },
+]
+`);
 
     //  Now they should all have trimerged changes
     expect(clientA.doc).toEqual({ text: 'abc' });

--- a/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
@@ -194,23 +194,7 @@ Array [
     },
   },
   Object {
-    "graph": "(a1 + b1) w/ base=undefined -> (a1+b1)",
-    "step": "User c: merge",
-    "value": Object {
-      "hello": "world",
-      "world": "world",
-    },
-  },
-  Object {
-    "graph": "((a1+b1) + a2) w/ base=a1 -> ((a1+b1)+a2)",
-    "step": "User c: merge",
-    "value": Object {
-      "hello": "vorld",
-      "world": "world",
-    },
-  },
-  Object {
-    "graph": "(((a1+b1)+a2) + b2) w/ base=b1 -> (((a1+b1)+a2)+b2)",
+    "graph": "(a2 + b2) w/ base=undefined -> (a2+b2)",
     "step": "User c: merge",
     "value": Object {
       "hello": "vorld",
@@ -218,7 +202,7 @@ Array [
     },
   },
   Object {
-    "graph": "(((a1+b1)+a2)+b2) -> c1",
+    "graph": "(a2+b2) -> c1",
     "step": "User c: change hello",
     "value": Object {
       "hello": "world",

--- a/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
@@ -76,7 +76,7 @@ describe('TrimergeClient: 3 users', () => {
     clientB.updateDoc({ text: 'b' }, { ref: 'b1', message: 'set text' });
     clientC.updateDoc({ text: 'c' }, { ref: 'c1', message: 'set text' });
 
-    // Now client 1 and client 2 have different changes
+    // Now all clients have different changes
     expect(clientA.doc).toEqual({ text: 'a' });
     expect(clientB.doc).toEqual({ text: 'b' });
     expect(clientC.doc).toEqual({ text: 'c' });

--- a/packages/trimerge-sync/src/TrimergeClient_Fuzz.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Fuzz.test.ts
@@ -3,8 +3,9 @@ import { TrimergeClient } from './TrimergeClient';
 import { Differ } from './differ';
 import { MemoryStore } from './testLib/MemoryStore';
 import { computeRef, diff, merge, migrate, patch } from './testLib/MergeUtils';
-import { getBasicGraph } from './testLib/GraphVisualizers';
 import { timeout } from './lib/Timeout';
+
+jest.setTimeout(10_000);
 
 type TestEditMetadata = any;
 type TestSavedDoc = any;

--- a/packages/trimerge-sync/src/TrimergeClient_Fuzz.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Fuzz.test.ts
@@ -33,7 +33,7 @@ function makeClient(
   Delta,
   TestPresence
 > {
-  return new TrimergeClient(userId, 'test', store.getLocalStore, differ, 0);
+  return new TrimergeClient(userId, 'test', store.getLocalStore, differ);
 }
 
 describe('TrimergeClient Fuzz', () => {

--- a/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
@@ -136,4 +136,50 @@ Array [
 ]
 `);
   });
+  it('remigrates as updates come in', async () => {
+    const store = newStore();
+
+    const client1 = makeClientV1('a', store);
+    client1.updateDoc({ v: 1, field: 123 }, 'initialize');
+    expect(client1.doc).toEqual({ v: 1, field: 123 });
+
+    await timeout();
+
+    const client2 = makeClientV2('a', store);
+
+    await timeout();
+
+    expect(client2.doc).toEqual({ v: 2, field: '123' });
+
+    client1.updateDoc({ v: 1, field: 456 }, 'update field');
+
+    expect(client1.doc).toEqual({ v: 1, field: 456 });
+
+    await timeout();
+
+    // expect(client2.doc).toEqual({ v: 2, field: '456' });
+
+    await timeout();
+
+    expect(basicGraph(store, client2)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "graph": "undefined -> Z-zhYWBg",
+    "step": "User a: initialize",
+    "value": Object {
+      "field": 123,
+      "v": 1,
+    },
+  },
+  Object {
+    "graph": "Z-zhYWBg -> 2gIafKP_",
+    "step": "User a: update field",
+    "value": Object {
+      "field": 456,
+      "v": 1,
+    },
+  },
+]
+`);
+  });
 });

--- a/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
@@ -18,47 +18,35 @@ function makeClientV1(
   userId: string,
   store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
 ): TrimergeClient<DocV1, DocV1, TestEditMetadata, Delta, TestPresence> {
-  return new TrimergeClient(
-    userId,
-    'test',
-    store.getLocalStore,
-    {
-      migrate: (doc, editMetadata) => ({ doc, editMetadata }),
-      diff,
-      patch: (priorOrNext, delta) => patch(priorOrNext as any, delta),
-      computeRef,
-      merge,
-    },
-    0,
-  );
+  return new TrimergeClient(userId, 'test', store.getLocalStore, {
+    migrate: (doc, editMetadata) => ({ doc, editMetadata }),
+    diff,
+    patch: (priorOrNext, delta) => patch(priorOrNext as any, delta),
+    computeRef,
+    merge,
+  });
 }
 function makeClientV2(
   userId: string,
   store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
 ): TrimergeClient<DocV1 | DocV2, DocV2, TestEditMetadata, Delta, TestPresence> {
-  return new TrimergeClient(
-    userId,
-    'test',
-    store.getLocalStore,
-    {
-      migrate: (doc, editMetadata) => {
-        switch (doc.v) {
-          case 1:
-            return {
-              doc: { v: 2, field: String(doc.field) },
-              editMetadata: 'migrated to v2',
-            };
-          case 2:
-            return { doc, editMetadata };
-        }
-      },
-      diff,
-      patch: (priorOrNext, delta) => patch(priorOrNext as any, delta),
-      computeRef,
-      merge,
+  return new TrimergeClient(userId, 'test', store.getLocalStore, {
+    migrate: (doc, editMetadata) => {
+      switch (doc.v) {
+        case 1:
+          return {
+            doc: { v: 2, field: String(doc.field) },
+            editMetadata: 'migrated to v2',
+          };
+        case 2:
+          return { doc, editMetadata };
+      }
     },
-    0,
-  );
+    diff,
+    patch: (priorOrNext, delta) => patch(priorOrNext as any, delta),
+    computeRef,
+    merge,
+  });
 }
 
 function basicGraph(

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -462,10 +462,10 @@ Array [
     "remoteSave": "ready",
   },
   Object {
-    "localRead": "loading",
+    "localRead": "ready",
     "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
     "remoteSave": "ready",
   },
   Object {

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -55,7 +55,7 @@ function makeClient(
   Delta,
   TestPresence
 > {
-  return new TrimergeClient(userId, clientId, store.getLocalStore, differ, 0);
+  return new TrimergeClient(userId, clientId, store.getLocalStore, differ);
 }
 
 function basicGraph(
@@ -113,21 +113,21 @@ describe('Remote sync', () => {
     const remoteGraph1 = basicGraph(remoteStore, client);
     expect(remoteGraph1).toEqual(localGraph1);
     expect(localGraph1).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "graph": "undefined -> DuQe--Vh",
-          "step": "User a: initialize",
-          "value": Object {},
-        },
-        Object {
-          "graph": "DuQe--Vh -> u0wBto6f",
-          "step": "User a: add hello",
-          "value": Object {
-            "hello": "world",
-          },
-        },
-      ]
-    `);
+Array [
+  Object {
+    "graph": "DuQe--Vh -> u0wBto6f",
+    "step": "User a: add hello",
+    "value": Object {
+      "hello": "world",
+    },
+  },
+  Object {
+    "graph": "undefined -> DuQe--Vh",
+    "step": "User a: initialize",
+    "value": Object {},
+  },
+]
+`);
     expect(syncUpdates).toMatchInlineSnapshot(`
 Array [
   Object {
@@ -139,59 +139,66 @@ Array [
   },
   Object {
     "localRead": "loading",
-    "localSave": "pending",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "ready",
   },
   Object {
-    "localRead": "ready",
-    "localSave": "pending",
+    "localRead": "loading",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
-    "remoteSave": "ready",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "saving",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
-    "localSave": "pending",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
     "remoteConnect": "connecting",
     "remoteRead": "loading",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "pending",
-    "remoteConnect": "online",
-    "remoteRead": "loading",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "pending",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "pending",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
     "localSave": "ready",
     "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "pending",
+    "remoteRead": "loading",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
@@ -243,70 +250,70 @@ Array [
     const remoteGraph1 = basicGraph(remoteStore, client);
     expect(remoteGraph1).toEqual(localGraph1);
     expect(localGraph1).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "graph": "undefined -> DuQe--Vh",
-          "step": "User a: initialize",
-          "value": Object {},
-        },
-        Object {
-          "graph": "DuQe--Vh -> u0wBto6f",
-          "step": "User a: add hello",
-          "value": Object {
-            "hello": "world",
-          },
-        },
-        Object {
-          "graph": "u0wBto6f -> mtMnDodx",
-          "step": "User a: edit hello",
-          "value": Object {
-            "hello": "world 2",
-          },
-        },
-        Object {
-          "graph": "mtMnDodx -> tB2Oxxss",
-          "step": "User a: edit hello",
-          "value": Object {
-            "hello": "world 3",
-          },
-        },
-        Object {
-          "graph": "tB2Oxxss -> ltIl6khP",
-          "step": "User a: edit hello",
-          "value": Object {
-            "hello": "world 4",
-          },
-        },
-        Object {
-          "graph": "ltIl6khP -> 6_CORFe7",
-          "step": "User a: edit hello",
-          "value": Object {
-            "hello": "world 5",
-          },
-        },
-        Object {
-          "graph": "6_CORFe7 -> OhiKsT4g",
-          "step": "User a: edit hello",
-          "value": Object {
-            "hello": "world 6",
-          },
-        },
-        Object {
-          "graph": "OhiKsT4g -> bTzlNzXZ",
-          "step": "User a: edit hello",
-          "value": Object {
-            "hello": "world 7",
-          },
-        },
-        Object {
-          "graph": "bTzlNzXZ -> ilW_0_ne",
-          "step": "User a: edit hello",
-          "value": Object {
-            "hello": "world 8",
-          },
-        },
-      ]
-    `);
+Array [
+  Object {
+    "graph": "DuQe--Vh -> u0wBto6f",
+    "step": "User a: add hello",
+    "value": Object {
+      "hello": "world",
+    },
+  },
+  Object {
+    "graph": "u0wBto6f -> mtMnDodx",
+    "step": "User a: edit hello",
+    "value": Object {
+      "hello": "world 2",
+    },
+  },
+  Object {
+    "graph": "mtMnDodx -> tB2Oxxss",
+    "step": "User a: edit hello",
+    "value": Object {
+      "hello": "world 3",
+    },
+  },
+  Object {
+    "graph": "tB2Oxxss -> ltIl6khP",
+    "step": "User a: edit hello",
+    "value": Object {
+      "hello": "world 4",
+    },
+  },
+  Object {
+    "graph": "ltIl6khP -> 6_CORFe7",
+    "step": "User a: edit hello",
+    "value": Object {
+      "hello": "world 5",
+    },
+  },
+  Object {
+    "graph": "6_CORFe7 -> OhiKsT4g",
+    "step": "User a: edit hello",
+    "value": Object {
+      "hello": "world 6",
+    },
+  },
+  Object {
+    "graph": "OhiKsT4g -> bTzlNzXZ",
+    "step": "User a: edit hello",
+    "value": Object {
+      "hello": "world 7",
+    },
+  },
+  Object {
+    "graph": "bTzlNzXZ -> ilW_0_ne",
+    "step": "User a: edit hello",
+    "value": Object {
+      "hello": "world 8",
+    },
+  },
+  Object {
+    "graph": "undefined -> DuQe--Vh",
+    "step": "User a: initialize",
+    "value": Object {},
+  },
+]
+`);
   });
 
   it('syncs two clients to a remote', async () => {
@@ -340,59 +347,66 @@ Array [
   },
   Object {
     "localRead": "loading",
-    "localSave": "pending",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "ready",
   },
   Object {
-    "localRead": "ready",
-    "localSave": "pending",
+    "localRead": "loading",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
-    "remoteSave": "ready",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "saving",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
-    "localSave": "pending",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
     "remoteConnect": "connecting",
     "remoteRead": "loading",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "pending",
-    "remoteConnect": "online",
-    "remoteRead": "loading",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "pending",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "pending",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
     "localSave": "ready",
     "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "pending",
+    "remoteRead": "loading",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
@@ -411,30 +425,30 @@ Array [
 ]
 `);
     expect(syncUpdates2).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "localRead": "loading",
-          "localSave": "ready",
-          "remoteConnect": "offline",
-          "remoteRead": "offline",
-          "remoteSave": "ready",
-        },
-        Object {
-          "localRead": "loading",
-          "localSave": "ready",
-          "remoteConnect": "online",
-          "remoteRead": "ready",
-          "remoteSave": "ready",
-        },
-        Object {
-          "localRead": "ready",
-          "localSave": "ready",
-          "remoteConnect": "online",
-          "remoteRead": "ready",
-          "remoteSave": "ready",
-        },
-      ]
-    `);
+Array [
+  Object {
+    "localRead": "loading",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "ready",
+    "remoteConnect": "online",
+    "remoteRead": "ready",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "error",
+    "localSave": "ready",
+    "remoteConnect": "online",
+    "remoteRead": "ready",
+    "remoteSave": "ready",
+  },
+]
+`);
   });
 
   it('syncs two clients to remote with a local split', async () => {
@@ -465,9 +479,7 @@ Array [
     expect(states2).toMatchInlineSnapshot(`
 Array [
   undefined,
-  Object {
-    "hello": "world",
-  },
+  Object {},
 ]
 `);
 
@@ -491,9 +503,7 @@ Array [
     expect(states2).toMatchInlineSnapshot(`
 Array [
   undefined,
-  Object {
-    "hello": "world",
-  },
+  Object {},
   Object {
     "hello": "world",
     "world": "hello",
@@ -506,24 +516,18 @@ Array [
     await timeout(100);
 
     expect(states1).toMatchInlineSnapshot(`
-      Array [
-        undefined,
-        Object {},
-        Object {
-          "hello": "world",
-        },
-        Object {
-          "hello": "world",
-          "world": "hello",
-        },
-      ]
-    `);
-    expect(states2).toMatchInlineSnapshot(`
 Array [
   undefined,
+  Object {},
   Object {
     "hello": "world",
   },
+]
+`);
+    expect(states2).toMatchInlineSnapshot(`
+Array [
+  undefined,
+  Object {},
   Object {
     "hello": "world",
     "world": "hello",
@@ -573,35 +577,77 @@ Array [
   },
   Object {
     "localRead": "loading",
-    "localSave": "pending",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "ready",
   },
   Object {
-    "localRead": "ready",
-    "localSave": "pending",
+    "localRead": "loading",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
-    "remoteSave": "ready",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "saving",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
-    "localSave": "pending",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
     "remoteConnect": "connecting",
     "remoteRead": "loading",
-    "remoteSave": "ready",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
-    "localSave": "pending",
+    "localSave": "ready",
     "remoteConnect": "online",
     "remoteRead": "loading",
-    "remoteSave": "ready",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
-    "localSave": "pending",
+    "localSave": "ready",
+    "remoteConnect": "online",
+    "remoteRead": "ready",
+    "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
     "remoteConnect": "online",
     "remoteRead": "ready",
     "remoteSave": "ready",
@@ -612,6 +658,20 @@ Array [
     "remoteConnect": "online",
     "remoteRead": "ready",
     "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "saving",
+    "remoteConnect": "online",
+    "remoteRead": "ready",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "online",
+    "remoteRead": "ready",
+    "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
@@ -633,48 +693,6 @@ Array [
     "remoteConnect": "online",
     "remoteRead": "ready",
     "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "pending",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "pending",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -115,16 +115,16 @@ describe('Remote sync', () => {
     expect(localGraph1).toMatchInlineSnapshot(`
 Array [
   Object {
+    "graph": "undefined -> DuQe--Vh",
+    "step": "User a: initialize",
+    "value": Object {},
+  },
+  Object {
     "graph": "DuQe--Vh -> u0wBto6f",
     "step": "User a: add hello",
     "value": Object {
       "hello": "world",
     },
-  },
-  Object {
-    "graph": "undefined -> DuQe--Vh",
-    "step": "User a: initialize",
-    "value": Object {},
   },
 ]
 `);
@@ -146,38 +146,52 @@ Array [
   },
   Object {
     "localRead": "loading",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "loading",
     "localSave": "ready",
     "remoteConnect": "offline",
     "remoteRead": "offline",
-    "remoteSave": "pending",
+    "remoteSave": "ready",
   },
   Object {
     "localRead": "loading",
     "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
-    "remoteSave": "pending",
+    "remoteSave": "ready",
   },
   Object {
     "localRead": "loading",
     "localSave": "ready",
     "remoteConnect": "offline",
     "remoteRead": "offline",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
     "remoteSave": "pending",
   },
   Object {
-    "localRead": "loading",
+    "localRead": "ready",
     "localSave": "ready",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
@@ -252,6 +266,11 @@ Array [
     expect(localGraph1).toMatchInlineSnapshot(`
 Array [
   Object {
+    "graph": "undefined -> DuQe--Vh",
+    "step": "User a: initialize",
+    "value": Object {},
+  },
+  Object {
     "graph": "DuQe--Vh -> u0wBto6f",
     "step": "User a: add hello",
     "value": Object {
@@ -307,11 +326,6 @@ Array [
       "hello": "world 8",
     },
   },
-  Object {
-    "graph": "undefined -> DuQe--Vh",
-    "step": "User a: initialize",
-    "value": Object {},
-  },
 ]
 `);
   });
@@ -354,38 +368,52 @@ Array [
   },
   Object {
     "localRead": "loading",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "loading",
     "localSave": "ready",
     "remoteConnect": "offline",
     "remoteRead": "offline",
-    "remoteSave": "pending",
+    "remoteSave": "ready",
   },
   Object {
     "localRead": "loading",
     "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
-    "remoteSave": "pending",
+    "remoteSave": "ready",
   },
   Object {
     "localRead": "loading",
     "localSave": "ready",
     "remoteConnect": "offline",
     "remoteRead": "offline",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
     "remoteSave": "pending",
   },
   Object {
-    "localRead": "loading",
+    "localRead": "ready",
     "localSave": "ready",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
@@ -441,7 +469,7 @@ Array [
     "remoteSave": "ready",
   },
   Object {
-    "localRead": "error",
+    "localRead": "ready",
     "localSave": "ready",
     "remoteConnect": "online",
     "remoteRead": "ready",
@@ -480,6 +508,9 @@ Array [
 Array [
   undefined,
   Object {},
+  Object {
+    "hello": "world",
+  },
 ]
 `);
 
@@ -506,6 +537,9 @@ Array [
   Object {},
   Object {
     "hello": "world",
+  },
+  Object {
+    "hello": "world",
     "world": "hello",
   },
 ]
@@ -522,12 +556,19 @@ Array [
   Object {
     "hello": "world",
   },
+  Object {
+    "hello": "world",
+    "world": "hello",
+  },
 ]
 `);
     expect(states2).toMatchInlineSnapshot(`
 Array [
   undefined,
   Object {},
+  Object {
+    "hello": "world",
+  },
   Object {
     "hello": "world",
     "world": "hello",
@@ -584,38 +625,52 @@ Array [
   },
   Object {
     "localRead": "loading",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "loading",
     "localSave": "ready",
     "remoteConnect": "offline",
     "remoteRead": "offline",
-    "remoteSave": "pending",
+    "remoteSave": "ready",
   },
   Object {
     "localRead": "loading",
     "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
-    "remoteSave": "pending",
+    "remoteSave": "ready",
   },
   Object {
     "localRead": "loading",
     "localSave": "ready",
     "remoteConnect": "offline",
     "remoteRead": "offline",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
     "remoteSave": "pending",
   },
   Object {
-    "localRead": "loading",
+    "localRead": "ready",
     "localSave": "ready",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
@@ -661,10 +716,24 @@ Array [
   },
   Object {
     "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "online",
+    "remoteRead": "ready",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "ready",
     "localSave": "saving",
     "remoteConnect": "online",
     "remoteRead": "ready",
-    "remoteSave": "pending",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "online",
+    "remoteRead": "ready",
+    "remoteSave": "ready",
   },
   Object {
     "localRead": "ready",
@@ -675,16 +744,9 @@ Array [
   },
   Object {
     "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
     "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
     "remoteSave": "pending",
   },
   Object {
@@ -693,6 +755,20 @@ Array [
     "remoteConnect": "online",
     "remoteRead": "ready",
     "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
@@ -894,59 +970,108 @@ Array [
   },
   Object {
     "localRead": "loading",
-    "localSave": "pending",
+    "localSave": "saving",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "saving",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "saving",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "loading",
+    "localSave": "ready",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "ready",
   },
   Object {
     "localRead": "ready",
-    "localSave": "pending",
+    "localSave": "ready",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "ready",
   },
   Object {
     "localRead": "ready",
-    "localSave": "pending",
-    "remoteConnect": "connecting",
-    "remoteRead": "loading",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "pending",
-    "remoteConnect": "online",
-    "remoteRead": "loading",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "pending",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
     "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
     "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
     "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "connecting",
+    "remoteRead": "loading",
+    "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "online",
+    "remoteRead": "loading",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
@@ -1010,7 +1135,14 @@ Array [
   },
   Object {
     "localRead": "ready",
-    "localSave": "pending",
+    "localSave": "saving",
+    "remoteConnect": "online",
+    "remoteRead": "ready",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
     "remoteConnect": "online",
     "remoteRead": "ready",
     "remoteSave": "ready",
@@ -1024,7 +1156,14 @@ Array [
   },
   Object {
     "localRead": "ready",
-    "localSave": "saving",
+    "localSave": "ready",
+    "remoteConnect": "online",
+    "remoteRead": "ready",
+    "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
     "remoteConnect": "online",
     "remoteRead": "ready",
     "remoteSave": "pending",
@@ -1034,7 +1173,21 @@ Array [
     "localSave": "ready",
     "remoteConnect": "online",
     "remoteRead": "ready",
+    "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "online",
+    "remoteRead": "ready",
     "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "ready",
+    "remoteConnect": "online",
+    "remoteRead": "ready",
+    "remoteSave": "ready",
   },
   Object {
     "localRead": "ready",

--- a/packages/trimerge-sync/src/differ.ts
+++ b/packages/trimerge-sync/src/differ.ts
@@ -24,7 +24,7 @@ export type CommitDoc<Doc, EditMetadata> = {
 } & DocAndMetadata<Doc, EditMetadata>;
 
 export type MergeResult<LatestDoc, EditMetadata> = {
-  lazy?: boolean;
+  temp?: boolean;
 } & DocAndMetadata<LatestDoc, EditMetadata>;
 
 export type MergeDocFn<LatestDoc, EditMetadata> = (

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
@@ -80,49 +80,37 @@ describe('GraphVisualizers', () => {
     client2.updateDoc({ world: '3' }, 'initialize');
     await timeout();
     expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "graph": "undefined -> 9m0LhHdt",
-          "step": "User a: initialize",
-          "value": Object {
-            "hello": "1",
-          },
-        },
-        Object {
-          "graph": "undefined -> E2BlVX80",
-          "step": "User b: initialize",
-          "value": Object {
-            "world": "2",
-          },
-        },
-        Object {
-          "graph": "E2BlVX80 -> yxbBldSG",
-          "step": "User b: initialize",
-          "value": Object {
-            "world": "3",
-          },
-        },
-        Object {
-          "graph": "(9m0LhHdt + yxbBldSG) w/ base=undefined -> BAsEHbZm",
-          "step": "User b: merge",
-          "value": Object {
-            "hello": "1",
-            "world": "3",
-          },
-        },
-      ]
-    `);
+Array [
+  Object {
+    "graph": "undefined -> 9m0LhHdt",
+    "step": "User a: initialize",
+    "value": Object {
+      "hello": "1",
+    },
+  },
+  Object {
+    "graph": "undefined -> E2BlVX80",
+    "step": "User b: initialize",
+    "value": Object {
+      "world": "2",
+    },
+  },
+  Object {
+    "graph": "E2BlVX80 -> yxbBldSG",
+    "step": "User b: initialize",
+    "value": Object {
+      "world": "3",
+    },
+  },
+]
+`);
     expect(dotGraph(store, client1)).toMatchInlineSnapshot(`
-      "digraph {
-      \\"9m0LhHdt\\" [shape=ellipse, label=\\"initialize\\"]
-      \\"E2BlVX80\\" [shape=ellipse, label=\\"initialize\\"]
-      \\"yxbBldSG\\" [shape=ellipse, label=\\"initialize\\"]
-      \\"E2BlVX80\\" -> \\"yxbBldSG\\" [label=\\"User b: [object Object]\\"]
-      \\"BAsEHbZm\\" [shape=rectangle, label={\\"ref\\":\\"(9m0LhHdt+yxbBldSG)\\",\\"message\\":\\"merge\\"}]
-      \\"9m0LhHdt\\" -> \\"BAsEHbZm\\" [label=left]
-      \\"undefined\\" -> \\"BAsEHbZm\\" [style=dashed, label=base]
-      \\"yxbBldSG\\" -> \\"BAsEHbZm\\" [label=right]
-      }"
-    `);
+"digraph {
+\\"9m0LhHdt\\" [shape=ellipse, label=\\"initialize\\"]
+\\"E2BlVX80\\" [shape=ellipse, label=\\"initialize\\"]
+\\"yxbBldSG\\" [shape=ellipse, label=\\"initialize\\"]
+\\"E2BlVX80\\" -> \\"yxbBldSG\\" [label=\\"User b: [object Object]\\"]
+}"
+`);
   });
 });

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
@@ -33,7 +33,7 @@ function makeClient(
   Delta,
   TestPresence
 > {
-  return new TrimergeClient(userId, 'test', store.getLocalStore, differ, 0);
+  return new TrimergeClient(userId, 'test', store.getLocalStore, differ);
 }
 
 function basicGraph(

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
@@ -31,14 +31,6 @@ describe('MemoryLocalStore', () => {
 Array [
   Array [
     Object {
-      "connect": "offline",
-      "read": "offline",
-      "save": "pending",
-      "type": "remote-state",
-    },
-  ],
-  Array [
-    Object {
       "commits": Array [
         Object {
           "clientId": "test",
@@ -53,16 +45,24 @@ Array [
   ],
   Array [
     Object {
+      "type": "ready",
+    },
+  ],
+  Array [
+    Object {
+      "connect": "offline",
+      "read": "offline",
+      "save": "pending",
+      "type": "remote-state",
+    },
+  ],
+  Array [
+    Object {
       "refs": Array [
         "test1",
       ],
       "syncId": "1",
       "type": "ack",
-    },
-  ],
-  Array [
-    Object {
-      "type": "ready",
     },
   ],
   Array [
@@ -92,14 +92,6 @@ Array [
 Array [
   Array [
     Object {
-      "connect": "offline",
-      "read": "offline",
-      "save": "pending",
-      "type": "remote-state",
-    },
-  ],
-  Array [
-    Object {
       "commits": Array [
         Object {
           "clientId": "test",
@@ -114,16 +106,24 @@ Array [
   ],
   Array [
     Object {
+      "type": "ready",
+    },
+  ],
+  Array [
+    Object {
+      "connect": "offline",
+      "read": "offline",
+      "save": "pending",
+      "type": "remote-state",
+    },
+  ],
+  Array [
+    Object {
       "refs": Array [
         "test1",
       ],
       "syncId": "1",
       "type": "ack",
-    },
-  ],
-  Array [
-    Object {
-      "type": "ready",
     },
   ],
   Array [


### PR DESCRIPTION
- remove bufferMs from TrimergeClient, now every commit immediately pushes to local store
  - update callsites
  - update snapshots
  - introduce a promise queue in AbstractLocalStore
- rename lazy commits to temp commits
- introduce temp merge commits
  - by default all merges will be temp!
  - Differ.merge can return `{ temp: false }` to override
- correctly roll back temp commits when getting new remote commits