### PR TITLE
restructure commit types [ED-3237]

### DIFF
--- a/packages/trimerge-sync/src/AbstractLocalStore.test.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.test.ts
@@ -6,8 +6,15 @@ import {
   RemoteSyncInfo,
 } from './types';
 
-class MockLocalStore extends AbstractLocalStore<unknown, unknown, unknown> {
-  constructor(onEvent: OnEventFn<unknown, unknown, unknown> = () => undefined) {
+class MockLocalStore extends AbstractLocalStore<
+  unknown,
+  unknown,
+  unknown,
+  unknown
+> {
+  constructor(
+    onEvent: OnEventFn<unknown, unknown, unknown, unknown> = () => undefined,
+  ) {
     super('', '', onEvent);
   }
   async acknowledgeRemoteCommits(): Promise<void> {
@@ -27,13 +34,13 @@ class MockLocalStore extends AbstractLocalStore<unknown, unknown, unknown> {
   }
 
   async *getLocalCommits(): AsyncIterableIterator<
-    CommitsEvent<unknown, unknown, unknown>
+    CommitsEvent<unknown, unknown, unknown, unknown>
   > {
     //
   }
 
   async *getCommitsForRemote(): AsyncIterableIterator<
-    CommitsEvent<unknown, unknown, unknown>
+    CommitsEvent<unknown, unknown, unknown, unknown>
   > {
     //
   }

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -11,6 +11,7 @@ type TestEditMetadata = string;
 type TestSavedDoc = any;
 type TestDoc = any;
 type TestPresence = any;
+type TestCreationMetadata = any;
 
 const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
   migrate,
@@ -21,30 +22,54 @@ const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
 };
 
 function newStore() {
-  return new MemoryStore<TestEditMetadata, Delta, TestPresence>();
+  return new MemoryStore<
+    TestEditMetadata,
+    Delta,
+    TestPresence,
+    TestCreationMetadata
+  >();
 }
 
 function makeClient(
   userId: string,
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+  store: MemoryStore<
+    TestEditMetadata,
+    Delta,
+    TestPresence,
+    TestCreationMetadata
+  >,
 ): TrimergeClient<
   TestSavedDoc,
   TestDoc,
   TestEditMetadata,
   Delta,
-  TestPresence
+  TestPresence,
+  TestCreationMetadata
 > {
-  return new TrimergeClient(userId, 'test', store.getLocalStore, differ, 0);
+  return new TrimergeClient(
+    userId,
+    'test',
+    store.getLocalStore,
+    differ,
+    0,
+    () => 'test',
+  );
 }
 
 function basicGraph(
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+  store: MemoryStore<
+    TestEditMetadata,
+    Delta,
+    TestPresence,
+    TestCreationMetadata
+  >,
   client1: TrimergeClient<
     TestSavedDoc,
     TestDoc,
     TestEditMetadata,
     Delta,
-    TestPresence
+    TestPresence,
+    TestCreationMetadata
   >,
 ) {
   return getBasicGraph(
@@ -60,7 +85,8 @@ function sortedClients(
     TestDoc,
     TestEditMetadata,
     Delta,
-    TestPresence
+    TestPresence,
+    TestCreationMetadata
   >,
 ) {
   return Array.from(client.clients).sort(clientSort);

--- a/packages/trimerge-sync/src/lib/Commits.ts
+++ b/packages/trimerge-sync/src/lib/Commits.ts
@@ -1,4 +1,4 @@
-import { Commit } from '../types';
+import { CommitBody } from '../types';
 
 export type CommitRefs = {
   ref: string;
@@ -8,5 +8,6 @@ export type CommitRefs = {
 };
 
 // used for getting any possible refs from a general commit, refs that do not apply will be undefined.
-export const asCommitRefs = (commit: Commit<unknown, unknown>): CommitRefs =>
-  commit;
+export const asCommitRefs = (
+  commit: CommitBody<unknown, unknown>,
+): CommitRefs => commit;

--- a/packages/trimerge-sync/src/merge-heads.ts
+++ b/packages/trimerge-sync/src/merge-heads.ts
@@ -1,7 +1,9 @@
 export type MergableCommit = {
-  ref: string;
-  baseRef?: string;
-  mergeRef?: string;
+  body: {
+    ref: string;
+    baseRef?: string;
+    mergeRef?: string;
+  };
 };
 
 type Visitor = {
@@ -72,7 +74,9 @@ export function mergeHeads<N extends MergableCommit>(
             return true;
           }
         }
-        const { baseRef, mergeRef } = getCommit(commitRef);
+        const {
+          body: { baseRef, mergeRef },
+        } = getCommit(commitRef);
         if (baseRef !== undefined) {
           nextCommitRefs.add(baseRef);
           leaf.seenRefs.add(baseRef);

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.ts
@@ -1,5 +1,5 @@
 import { asCommitRefs } from '../lib/Commits';
-import { Commit, isMergeCommit } from '../types';
+import { Commit, CommitBody, isMergeCommit } from '../types';
 
 type BasicGraphItem = {
   graph: string;
@@ -7,25 +7,25 @@ type BasicGraphItem = {
   value: any;
 };
 export function getBasicGraph<EditMetadata>(
-  commits: Iterable<Commit<EditMetadata, unknown>>,
-  getEditLabel: (commit: Commit<EditMetadata, unknown>) => string,
-  getValue: (commit: Commit<EditMetadata, unknown>) => any,
+  commits: Iterable<Commit<EditMetadata, unknown, unknown>>,
+  getEditLabel: (commit: CommitBody<EditMetadata, unknown>) => string,
+  getValue: (commit: CommitBody<EditMetadata, unknown>) => any,
 ): BasicGraphItem[] {
   const result = [];
-  for (const commit of commits) {
-    const userId = commit.userId;
-    const { ref, baseRef, mergeBaseRef, mergeRef } = asCommitRefs(commit);
+  for (const { body } of commits) {
+    const userId = body.userId;
+    const { ref, baseRef, mergeBaseRef, mergeRef } = asCommitRefs(body);
     if (mergeRef) {
       result.push({
         graph: `(${baseRef} + ${mergeRef}) w/ base=${mergeBaseRef} -> ${ref}`,
         step: `User ${userId}: merge`,
-        value: getValue(commit),
+        value: getValue(body),
       });
     } else {
       result.push({
         graph: `${baseRef} -> ${ref}`,
-        step: `User ${userId}: ${getEditLabel(commit)}`,
-        value: getValue(commit),
+        step: `User ${userId}: ${getEditLabel(body)}`,
+        value: getValue(body),
       });
     }
   }
@@ -33,9 +33,9 @@ export function getBasicGraph<EditMetadata>(
 }
 
 export function getDotGraph<EditMetadata>(
-  commits: Iterable<Commit<EditMetadata, unknown>>,
-  getEditLabel: (commit: Commit<EditMetadata, any>) => string,
-  getValue: (commit: Commit<EditMetadata, any>) => string,
+  commits: Iterable<CommitBody<EditMetadata, unknown>>,
+  getEditLabel: (commit: CommitBody<EditMetadata, any>) => string,
+  getValue: (commit: CommitBody<EditMetadata, any>) => string,
 ): string {
   const lines: string[] = ['digraph {'];
   for (const commit of commits) {

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
@@ -2,12 +2,12 @@ import { AbstractLocalStore, BroadcastEvent } from '../AbstractLocalStore';
 import { MemoryBroadcastChannel } from './MemoryBroadcastChannel';
 import {
   AckCommitsEvent,
-  Commit,
   GetRemoteFn,
   CommitsEvent,
   OnEventFn,
   RemoteSyncInfo,
   CommitAck,
+  Commit,
 } from '../types';
 import { MemoryStore } from './MemoryStore';
 
@@ -15,18 +15,24 @@ export class MemoryLocalStore<
   EditMetadata,
   Delta,
   Presence,
-> extends AbstractLocalStore<EditMetadata, Delta, Presence> {
+  CreationMetadata,
+> extends AbstractLocalStore<EditMetadata, Delta, Presence, CreationMetadata> {
   private _closed = false;
   public readonly channel: MemoryBroadcastChannel<
-    BroadcastEvent<EditMetadata, Delta, Presence>
+    BroadcastEvent<EditMetadata, Delta, Presence, CreationMetadata>
   >;
 
   constructor(
-    private readonly store: MemoryStore<EditMetadata, Delta, Presence>,
+    private readonly store: MemoryStore<
+      EditMetadata,
+      Delta,
+      Presence,
+      CreationMetadata
+    >,
     userId: string,
     clientId: string,
-    onEvent: OnEventFn<EditMetadata, Delta, Presence>,
-    getRemote?: GetRemoteFn<EditMetadata, Delta, Presence>,
+    onEvent: OnEventFn<EditMetadata, Delta, Presence, CreationMetadata>,
+    getRemote?: GetRemoteFn<EditMetadata, Delta, Presence, CreationMetadata>,
   ) {
     super(userId, clientId, onEvent, getRemote, {
       initialDelayMs: 0,
@@ -44,10 +50,9 @@ export class MemoryLocalStore<
   }
 
   protected addCommits(
-    commits: Commit<EditMetadata, Delta>[],
-    remoteSyncId?: string,
+    commits: Commit<EditMetadata, Delta, CreationMetadata>[],
   ): Promise<AckCommitsEvent> {
-    return this.store.addCommits(commits, remoteSyncId);
+    return this.store.addCommits(commits);
   }
 
   protected async acknowledgeRemoteCommits(
@@ -58,7 +63,7 @@ export class MemoryLocalStore<
   }
 
   protected async broadcastLocal(
-    event: BroadcastEvent<EditMetadata, Delta, Presence>,
+    event: BroadcastEvent<EditMetadata, Delta, Presence, CreationMetadata>,
   ): Promise<void> {
     if (this._closed) {
       return;
@@ -67,13 +72,13 @@ export class MemoryLocalStore<
   }
 
   protected async *getLocalCommits(): AsyncIterableIterator<
-    CommitsEvent<EditMetadata, Delta, Presence>
+    CommitsEvent<EditMetadata, Delta, Presence, CreationMetadata>
   > {
     yield await this.store.getLocalCommitsEvent();
   }
 
   protected getCommitsForRemote(): AsyncIterableIterator<
-    CommitsEvent<EditMetadata, Delta, Presence>
+    CommitsEvent<EditMetadata, Delta, Presence, CreationMetadata>
   > {
     return this.store.getCommitsForRemote();
   }

--- a/packages/trimerge-sync/src/validateCommits.ts
+++ b/packages/trimerge-sync/src/validateCommits.ts
@@ -1,17 +1,17 @@
 import { asCommitRefs } from './lib/Commits';
-import type { AckCommitsEvent, Commit } from './types';
+import type { AckCommitsEvent, CommitBody } from './types';
 
 export type CommitValidation<EditMetadata, Delta> = {
-  newCommits: readonly Commit<EditMetadata, Delta>[];
+  newCommits: readonly CommitBody<EditMetadata, Delta>[];
   invalidRefs: Set<string>;
   referencedCommits: Set<string>;
 };
 
 export function validateCommitOrder<EditMetadata, Delta>(
-  commits: readonly Commit<EditMetadata, Delta>[],
+  commits: readonly CommitBody<EditMetadata, Delta>[],
 ): CommitValidation<EditMetadata, Delta> {
   const newCommitRefs = new Set<string>();
-  const newCommits: Commit<EditMetadata, Delta>[] = [];
+  const newCommits: CommitBody<EditMetadata, Delta>[] = [];
   const referencedCommits = new Set<string>();
   const invalidRefs = new Set<string>();
   function addReferencedCommit(ref?: string) {


### PR DESCRIPTION
Some things I'm not sure about:
 - potentially we don't need an explicit commit body field and those fields can be directly on the commit object?
 - right now the CreationMetadata is completely delegated to the userland but maybe we can be opinionated about this and generate it within trimerge client? would clean up the type parameters quite a bit.