### PR TITLE
grab cursor from commits for indexed db local store

### DIFF
--- a/packages/trimerge-sync-basic-server/src/lib/SqliteDocStore.ts
+++ b/packages/trimerge-sync-basic-server/src/lib/SqliteDocStore.ts
@@ -104,6 +104,7 @@ export class SqliteDocStore implements DocStore {
             delta: delta ? JSON.parse(delta) : undefined,
             metadata: metadata ? JSON.parse(metadata) : undefined,
             main: Boolean(main),
+            cursor: remoteSyncId,
           };
         } else {
           return {
@@ -113,6 +114,7 @@ export class SqliteDocStore implements DocStore {
             delta: delta ? JSON.parse(delta) : undefined,
             metadata: metadata ? JSON.parse(metadata) : undefined,
             main: Boolean(main),
+            cursor: remoteSyncId,
           };
         }
       },

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -44,6 +44,19 @@ export function isMergeCommit(
   return (commit as MergeCommit<unknown, unknown>).mergeRef !== undefined;
 }
 
+export function hasServerInfo(
+  commit: Commit<unknown, unknown>,
+): commit is ServerCommit<unknown, unknown>;
+export function hasServerInfo(commit: CommitAck): commit is ServerCommitAck;
+export function hasServerInfo(
+  commit: Commit<unknown, unknown> | CommitAck,
+): commit is ServerCommit<unknown, unknown> | ServerCommitAck {
+  return (
+    (commit as ServerCommit<unknown, unknown>).main !== undefined &&
+    (commit as ServerCommit<unknown, unknown>).cursor !== undefined
+  );
+}
+
 export type Commit<EditMetadata, Delta> =
   | MergeCommit<EditMetadata, Delta>
   | EditCommit<EditMetadata, Delta>;
@@ -113,6 +126,8 @@ export type CommitAck = {
   // If the remote acking this commit is authoritative, main will indicate if this
   // commit is on the mainline or not, otherwise it will be undefined.
   main?: boolean;
+
+  cursor?: string;
 };
 
 export type ServerCommitAck = Required<CommitAck>;


### PR DESCRIPTION
From the conversation earlier today with @aglick-descript, acks are just full commits so this pr updates the indexed db local store to grab that information off the Commits if its available, and updates existing commits in the indexed db if they already exist locally.