### PR TITLE
don't send client join if the current connect state is already online

### DIFF
--- a/packages/trimerge-sync/src/AbstractLocalStore.test.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.test.ts
@@ -86,9 +86,10 @@ describe('AbstractLocalStore', () => {
     const fn = jest.fn();
     let mockRemote: MockRemote;
     let sendSpy: jest.SpyInstance;
+    let localStore: MockLocalStore;
 
     await new Promise<void>((resolve) => {
-      new MockLocalStore(fn, (_, __, onEvent) => {
+      localStore = new MockLocalStore(fn, (_, __, onEvent) => {
         mockRemote = new MockRemote(onEvent);
         sendSpy = jest.spyOn(mockRemote, 'send');
         resolve();
@@ -121,6 +122,8 @@ Array [
   ],
 ]
 `);
+
+    await localStore!.shutdown();
   });
 
   it('handle empty update call', async () => {

--- a/packages/trimerge-sync/src/AbstractLocalStore.test.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.test.ts
@@ -1,14 +1,24 @@
 import { AbstractLocalStore } from './AbstractLocalStore';
+import { timeout } from './lib/Timeout';
 import {
   AckCommitsEvent,
   CommitsEvent,
+  GetRemoteFn,
   OnEventFn,
+  Remote,
   RemoteSyncInfo,
+  SyncEvent,
 } from './types';
 
 class MockLocalStore extends AbstractLocalStore<unknown, unknown, unknown> {
-  constructor(onEvent: OnEventFn<unknown, unknown, unknown> = () => undefined) {
-    super('', '', onEvent);
+  constructor(
+    onEvent: OnEventFn<unknown, unknown, unknown> = () => undefined,
+    getRemote?: GetRemoteFn<unknown, unknown, unknown>,
+  ) {
+    super('', '', onEvent, getRemote);
+    if (getRemote) {
+      this.initialize().catch(this.handleAsError('internal'));
+    }
   }
   async acknowledgeRemoteCommits(): Promise<void> {
     //
@@ -39,6 +49,18 @@ class MockLocalStore extends AbstractLocalStore<unknown, unknown, unknown> {
   }
 }
 
+class MockRemote implements Remote<unknown, unknown, unknown> {
+  constructor(readonly onEvent: OnEventFn<unknown, unknown, unknown>) {}
+
+  send(event: SyncEvent<unknown, unknown, unknown>): void {
+    //
+  }
+
+  shutdown(): void | Promise<void> {
+    //
+  }
+}
+
 describe('AbstractLocalStore', () => {
   it('fail if initialize is called twice', async () => {
     class DoubleInitTestStore extends MockLocalStore {
@@ -60,6 +82,47 @@ describe('AbstractLocalStore', () => {
     await store.shutdown();
     expect(fn.mock.calls).toMatchInlineSnapshot(`Array []`);
   });
+  it('does not send two client join events if the current state is online', async () => {
+    const fn = jest.fn();
+    let mockRemote: MockRemote;
+    let sendSpy: jest.SpyInstance;
+
+    await new Promise<void>((resolve) => {
+      new MockLocalStore(fn, (_, __, onEvent) => {
+        mockRemote = new MockRemote(onEvent);
+        sendSpy = jest.spyOn(mockRemote, 'send');
+        resolve();
+        return mockRemote;
+      });
+    });
+
+    mockRemote!.onEvent({ type: 'remote-state', connect: 'online' });
+    mockRemote!.onEvent({ type: 'remote-state', connect: 'online' });
+
+    await timeout();
+
+    expect(sendSpy!.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    Object {
+      "type": "ready",
+    },
+  ],
+  Array [
+    Object {
+      "info": Object {
+        "clientId": "",
+        "presence": undefined,
+        "ref": undefined,
+        "userId": "",
+      },
+      "type": "client-join",
+    },
+  ],
+]
+`);
+  });
+
   it('handle empty update call', async () => {
     const fn = jest.fn();
     const store = new MockLocalStore(fn);

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -197,7 +197,10 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, Presence>
         break;
       case 'remote-state':
         if (origin === 'remote') {
-          if (event.connect === 'online') {
+          if (
+            event.connect === 'online' &&
+            this.remoteSyncState.connect !== 'online'
+          ) {
             await this.sendEvent(
               {
                 type: 'client-join',


### PR DESCRIPTION
If the remote sends a status that of connect: "online" but the existing status is already online, don't send a client join message.