### PR TITLE
Differ.merge -> mergeAllBranches

### DIFF
--- a/packages/example-broadcast-channel/src/AppDoc.ts
+++ b/packages/example-broadcast-channel/src/AppDoc.ts
@@ -7,7 +7,7 @@ import {
   useTrimergeStateShutdown,
   useTrimergeSyncStatus,
 } from './lib/trimergeHooks';
-import { diff, merge, patch } from './lib/trimergeDiffer';
+import { diff, mergeAllBranches, patch } from './lib/trimergeDiffer';
 import { Differ } from 'trimerge-sync';
 import { computeRef } from 'trimerge-sync-hash';
 import { currentTabId } from './lib/currentTabId';
@@ -29,11 +29,11 @@ export const defaultDoc = {
 };
 
 export const differ: Differ<SavedAppDoc, LatestAppDoc, string, Delta> = {
-  migrate: (doc, editMetadata) => ({ doc, metadata }),
+  migrate: (doc, metadata) => ({ doc, metadata }),
   diff,
   patch: (priorOrNext, delta) => patch(priorOrNext, delta) ?? defaultDoc,
   computeRef,
-  merge,
+  mergeAllBranches,
 };
 
 const DEMO_DOC_ID = 'demo';

--- a/packages/example-broadcast-channel/src/AppDoc.ts
+++ b/packages/example-broadcast-channel/src/AppDoc.ts
@@ -29,7 +29,7 @@ export const defaultDoc = {
 };
 
 export const differ: Differ<SavedAppDoc, LatestAppDoc, string, Delta> = {
-  migrate: (doc, editMetadata) => ({ doc, editMetadata }),
+  migrate: (doc, editMetadata) => ({ doc, metadata }),
   diff,
   patch: (priorOrNext, delta) => patch(priorOrNext, delta) ?? defaultDoc,
   computeRef,

--- a/packages/example-broadcast-channel/src/lib/trimergeDiffer.ts
+++ b/packages/example-broadcast-channel/src/lib/trimergeDiffer.ts
@@ -19,7 +19,7 @@ const trimergeObjects = combineMergers(
 
 export const merge: MergeDocFn<any, string> = (base, left, right) => ({
   doc: trimergeObjects(base?.doc, left.doc, right.doc),
-  editMetadata: `merge`,
+  metadata: `merge`,
 });
 
 const jdp = create({ textDiff: { minLength: 20 } });

--- a/packages/example-broadcast-channel/src/lib/trimergeDiffer.ts
+++ b/packages/example-broadcast-channel/src/lib/trimergeDiffer.ts
@@ -6,7 +6,7 @@ import {
   trimergeString,
 } from 'trimerge';
 import {
-  makeAutoBranchMerger,
+  makeMergeAllBranchesFn,
   MergeAllBranchesFn,
   MergeDocFn,
 } from 'trimerge-sync';
@@ -27,7 +27,7 @@ export const merge: MergeDocFn<any, string> = (base, left, right) => ({
 });
 
 export const mergeAllBranches: MergeAllBranchesFn<any, any> =
-  makeAutoBranchMerger((a, b) => (a < b ? -1 : 1), merge);
+  makeMergeAllBranchesFn((a, b) => (a < b ? -1 : 1), merge);
 
 const jdp = create({ textDiff: { minLength: 20 } });
 

--- a/packages/example-broadcast-channel/src/lib/trimergeDiffer.ts
+++ b/packages/example-broadcast-channel/src/lib/trimergeDiffer.ts
@@ -5,7 +5,11 @@ import {
   trimergeObject,
   trimergeString,
 } from 'trimerge';
-import { MergeDocFn } from 'trimerge-sync';
+import {
+  makeAutoBranchMerger,
+  MergeAllBranchesFn,
+  MergeDocFn,
+} from 'trimerge-sync';
 import { create, Delta } from 'jsondiffpatch';
 import { produce } from 'immer';
 import { trimergeNumber } from './trimergeNumber';
@@ -21,6 +25,9 @@ export const merge: MergeDocFn<any, string> = (base, left, right) => ({
   doc: trimergeObjects(base?.doc, left.doc, right.doc),
   metadata: `merge`,
 });
+
+export const mergeAllBranches: MergeAllBranchesFn<any, any> =
+  makeAutoBranchMerger((a, b) => (a < b ? -1 : 1), merge);
 
 const jdp = create({ textDiff: { minLength: 20 } });
 

--- a/packages/example-broadcast-channel/src/lib/trimergeHooks.ts
+++ b/packages/example-broadcast-channel/src/lib/trimergeHooks.ts
@@ -7,9 +7,9 @@ import {
 import { WebsocketRemote } from 'trimerge-sync-basic-client';
 import { randomId } from './randomId';
 
-export type UpdateDocFn<LatestDoc, EditMetadata> = (
+export type UpdateDocFn<LatestDoc, CommitMetadata> = (
   doc: LatestDoc,
-  editMetadata: EditMetadata,
+  metadata: CommitMetadata,
 ) => void;
 export type UpdatePresenceFn<Presence> = (newPresence: Presence) => void;
 
@@ -21,13 +21,13 @@ const TRIMERGE_CLIENT_CACHE: Record<
 function getCachedTrimergeClient<
   SavedDoc,
   LatestDoc extends SavedDoc,
-  EditMetadata,
+  CommitMetadata,
   Delta,
 >(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<SavedDoc, LatestDoc, EditMetadata, Delta>,
+  differ: Differ<SavedDoc, LatestDoc, CommitMetadata, Delta>,
 ) {
   const key = `${docId}:${userId}:${clientId}`;
   if (!TRIMERGE_CLIENT_CACHE[key]) {
@@ -54,13 +54,13 @@ function getCachedTrimergeClient<
 export function useTrimergeStateShutdown<
   SavedDoc,
   LatestDoc extends SavedDoc,
-  EditMetadata,
+  CommitMetadata,
   Delta,
 >(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<SavedDoc, LatestDoc, EditMetadata, Delta>,
+  differ: Differ<SavedDoc, LatestDoc, CommitMetadata, Delta>,
 ): void {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
 
@@ -75,13 +75,13 @@ export function useTrimergeStateShutdown<
 export function useTrimergeDeleteDatabase<
   SavedDoc,
   LatestDoc extends SavedDoc,
-  EditMetadata,
+  CommitMetadata,
   Delta,
 >(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<SavedDoc, LatestDoc, EditMetadata, Delta>,
+  differ: Differ<SavedDoc, LatestDoc, CommitMetadata, Delta>,
 ): () => Promise<void> {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
 
@@ -97,14 +97,14 @@ export function useTrimergeDeleteDatabase<
 export function useTrimergeDoc<
   SavedDoc,
   LatestDoc extends SavedDoc,
-  EditMetadata,
+  CommitMetadata,
   Delta,
 >(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<SavedDoc, LatestDoc, EditMetadata, Delta>,
-): [LatestDoc, UpdateDocFn<LatestDoc, EditMetadata>] {
+  differ: Differ<SavedDoc, LatestDoc, CommitMetadata, Delta>,
+): [LatestDoc, UpdateDocFn<LatestDoc, CommitMetadata>] {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
   const [doc, setDoc] = useState(client.doc);
 
@@ -118,14 +118,14 @@ export function useTrimergeDoc<
 export function useTrimergeClientList<
   SavedDoc,
   LatestDoc extends SavedDoc,
-  EditMetadata,
+  CommitMetadata,
   Delta,
   Presence,
 >(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<SavedDoc, LatestDoc, EditMetadata, Delta>,
+  differ: Differ<SavedDoc, LatestDoc, CommitMetadata, Delta>,
 ): [ClientList<Presence>, UpdatePresenceFn<Presence>] {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
   const [clients, setClients] = useState(client.clients);
@@ -143,13 +143,13 @@ export function useTrimergeClientList<
 export function useTrimergeSyncStatus<
   SavedDoc,
   LatestDoc extends SavedDoc,
-  EditMetadata,
+  CommitMetadata,
   Delta,
 >(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<SavedDoc, LatestDoc, EditMetadata, Delta>,
+  differ: Differ<SavedDoc, LatestDoc, CommitMetadata, Delta>,
 ): SyncStatus {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
   const [status, setStatus] = useState(client.syncStatus);

--- a/packages/example-broadcast-channel/src/lib/trimergeHooks.ts
+++ b/packages/example-broadcast-channel/src/lib/trimergeHooks.ts
@@ -7,9 +7,9 @@ import {
 import { WebsocketRemote } from 'trimerge-sync-basic-client';
 import { randomId } from './randomId';
 
-export type UpdateDocFn<LatestDoc, CommitMetadata> = (
+export type UpdateDocFn<LatestDoc, EditMetadata> = (
   doc: LatestDoc,
-  metadata: CommitMetadata,
+  metadata: EditMetadata,
 ) => void;
 export type UpdatePresenceFn<Presence> = (newPresence: Presence) => void;
 
@@ -21,13 +21,13 @@ const TRIMERGE_CLIENT_CACHE: Record<
 function getCachedTrimergeClient<
   SavedDoc,
   LatestDoc extends SavedDoc,
-  CommitMetadata,
+  EditMetadata,
   Delta,
 >(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<SavedDoc, LatestDoc, CommitMetadata, Delta>,
+  differ: Differ<SavedDoc, LatestDoc, EditMetadata, Delta>,
 ) {
   const key = `${docId}:${userId}:${clientId}`;
   if (!TRIMERGE_CLIENT_CACHE[key]) {
@@ -54,13 +54,13 @@ function getCachedTrimergeClient<
 export function useTrimergeStateShutdown<
   SavedDoc,
   LatestDoc extends SavedDoc,
-  CommitMetadata,
+  EditMetadata,
   Delta,
 >(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<SavedDoc, LatestDoc, CommitMetadata, Delta>,
+  differ: Differ<SavedDoc, LatestDoc, EditMetadata, Delta>,
 ): void {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
 
@@ -75,13 +75,13 @@ export function useTrimergeStateShutdown<
 export function useTrimergeDeleteDatabase<
   SavedDoc,
   LatestDoc extends SavedDoc,
-  CommitMetadata,
+  EditMetadata,
   Delta,
 >(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<SavedDoc, LatestDoc, CommitMetadata, Delta>,
+  differ: Differ<SavedDoc, LatestDoc, EditMetadata, Delta>,
 ): () => Promise<void> {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
 
@@ -97,14 +97,14 @@ export function useTrimergeDeleteDatabase<
 export function useTrimergeDoc<
   SavedDoc,
   LatestDoc extends SavedDoc,
-  CommitMetadata,
+  EditMetadata,
   Delta,
 >(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<SavedDoc, LatestDoc, CommitMetadata, Delta>,
-): [LatestDoc, UpdateDocFn<LatestDoc, CommitMetadata>] {
+  differ: Differ<SavedDoc, LatestDoc, EditMetadata, Delta>,
+): [LatestDoc, UpdateDocFn<LatestDoc, EditMetadata>] {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
   const [doc, setDoc] = useState(client.doc);
 
@@ -118,14 +118,14 @@ export function useTrimergeDoc<
 export function useTrimergeClientList<
   SavedDoc,
   LatestDoc extends SavedDoc,
-  CommitMetadata,
+  EditMetadata,
   Delta,
   Presence,
 >(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<SavedDoc, LatestDoc, CommitMetadata, Delta>,
+  differ: Differ<SavedDoc, LatestDoc, EditMetadata, Delta>,
 ): [ClientList<Presence>, UpdatePresenceFn<Presence>] {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
   const [clients, setClients] = useState(client.clients);
@@ -143,13 +143,13 @@ export function useTrimergeClientList<
 export function useTrimergeSyncStatus<
   SavedDoc,
   LatestDoc extends SavedDoc,
-  CommitMetadata,
+  EditMetadata,
   Delta,
 >(
   docId: string,
   userId: string,
   clientId: string,
-  differ: Differ<SavedDoc, LatestDoc, CommitMetadata, Delta>,
+  differ: Differ<SavedDoc, LatestDoc, EditMetadata, Delta>,
 ): SyncStatus {
   const client = getCachedTrimergeClient(docId, userId, clientId, differ);
   const [status, setStatus] = useState(client.syncStatus);

--- a/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
+++ b/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
@@ -6,15 +6,15 @@ import type {
   SyncEvent,
 } from 'trimerge-sync';
 
-export class WebsocketRemote<CommitMetadata, Delta, Presence>
-  implements Remote<CommitMetadata, Delta, Presence>
+export class WebsocketRemote<EditMetadata, Delta, Presence>
+  implements Remote<EditMetadata, Delta, Presence>
 {
   private socket: WebSocket | undefined;
-  private bufferedEvents: SyncEvent<CommitMetadata, Delta, Presence>[] = [];
+  private bufferedEvents: SyncEvent<EditMetadata, Delta, Presence>[] = [];
   constructor(
     auth: unknown,
     { localStoreId, lastSyncCursor }: RemoteSyncInfo,
-    private readonly onEvent: OnRemoteEventFn<CommitMetadata, Delta, Presence>,
+    private readonly onEvent: OnRemoteEventFn<EditMetadata, Delta, Presence>,
     websocketUrl: string,
   ) {
     console.log(`[TRIMERGE-SYNC] Connecting to ${websocketUrl}...`);
@@ -46,7 +46,7 @@ export class WebsocketRemote<CommitMetadata, Delta, Presence>
     });
   }
 
-  send(event: SyncEvent<CommitMetadata, Delta, Presence>): void {
+  send(event: SyncEvent<EditMetadata, Delta, Presence>): void {
     if (!this.socket) {
       return;
     }

--- a/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
+++ b/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
@@ -6,15 +6,15 @@ import type {
   SyncEvent,
 } from 'trimerge-sync';
 
-export class WebsocketRemote<EditMetadata, Delta, Presence>
-  implements Remote<EditMetadata, Delta, Presence>
+export class WebsocketRemote<CommitMetadata, Delta, Presence>
+  implements Remote<CommitMetadata, Delta, Presence>
 {
   private socket: WebSocket | undefined;
-  private bufferedEvents: SyncEvent<EditMetadata, Delta, Presence>[] = [];
+  private bufferedEvents: SyncEvent<CommitMetadata, Delta, Presence>[] = [];
   constructor(
     auth: unknown,
     { localStoreId, lastSyncCursor }: RemoteSyncInfo,
-    private readonly onEvent: OnEventFn<EditMetadata, Delta, Presence>,
+    private readonly onEvent: OnEventFn<CommitMetadata, Delta, Presence>,
     websocketUrl: string,
   ) {
     console.log(`[TRIMERGE-SYNC] Connecting to ${websocketUrl}...`);
@@ -46,7 +46,7 @@ export class WebsocketRemote<EditMetadata, Delta, Presence>
     });
   }
 
-  send(event: SyncEvent<EditMetadata, Delta, Presence>): void {
+  send(event: SyncEvent<CommitMetadata, Delta, Presence>): void {
     if (!this.socket) {
       return;
     }

--- a/packages/trimerge-sync-basic-server/src/lib/SqliteDocStore.test.ts
+++ b/packages/trimerge-sync-basic-server/src/lib/SqliteDocStore.test.ts
@@ -42,7 +42,6 @@ describe('SqliteDocStore', () => {
       store.add([
         {
           ref: 'hello1',
-          userId: 'user-2',
           metadata: {
             clientId: 'client-1',
             hello: 'world',
@@ -51,24 +50,40 @@ describe('SqliteDocStore', () => {
 
         {
           ref: 'hello2',
-          userId: 'user-2',
           metadata: {
             clientId: 'client-1',
             hello: 'world',
           },
+
           baseRef: 'hello1',
-          delta: { delta: 'format' },
+          delta: JSON.stringify({ delta: 'format' }),
         },
       ]),
     ).toMatchInlineSnapshot(`
       Object {
         "acks": Array [
           Object {
-            "main": true,
+            "metadata": Object {
+              "clientId": "client-1",
+              "hello": "world",
+              "server": Object {
+                "main": true,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 0,
+              },
+            },
             "ref": "hello1",
           },
           Object {
-            "main": true,
+            "metadata": Object {
+              "clientId": "client-1",
+              "hello": "world",
+              "server": Object {
+                "main": true,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 1,
+              },
+            },
             "ref": "hello2",
           },
         ],
@@ -82,15 +97,20 @@ describe('SqliteDocStore', () => {
       store.add([
         {
           ref: 'hello3',
-          userId: 'client-2',
-          metadata: undefined,
+          metadata: {},
         },
       ]),
     ).toMatchInlineSnapshot(`
       Object {
         "acks": Array [
           Object {
-            "main": false,
+            "metadata": Object {
+              "server": Object {
+                "main": false,
+                "remoteSyncId": "1970-01-01T00:00:00.001Z",
+                "remoteSyncIndex": 0,
+              },
+            },
             "ref": "hello3",
           },
         ],
@@ -105,35 +125,43 @@ describe('SqliteDocStore', () => {
         "commits": Array [
           Object {
             "baseRef": undefined,
-            "delta": undefined,
-            "main": true,
+            "delta": null,
             "metadata": Object {
               "clientId": "client-1",
               "hello": "world",
+              "server": Object {
+                "main": true,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 0,
+              },
             },
             "ref": "hello1",
-            "userId": "user-2",
           },
           Object {
             "baseRef": "hello1",
-            "delta": Object {
-              "delta": "format",
-            },
-            "main": true,
+            "delta": "{\\"delta\\":\\"format\\"}",
             "metadata": Object {
               "clientId": "client-1",
               "hello": "world",
+              "server": Object {
+                "main": true,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 1,
+              },
             },
             "ref": "hello2",
-            "userId": "user-2",
           },
           Object {
             "baseRef": undefined,
-            "delta": undefined,
-            "main": false,
-            "metadata": undefined,
+            "delta": null,
+            "metadata": Object {
+              "server": Object {
+                "main": false,
+                "remoteSyncId": "1970-01-01T00:00:00.001Z",
+                "remoteSyncIndex": 0,
+              },
+            },
             "ref": "hello3",
-            "userId": "client-2",
           },
         ],
         "syncId": "1970-01-01T00:00:00.001Z",
@@ -147,11 +175,15 @@ describe('SqliteDocStore', () => {
         "commits": Array [
           Object {
             "baseRef": undefined,
-            "delta": undefined,
-            "main": false,
-            "metadata": undefined,
+            "delta": null,
+            "metadata": Object {
+              "server": Object {
+                "main": false,
+                "remoteSyncId": "1970-01-01T00:00:00.001Z",
+                "remoteSyncIndex": 0,
+              },
+            },
             "ref": "hello3",
-            "userId": "client-2",
           },
         ],
         "syncId": "1970-01-01T00:00:00.001Z",
@@ -167,13 +199,11 @@ describe('SqliteDocStore', () => {
       store.add([
         {
           ref: 'hello1',
-          userId: 'client-2',
           metadata: { hello: 'world', clientId: 'client-1' },
         },
 
         {
           ref: 'hello1',
-          userId: 'client-2',
           metadata: { hello: 'world', clientId: 'client-1' },
         },
       ]),
@@ -181,7 +211,15 @@ describe('SqliteDocStore', () => {
       Object {
         "acks": Array [
           Object {
-            "main": true,
+            "metadata": Object {
+              "clientId": "client-1",
+              "hello": "world",
+              "server": Object {
+                "main": true,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 0,
+              },
+            },
             "ref": "hello1",
           },
         ],
@@ -199,22 +237,13 @@ describe('SqliteDocStore', () => {
       store.add([
         {
           ref: 'hello1',
-          userId: 'client-2',
           baseRef: 'unknown',
           metadata: { hello: 'world', clientId: 'client-2' },
         },
 
         {
           ref: 'hello2',
-          userId: 'client-2',
           mergeRef: 'unknown',
-          metadata: { hello: 'world', clientId: 'client-2' },
-        },
-
-        {
-          ref: 'hello3',
-          userId: 'client-2',
-          mergeBaseRef: 'unknown',
           metadata: { hello: 'world', clientId: 'client-2' },
         },
       ]),
@@ -230,10 +259,6 @@ describe('SqliteDocStore', () => {
             "code": "unknown-ref",
             "message": "unknown mergeRef",
           },
-          "hello3": Object {
-            "code": "unknown-ref",
-            "message": "unknown mergeBaseRef",
-          },
         },
         "syncId": "1970-01-01T00:00:00.000Z",
         "type": "ack",
@@ -248,14 +273,12 @@ describe('SqliteDocStore', () => {
       store.add([
         {
           ref: 'hello1',
-          userId: 'client-2',
           baseRef: 'unknown',
           metadata: { hello: 'world', clientId: 'client-2' },
         },
 
         {
           ref: 'hello2',
-          userId: 'client-2',
           baseRef: 'hello1',
           metadata: { hello: 'world', clientId: 'client-2' },
         },
@@ -286,19 +309,16 @@ describe('SqliteDocStore', () => {
       store.add([
         {
           ref: 'hello1',
-          userId: 'user-2',
           metadata: { hello: 'world', clientId: 'client-1' },
         },
 
         {
           ref: 'hello2',
-          userId: 'user-2',
           metadata: { hello: 'mars', clientId: 'client-2' },
         },
 
         {
           ref: 'hello3',
-          userId: 'client-2',
           baseRef: 'hello1',
           mergeRef: 'hello2',
           metadata: { hello: 'wmoarrlsd', clientId: 'client-1' },
@@ -308,15 +328,39 @@ describe('SqliteDocStore', () => {
       Object {
         "acks": Array [
           Object {
-            "main": true,
+            "metadata": Object {
+              "clientId": "client-1",
+              "hello": "world",
+              "server": Object {
+                "main": true,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 0,
+              },
+            },
             "ref": "hello1",
           },
           Object {
-            "main": false,
+            "metadata": Object {
+              "clientId": "client-2",
+              "hello": "mars",
+              "server": Object {
+                "main": false,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 1,
+              },
+            },
             "ref": "hello2",
           },
           Object {
-            "main": true,
+            "metadata": Object {
+              "clientId": "client-1",
+              "hello": "wmoarrlsd",
+              "server": Object {
+                "main": true,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 2,
+              },
+            },
             "ref": "hello3",
           },
         ],
@@ -326,48 +370,56 @@ describe('SqliteDocStore', () => {
       }
     `);
     expect(store.getCommitsEvent()).toMatchInlineSnapshot(`
-Object {
-  "commits": Array [
-    Object {
-      "baseRef": undefined,
-      "delta": undefined,
-      "main": true,
-      "metadata": Object {
-        "clientId": "client-1",
-        "hello": "world",
-      },
-      "ref": "hello1",
-      "userId": "user-2",
-    },
-    Object {
-      "baseRef": undefined,
-      "delta": undefined,
-      "main": false,
-      "metadata": Object {
-        "clientId": "client-2",
-        "hello": "mars",
-      },
-      "ref": "hello2",
-      "userId": "user-2",
-    },
-    Object {
-      "baseRef": "hello1",
-      "delta": undefined,
-      "main": true,
-      "mergeBaseRef": undefined,
-      "mergeRef": "hello2",
-      "metadata": Object {
-        "clientId": "client-1",
-        "hello": "wmoarrlsd",
-      },
-      "ref": "hello3",
-      "userId": "client-2",
-    },
-  ],
-  "syncId": "1970-01-01T00:00:00.000Z",
-  "type": "commits",
-}
-`);
+      Object {
+        "commits": Array [
+          Object {
+            "baseRef": undefined,
+            "delta": null,
+            "metadata": Object {
+              "clientId": "client-1",
+              "hello": "world",
+              "server": Object {
+                "main": true,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 0,
+              },
+            },
+            "ref": "hello1",
+          },
+          Object {
+            "baseRef": undefined,
+            "delta": null,
+            "metadata": Object {
+              "clientId": "client-2",
+              "hello": "mars",
+              "server": Object {
+                "main": false,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 1,
+              },
+            },
+            "ref": "hello2",
+          },
+          Object {
+            "baseRef": "hello1",
+            "delta": null,
+            "mergeRef": "hello2",
+            "metadata": Object {
+              "clientId": "client-1",
+              "hello": "wmoarrlsd",
+              "server": Object {
+                "main": true,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 2,
+              },
+            },
+            "ref": "hello3",
+          },
+        ],
+        "syncId": "1970-01-01T00:00:00.000Z",
+        "type": "commits",
+      }
+    `);
   });
   it('existing db', async () => {
     let store = makeSqliteStore('existing db');
@@ -375,19 +427,16 @@ Object {
     store.add([
       {
         ref: 'hello1',
-        userId: 'user-2',
         metadata: { hello: 'world', clientId: 'client-1' },
       },
 
       {
         ref: 'hello2',
-        userId: 'user-2',
         metadata: { hello: 'mars', clientId: 'client-2' },
       },
 
       {
         ref: 'hello3',
-        userId: 'user-2',
         baseRef: 'hello1',
         mergeRef: 'hello2',
         metadata: { hello: 'wmoarrlsd', clientId: 'client-1' },
@@ -401,65 +450,75 @@ Object {
     store.add([
       {
         ref: 'hello4',
-        userId: 'user-2',
         baseRef: 'hello3',
         metadata: { hello: 'blargan', clientId: 'client-1' },
       },
     ]);
 
     expect(store.getCommitsEvent()).toMatchInlineSnapshot(`
-Object {
-  "commits": Array [
-    Object {
-      "baseRef": undefined,
-      "delta": undefined,
-      "main": true,
-      "metadata": Object {
-        "clientId": "client-1",
-        "hello": "world",
-      },
-      "ref": "hello1",
-      "userId": "user-2",
-    },
-    Object {
-      "baseRef": "hello3",
-      "delta": undefined,
-      "main": false,
-      "metadata": Object {
-        "clientId": "client-1",
-        "hello": "blargan",
-      },
-      "ref": "hello4",
-      "userId": "user-2",
-    },
-    Object {
-      "baseRef": undefined,
-      "delta": undefined,
-      "main": false,
-      "metadata": Object {
-        "clientId": "client-2",
-        "hello": "mars",
-      },
-      "ref": "hello2",
-      "userId": "user-2",
-    },
-    Object {
-      "baseRef": "hello1",
-      "delta": undefined,
-      "main": true,
-      "mergeBaseRef": undefined,
-      "mergeRef": "hello2",
-      "metadata": Object {
-        "clientId": "client-1",
-        "hello": "wmoarrlsd",
-      },
-      "ref": "hello3",
-      "userId": "user-2",
-    },
-  ],
-  "syncId": "1970-01-01T00:00:00.000Z",
-  "type": "commits",
-}
-`);
+      Object {
+        "commits": Array [
+          Object {
+            "baseRef": undefined,
+            "delta": null,
+            "metadata": Object {
+              "clientId": "client-1",
+              "hello": "world",
+              "server": Object {
+                "main": true,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 0,
+              },
+            },
+            "ref": "hello1",
+          },
+          Object {
+            "baseRef": "hello3",
+            "delta": null,
+            "metadata": Object {
+              "clientId": "client-1",
+              "hello": "blargan",
+              "server": Object {
+                "main": false,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 0,
+              },
+            },
+            "ref": "hello4",
+          },
+          Object {
+            "baseRef": undefined,
+            "delta": null,
+            "metadata": Object {
+              "clientId": "client-2",
+              "hello": "mars",
+              "server": Object {
+                "main": false,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 1,
+              },
+            },
+            "ref": "hello2",
+          },
+          Object {
+            "baseRef": "hello1",
+            "delta": null,
+            "mergeRef": "hello2",
+            "metadata": Object {
+              "clientId": "client-1",
+              "hello": "wmoarrlsd",
+              "server": Object {
+                "main": true,
+                "remoteSyncId": "1970-01-01T00:00:00.000Z",
+                "remoteSyncIndex": 2,
+              },
+            },
+            "ref": "hello3",
+          },
+        ],
+        "syncId": "1970-01-01T00:00:00.000Z",
+        "type": "commits",
+      }
+    `);
   });
 });

--- a/packages/trimerge-sync-hash/src/index.test.ts
+++ b/packages/trimerge-sync-hash/src/index.test.ts
@@ -2,20 +2,16 @@ import { computeRef } from './index';
 
 describe('computeRef', () => {
   it.each`
-    baseRef      | mergeRef     | delta     | editMetadata  | result
-    ${undefined} | ${undefined} | ${[1, 2]} | ${'hi'}       | ${'slefeaKS-06WMEZtIXIWXgmC6fFUWFaENkaxURMhwP8'}
-    ${null}      | ${null}      | ${[1, 2]} | ${'hi'}       | ${'slefeaKS-06WMEZtIXIWXgmC6fFUWFaENkaxURMhwP8'}
-    ${undefined} | ${undefined} | ${[3, 2]} | ${'hi'}       | ${'CCq3OpOtTeYPPk0YCSW8yzXsN-zY-4HG6NHp5_RKu6k'}
-    ${undefined} | ${undefined} | ${[3, 2]} | ${'hi there'} | ${'QAK4T6AtKmxKuebS_1wBllhP-G624YXmKsQqC778Jtg'}
-    ${'hello'}   | ${undefined} | ${[1, 2]} | ${'hi'}       | ${'dUHl1xTlni8fW7LTJuOUAhoaZxyHuPJgfeUajcS_e2U'}
-    ${'hello'}   | ${'there'}   | ${[1, 2]} | ${'hi'}       | ${'tudzPVPEIApUcQVIQB9CvNICLz2vVgyl_ucgpYuGI5M'}
-    ${'hello'}   | ${'there'}   | ${[1, 2]} | ${'hi there'} | ${'LWjiVabbHLdu3vxwLpgC8heaHtOKMf5r8kyZ_-yWqg0'}
+    baseRef      | mergeRef     | delta     | result
+    ${undefined} | ${undefined} | ${[1, 2]} | ${'e4tEP48WbeAPyyMX-iR91_nNv68Lz6_iEAF2DOuA8IA'}
+    ${null}      | ${null}      | ${[1, 2]} | ${'e4tEP48WbeAPyyMX-iR91_nNv68Lz6_iEAF2DOuA8IA'}
+    ${undefined} | ${undefined} | ${[3, 2]} | ${'tzR6s--4kaAP4stUmtJrYkCkBw4EQiB21Ubym8S5TJM'}
+    ${'hello'}   | ${undefined} | ${[1, 2]} | ${'fv38CwR5uuYSAv4mj9BVsup68Gn2ui9wsRefumjZw64'}
+    ${'hello'}   | ${'there'}   | ${[1, 2]} | ${'Ds_llmZ9Wr1yLauPZd5aSR83TnAGPWlYd6cGpGAaZD4'}
   `(
-    'computeRef($baseRef, $mergeRef, $delta, $editMetadata) => $result',
-    ({ baseRef, mergeRef, delta, editMetadata, result }) => {
-      expect(computeRef(baseRef, mergeRef, delta, editMetadata)).toEqual(
-        result,
-      );
+    'computeRef($baseRef, $mergeRef, $delta) => $result',
+    ({ baseRef, mergeRef, delta, result }) => {
+      expect(computeRef(baseRef, mergeRef, delta)).toEqual(result);
     },
   );
 });

--- a/packages/trimerge-sync-hash/src/index.ts
+++ b/packages/trimerge-sync-hash/src/index.ts
@@ -9,10 +9,9 @@ export function computeRef(
   baseRef: string | undefined,
   mergeRef: string | undefined,
   delta: any,
-  editMetadata: any,
 ): string {
   const sha = new Jssha('SHA-256', 'TEXT', { encoding: 'UTF8' });
-  sha.update(JSON.stringify([baseRef, mergeRef, delta, editMetadata]));
+  sha.update(JSON.stringify([baseRef, mergeRef, delta]));
   // Convert to Base64 URL
   return sha
     .getHash('B64')

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.test.ts
@@ -1,4 +1,4 @@
-import { merge, patch } from './BasicDiffer';
+import { mergeAllBranches, patch } from './BasicDiffer';
 
 describe('patch', () => {
   it('patches undefined', () => {

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.test.ts
@@ -1,4 +1,4 @@
-import { mergeAllBranches, patch } from './BasicDiffer';
+import { merge, patch } from './BasicDiffer';
 
 describe('patch', () => {
   it('patches undefined', () => {
@@ -20,7 +20,7 @@ describe('merge', () => {
     ).toMatchInlineSnapshot(`
       Object {
         "doc": "hithere",
-        "editMetadata": Object {
+        "metadata": Object {
           "message": "merge",
           "ref": "(1+2)",
         },
@@ -37,7 +37,7 @@ describe('merge', () => {
     ).toMatchInlineSnapshot(`
       Object {
         "doc": "h thereello",
-        "editMetadata": Object {
+        "metadata": Object {
           "message": "merge",
           "ref": "(2+3)",
         },

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.test.ts
@@ -14,8 +14,8 @@ describe('merge', () => {
     expect(
       merge(
         undefined,
-        { ref: '1', doc: 'hi', editMetadata: '' },
-        { ref: '2', doc: 'there', editMetadata: '' },
+        { ref: '1', doc: 'hi', metadata: '' },
+        { ref: '2', doc: 'there', metadata: '' },
       ),
     ).toMatchInlineSnapshot(`
       Object {
@@ -30,9 +30,9 @@ describe('merge', () => {
   it('merges with base', () => {
     expect(
       merge(
-        { ref: '1', doc: 'hi', editMetadata: '' },
-        { ref: '2', doc: 'hi there', editMetadata: '' },
-        { ref: '3', doc: 'hello', editMetadata: '' },
+        { ref: '1', doc: 'hi', metadata: '' },
+        { ref: '2', doc: 'hi there', metadata: '' },
+        { ref: '3', doc: 'hello', metadata: '' },
       ),
     ).toMatchInlineSnapshot(`
       Object {

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
@@ -10,6 +10,7 @@ import {
 import { create, Delta } from 'jsondiffpatch';
 import { produce } from 'immer';
 import { computeRef as computeShaRef } from 'trimerge-sync-hash';
+import { makeAutoBranchMerger, MergeAllBranchesFn } from 'trimerge-sync';
 
 const trimergeObjects = combineMergers(
   trimergeEquality,
@@ -23,6 +24,9 @@ export const merge: MergeDocFn<any, any> = (base, left, right) => ({
     message: `merge`,
   },
 });
+export const mergeAllBranches: MergeAllBranchesFn<any, any> =
+  makeAutoBranchMerger((a, b) => (a < b ? -1 : 1), merge);
+
 export const jdp = create({ textDiff: { minLength: 20 } });
 
 export function patch<T>(base: T, delta: Delta | undefined): T {
@@ -40,12 +44,11 @@ export function computeRef(
   baseRef: string | undefined,
   mergeRef: string | undefined,
   delta: any,
-  editMetadata: any,
 ): string {
-  return computeShaRef(baseRef, mergeRef, delta, editMetadata).slice(0, 8);
+  return computeShaRef(baseRef, mergeRef, delta).slice(0, 8);
 }
 
-type TestEditMetadata = string;
+type TestCommitMetadata = string;
 type TestSavedDoc = any;
 type TestDoc = any;
 type TestPresence = any;
@@ -53,10 +56,10 @@ type TestPresence = any;
 export const differ: Differ<
   TestSavedDoc,
   TestDoc,
-  TestEditMetadata,
+  TestCommitMetadata,
   TestPresence
 > = {
-  migrate: (doc, editMetadata) => ({ doc, metadata }),
+  migrate: (doc, metadata) => ({ doc, metadata }),
   diff,
   patch,
   computeRef,

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
@@ -60,5 +60,5 @@ export const differ: Differ<
   diff,
   patch,
   computeRef,
-  merge,
+  mergeAllBranches,
 };

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
@@ -18,7 +18,7 @@ const trimergeObjects = combineMergers(
 );
 export const merge: MergeDocFn<any, any> = (base, left, right) => ({
   doc: trimergeObjects(base?.doc, left.doc, right.doc),
-  editMetadata: {
+  metadata: {
     ref: `(${left.ref}+${right.ref})`,
     message: `merge`,
   },
@@ -56,7 +56,7 @@ export const differ: Differ<
   TestEditMetadata,
   TestPresence
 > = {
-  migrate: (doc, editMetadata) => ({ doc, editMetadata }),
+  migrate: (doc, editMetadata) => ({ doc, metadata }),
   diff,
   patch,
   computeRef,

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
@@ -10,7 +10,7 @@ import {
 import { create, Delta } from 'jsondiffpatch';
 import { produce } from 'immer';
 import { computeRef as computeShaRef } from 'trimerge-sync-hash';
-import { makeAutoBranchMerger, MergeAllBranchesFn } from 'trimerge-sync';
+import { makeMergeAllBranchesFn, MergeAllBranchesFn } from 'trimerge-sync';
 
 const trimergeObjects = combineMergers(
   trimergeEquality,
@@ -25,7 +25,7 @@ export const merge: MergeDocFn<any, any> = (base, left, right) => ({
   },
 });
 export const mergeAllBranches: MergeAllBranchesFn<any, any> =
-  makeAutoBranchMerger((a, b) => (a < b ? -1 : 1), merge);
+  makeMergeAllBranchesFn((a, b) => (a < b ? -1 : 1), merge);
 
 export const jdp = create({ textDiff: { minLength: 20 } });
 

--- a/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/BasicDiffer.ts
@@ -48,7 +48,7 @@ export function computeRef(
   return computeShaRef(baseRef, mergeRef, delta).slice(0, 8);
 }
 
-type TestCommitMetadata = string;
+type TestEditMetadata = string;
 type TestSavedDoc = any;
 type TestDoc = any;
 type TestPresence = any;
@@ -56,7 +56,7 @@ type TestPresence = any;
 export const differ: Differ<
   TestSavedDoc,
   TestDoc,
-  TestCommitMetadata,
+  TestEditMetadata,
   TestPresence
 > = {
   migrate: (doc, metadata) => ({ doc, metadata }),

--- a/packages/trimerge-sync-indexed-db/src/testLib/MockRemote.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/MockRemote.ts
@@ -14,6 +14,7 @@ class MockRemote implements Remote<any, any, any> {
     private readonly remoteSyncInfo: RemoteSyncInfo,
     private readonly onEvent: OnRemoteEventFn<any, any, any>,
     private readonly commits?: Commit<any, any>[],
+    private readonly getRemoteMetadata?: (commit: Commit<any, any>) => any,
   ) {
     this.onEvent({ type: 'remote-state', connect: 'online' });
     this.onEvent({ type: 'ready' });
@@ -29,7 +30,10 @@ class MockRemote implements Remote<any, any, any> {
           addInvalidRefsToAckEvent(
             {
               type: 'ack',
-              acks: newCommits.map(({ ref }) => ({ ref })),
+              acks: newCommits.map((commit) => ({
+                ref: commit.ref,
+                metadata: this.getRemoteMetadata?.(commit),
+              })),
               syncId: 'foo',
             },
             invalidRefs,
@@ -46,7 +50,8 @@ export const getMockRemote = getMockRemoteForCommits();
 
 export function getMockRemoteForCommits(
   commits?: Commit<any, any>[],
+  getRemoteMetadata?: (commit: Commit<any, any>) => any,
 ): GetRemoteFn<any, any, any> {
   return (userId, remoteSyncInfo, onEvent) =>
-    new MockRemote(userId, remoteSyncInfo, onEvent, commits);
+    new MockRemote(userId, remoteSyncInfo, onEvent, commits, getRemoteMetadata);
 }

--- a/packages/trimerge-sync-indexed-db/src/testLib/MockRemote.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/MockRemote.ts
@@ -13,7 +13,7 @@ class MockRemote implements Remote<any, any, any> {
     private readonly userId: string,
     private readonly remoteSyncInfo: RemoteSyncInfo,
     private readonly onEvent: OnRemoteEventFn<any, any, any>,
-    private readonly commits?: Commit<any, any>[],
+    private readonly commits: Map<string, Commit<any, any>> = new Map(),
     private readonly getRemoteMetadata?: (commit: Commit<any, any>) => any,
   ) {
     this.onEvent({ type: 'remote-state', connect: 'online' });
@@ -25,15 +25,24 @@ class MockRemote implements Remote<any, any, any> {
         const { newCommits, invalidRefs } = validateCommitOrder<any, any>(
           event.commits,
         );
-        this.commits?.push(...newCommits);
+        for (const commit of newCommits) {
+          if (!this.commits.has(commit.ref)) {
+            this.commits.set(commit.ref, commit);
+          }
+        }
         this.onEvent(
           addInvalidRefsToAckEvent(
             {
               type: 'ack',
-              acks: newCommits.map((commit) => ({
-                ref: commit.ref,
-                metadata: this.getRemoteMetadata?.(commit),
-              })),
+              acks: newCommits.map(({ ref }) => {
+                return {
+                  ref,
+                  metadata: this.getRemoteMetadata?.(
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    this.commits.get(ref)!,
+                  ),
+                };
+              }),
               syncId: 'foo',
             },
             invalidRefs,
@@ -46,10 +55,10 @@ class MockRemote implements Remote<any, any, any> {
     this.onEvent({ type: 'remote-state', connect: 'offline', read: 'offline' });
   }
 }
-export const getMockRemote = getMockRemoteForCommits();
+export const getMockRemote = getMockRemoteWithMap();
 
-export function getMockRemoteForCommits(
-  commits?: Commit<any, any>[],
+export function getMockRemoteWithMap(
+  commits?: Map<string, Commit<any, any>>,
   getRemoteMetadata?: (commit: Commit<any, any>) => any,
 ): GetRemoteFn<any, any, any> {
   return (userId, remoteSyncInfo, onEvent) =>

--- a/packages/trimerge-sync-indexed-db/src/testLib/MockRemote.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/MockRemote.ts
@@ -20,6 +20,7 @@ class MockRemote implements Remote<any, any, any> {
     this.onEvent({ type: 'ready' });
   }
   send(event: SyncEvent<any, any, any>): void {
+    // broadcast to other clients
     switch (event.type) {
       case 'commits':
         const { newCommits, invalidRefs } = validateCommitOrder<any, any>(

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
@@ -868,7 +868,7 @@ describe('createIndexedDbBackendFactory', () => {
     await client1.shutdown();
     await client2.shutdown();
 
-    await expect(dumpDatabase('test-doc-remote')).resolves
+    await expect(dumpDatabase('test-doc-remote3')).resolves
       .toMatchInlineSnapshot(`
             Object {
               "commits": Array [

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
@@ -724,8 +724,8 @@ describe('createIndexedDbBackendFactory', () => {
 
   it('updates metadata from remote with two users', async () => {
     const mockRemote = getMockRemoteWithMap(new Map(), (commit) => ({
-      newMetadata: { fromRemote: 1, ref: commit.ref },
-      oldMetadata: commit.metadata,
+      fromRemote: true,
+      ref: commit.ref,
     }));
     const client1 = makeTestClient(
       'test',
@@ -769,11 +769,8 @@ describe('createIndexedDbBackendFactory', () => {
                     "hello",
                   ],
                   "metadata": Object {
-                    "newMetadata": Object {
-                      "fromRemote": 1,
-                      "ref": "G0a5Az3Q",
-                    },
-                    "oldMetadata": "client 1",
+                    "fromRemote": true,
+                    "ref": "G0a5Az3Q",
                   },
                   "ref": "G0a5Az3Q",
                   "remoteSyncId": "foo",
@@ -804,11 +801,8 @@ describe('createIndexedDbBackendFactory', () => {
                     "hello",
                   ],
                   "metadata": Object {
-                    "newMetadata": Object {
-                      "fromRemote": 1,
-                      "ref": "G0a5Az3Q",
-                    },
-                    "oldMetadata": "client 1",
+                    "fromRemote": true,
+                    "ref": "G0a5Az3Q",
                   },
                   "ref": "G0a5Az3Q",
                   "remoteSyncId": "foo",
@@ -832,8 +826,8 @@ describe('createIndexedDbBackendFactory', () => {
 
   it('updates metadata from remote with two clients on the same local store', async () => {
     const mockRemote = getMockRemoteWithMap(new Map(), (commit) => ({
-      newMetadata: { fromRemote: 1, ref: commit.ref },
-      oldMetadata: commit.metadata,
+      fromRemote: true,
+      ref: commit.ref,
     }));
     const client1 = makeTestClient(
       'test',
@@ -878,11 +872,8 @@ describe('createIndexedDbBackendFactory', () => {
                     "hello",
                   ],
                   "metadata": Object {
-                    "newMetadata": Object {
-                      "fromRemote": 1,
-                      "ref": "G0a5Az3Q",
-                    },
-                    "oldMetadata": "client 1",
+                    "fromRemote": true,
+                    "ref": "G0a5Az3Q",
                   },
                   "ref": "G0a5Az3Q",
                   "remoteSyncId": "foo",

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
@@ -723,27 +723,29 @@ describe('createIndexedDbBackendFactory', () => {
   });
 
   it('updates metadata from remote with two users', async () => {
-    const mockRemote = getMockRemoteWithMap(new Map(), (commit) => ({
+    const getMockRemoteFn = getMockRemoteWithMap(new Map(), (commit) => ({
       fromRemote: true,
       ref: commit.ref,
     }));
+
+    // TODO: this remote doesn't broadcast anything (commits, etc) back to clients
     const client1 = makeTestClient(
       'test',
       '1',
       'test-doc-remoteA',
       'test-doc-store',
-      mockRemote,
+      getMockRemoteFn,
     );
     const client2 = makeTestClient(
       'test',
       '2',
       'test-doc-remoteB',
       'test-doc-store',
-      mockRemote,
+      getMockRemoteFn,
     );
 
     // In this test, both users make the exact same edit, so we want to
-    // settled on the first one that makes it to the remote
+    // settle on the first one that makes it to the remote
     client1.updateDoc('hello', 'client 1');
     client2.updateDoc('hello', 'client 2');
 
@@ -845,7 +847,7 @@ describe('createIndexedDbBackendFactory', () => {
     );
 
     // In this test, both users make the exact same edit, so we want to
-    // settled on the first one that makes it to the remote
+    // settle on the first one that makes it to the remote
     client1.updateDoc('hello', 'client 1');
     client2.updateDoc('hello', 'client 2');
 

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
@@ -63,30 +63,32 @@ Object {
         "hello",
       ],
       "metadata": "",
-      "ref": "W04IBhus",
+      "ref": "G0a5Az3Q",
       "remoteSyncId": "",
       "syncId": 1,
-      "userId": "test",
     },
     Object {
-      "baseRef": "W04IBhus",
+      "baseRef": "G0a5Az3Q",
       "delta": Array [
         "hello",
         "hello there",
       ],
       "metadata": "",
-      "ref": "r4VLd8ne",
+      "ref": "HwWFgzWO",
       "remoteSyncId": "",
       "syncId": 2,
-      "userId": "test",
     },
   ],
   "heads": Array [
     Object {
-      "ref": "r4VLd8ne",
+      "ref": "HwWFgzWO",
     },
   ],
-  "remotes": Array [],
+  "remotes": Array [
+    Object {
+      "localStoreId": "test-doc-store",
+    },
+  ],
 }
 `);
   });
@@ -143,62 +145,62 @@ Object {
 Object {
   "commits": Array [
     Object {
-      "baseRef": "W04IBhus",
-      "delta": Array [
-        "hello",
-        "hello world",
-      ],
-      "metadata": "",
-      "ref": "GhP0VPg5",
-      "remoteSyncId": "",
-      "syncId": 2,
-      "userId": "test",
-    },
-    Object {
-      "baseRef": "GhP0VPg5",
-      "delta": Array [
-        "hello world",
-        "hello there",
-      ],
-      "metadata": "",
-      "ref": "JvrfzM9e",
-      "remoteSyncId": "",
-      "syncId": 3,
-      "userId": "test",
-    },
-    Object {
-      "baseRef": "GhP0VPg5",
-      "delta": Array [
-        "hello world",
-        "oh hello",
-      ],
-      "metadata": "",
-      "ref": "Rofed6go",
-      "remoteSyncId": "",
-      "syncId": 4,
-      "userId": "test",
-    },
-    Object {
       "baseRef": undefined,
       "delta": Array [
         "hello",
       ],
       "metadata": "",
-      "ref": "W04IBhus",
+      "ref": "G0a5Az3Q",
       "remoteSyncId": "",
       "syncId": 1,
-      "userId": "test",
+    },
+    Object {
+      "baseRef": "G0a5Az3Q",
+      "delta": Array [
+        "hello",
+        "hello world",
+      ],
+      "metadata": "",
+      "ref": "VXV5D7z7",
+      "remoteSyncId": "",
+      "syncId": 2,
+    },
+    Object {
+      "baseRef": "VXV5D7z7",
+      "delta": Array [
+        "hello world",
+        "hello there",
+      ],
+      "metadata": "",
+      "ref": "YFy1LPs2",
+      "remoteSyncId": "",
+      "syncId": 3,
+    },
+    Object {
+      "baseRef": "VXV5D7z7",
+      "delta": Array [
+        "hello world",
+        "oh hello",
+      ],
+      "metadata": "",
+      "ref": "aG60Gm4o",
+      "remoteSyncId": "",
+      "syncId": 4,
     },
   ],
   "heads": Array [
     Object {
-      "ref": "JvrfzM9e",
+      "ref": "YFy1LPs2",
     },
     Object {
-      "ref": "Rofed6go",
+      "ref": "aG60Gm4o",
     },
   ],
-  "remotes": Array [],
+  "remotes": Array [
+    Object {
+      "localStoreId": "test-doc-store",
+    },
+  ],
 }
 `);
   });
@@ -275,15 +277,14 @@ Object {
         "hello remote",
       ],
       "metadata": "",
-      "ref": "lIKnl-vc",
+      "ref": "F2C9k7m0",
       "remoteSyncId": "foo",
       "syncId": 1,
-      "userId": "test",
     },
   ],
   "heads": Array [
     Object {
-      "ref": "lIKnl-vc",
+      "ref": "F2C9k7m0",
     },
   ],
   "remotes": Array [
@@ -304,15 +305,14 @@ Object {
         "hello remote",
       ],
       "metadata": "",
-      "ref": "lIKnl-vc",
+      "ref": "F2C9k7m0",
       "remoteSyncId": "",
       "syncId": 1,
-      "userId": "test",
     },
   ],
   "heads": Array [
     Object {
-      "ref": "lIKnl-vc",
+      "ref": "F2C9k7m0",
     },
   ],
   "remotes": Array [],
@@ -339,15 +339,14 @@ Object {
         "hello remote",
       ],
       "metadata": "",
-      "ref": "lIKnl-vc",
+      "ref": "F2C9k7m0",
       "remoteSyncId": "foo",
       "syncId": 1,
-      "userId": "test",
     },
   ],
   "heads": Array [
     Object {
-      "ref": "lIKnl-vc",
+      "ref": "F2C9k7m0",
     },
   ],
   "remotes": Array [
@@ -388,32 +387,30 @@ Object {
 Object {
   "commits": Array [
     Object {
-      "baseRef": "axg0ZCUR",
-      "delta": Array [
-        "hello offline remote",
-        "hello online remote",
-      ],
-      "metadata": "",
-      "ref": "_btn0pve",
-      "remoteSyncId": "foo",
-      "syncId": 2,
-      "userId": "test",
-    },
-    Object {
       "baseRef": undefined,
       "delta": Array [
         "hello offline remote",
       ],
       "metadata": "",
-      "ref": "axg0ZCUR",
+      "ref": "QBwr4r32",
       "remoteSyncId": "foo",
       "syncId": 1,
-      "userId": "test",
+    },
+    Object {
+      "baseRef": "QBwr4r32",
+      "delta": Array [
+        "hello offline remote",
+        "hello online remote",
+      ],
+      "metadata": "",
+      "ref": "YSkdCqy1",
+      "remoteSyncId": "foo",
+      "syncId": 2,
     },
   ],
   "heads": Array [
     Object {
-      "ref": "_btn0pve",
+      "ref": "YSkdCqy1",
     },
   ],
   "remotes": Array [
@@ -472,70 +469,64 @@ Array [
       1,
     ],
     "metadata": "",
-    "ref": "f_zx0amC",
+    "ref": "N5uy2QOO",
     "remoteSyncId": "",
     "syncId": 1,
-    "userId": "test",
   },
   Object {
-    "baseRef": "f_zx0amC",
+    "baseRef": "N5uy2QOO",
     "delta": Array [
       1,
       2,
     ],
     "metadata": "",
-    "ref": "MN9DSWRy",
+    "ref": "F55ccS6M",
     "remoteSyncId": "",
     "syncId": 2,
-    "userId": "test",
   },
   Object {
-    "baseRef": "MN9DSWRy",
+    "baseRef": "F55ccS6M",
     "delta": Array [
       2,
       3,
     ],
     "metadata": "",
-    "ref": "ghfnnw_t",
+    "ref": "uBHlRZDM",
     "remoteSyncId": "",
     "syncId": 3,
-    "userId": "test",
   },
   Object {
-    "baseRef": "ghfnnw_t",
+    "baseRef": "uBHlRZDM",
     "delta": Array [
       3,
       4,
     ],
     "metadata": "",
-    "ref": "donKeCF-",
+    "ref": "CujSo7BT",
     "remoteSyncId": "",
     "syncId": 4,
-    "userId": "test",
   },
   Object {
-    "baseRef": "donKeCF-",
+    "baseRef": "CujSo7BT",
     "delta": Array [
       4,
       5,
     ],
     "metadata": "",
-    "ref": "pb34uqhZ",
+    "ref": "bXqUP_u1",
     "remoteSyncId": "",
     "syncId": 5,
-    "userId": "test",
   },
   Object {
-    "baseRef": "pb34uqhZ",
+    "baseRef": "bXqUP_u1",
     "delta": Array [
       5,
       6,
     ],
     "metadata": "",
-    "ref": "u2ev8uuN",
+    "ref": "5mFFausi",
     "remoteSyncId": "",
     "syncId": 6,
-    "userId": "test",
   },
 ]
 `);

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
@@ -10,7 +10,7 @@ import {
 } from './trimerge-indexed-db';
 import { differ } from './testLib/BasicDiffer';
 import { timeout } from './lib/timeout';
-import { getMockRemote, getMockRemoteForCommits } from './testLib/MockRemote';
+import { getMockRemote, getMockRemoteWithMap } from './testLib/MockRemote';
 import { dumpDatabase, getIdbDatabases } from './testLib/IndexedDB';
 
 function makeTestClient(
@@ -58,42 +58,42 @@ describe('createIndexedDbBackendFactory', () => {
     await client.shutdown();
 
     await expect(dumpDatabase(docId)).resolves.toMatchInlineSnapshot(`
-Object {
-  "commits": Array [
-    Object {
-      "baseRef": undefined,
-      "delta": Array [
-        "hello",
-      ],
-      "metadata": "",
-      "ref": "G0a5Az3Q",
-      "remoteSyncId": "",
-      "syncId": 1,
-    },
-    Object {
-      "baseRef": "G0a5Az3Q",
-      "delta": Array [
-        "hello",
-        "hello there",
-      ],
-      "metadata": "",
-      "ref": "HwWFgzWO",
-      "remoteSyncId": "",
-      "syncId": 2,
-    },
-  ],
-  "heads": Array [
-    Object {
-      "ref": "HwWFgzWO",
-    },
-  ],
-  "remotes": Array [
-    Object {
-      "localStoreId": "test-doc-store",
-    },
-  ],
-}
-`);
+            Object {
+              "commits": Array [
+                Object {
+                  "baseRef": undefined,
+                  "delta": Array [
+                    "hello",
+                  ],
+                  "metadata": "",
+                  "ref": "G0a5Az3Q",
+                  "remoteSyncId": "",
+                  "syncId": 1,
+                },
+                Object {
+                  "baseRef": "G0a5Az3Q",
+                  "delta": Array [
+                    "hello",
+                    "hello there",
+                  ],
+                  "metadata": "",
+                  "ref": "HwWFgzWO",
+                  "remoteSyncId": "",
+                  "syncId": 2,
+                },
+              ],
+              "heads": Array [
+                Object {
+                  "ref": "HwWFgzWO",
+                },
+              ],
+              "remotes": Array [
+                Object {
+                  "localStoreId": "test-doc-store",
+                },
+              ],
+            }
+          `);
   });
 
   it('creates indexed db and can read it', async () => {
@@ -145,67 +145,67 @@ Object {
     await client2.shutdown();
 
     await expect(dumpDatabase(docId)).resolves.toMatchInlineSnapshot(`
-Object {
-  "commits": Array [
-    Object {
-      "baseRef": undefined,
-      "delta": Array [
-        "hello",
-      ],
-      "metadata": "",
-      "ref": "G0a5Az3Q",
-      "remoteSyncId": "",
-      "syncId": 1,
-    },
-    Object {
-      "baseRef": "G0a5Az3Q",
-      "delta": Array [
-        "hello",
-        "hello world",
-      ],
-      "metadata": "",
-      "ref": "VXV5D7z7",
-      "remoteSyncId": "",
-      "syncId": 2,
-    },
-    Object {
-      "baseRef": "VXV5D7z7",
-      "delta": Array [
-        "hello world",
-        "hello there",
-      ],
-      "metadata": "",
-      "ref": "YFy1LPs2",
-      "remoteSyncId": "",
-      "syncId": 3,
-    },
-    Object {
-      "baseRef": "VXV5D7z7",
-      "delta": Array [
-        "hello world",
-        "oh hello",
-      ],
-      "metadata": "",
-      "ref": "aG60Gm4o",
-      "remoteSyncId": "",
-      "syncId": 4,
-    },
-  ],
-  "heads": Array [
-    Object {
-      "ref": "YFy1LPs2",
-    },
-    Object {
-      "ref": "aG60Gm4o",
-    },
-  ],
-  "remotes": Array [
-    Object {
-      "localStoreId": "test-doc-store",
-    },
-  ],
-}
-`);
+            Object {
+              "commits": Array [
+                Object {
+                  "baseRef": undefined,
+                  "delta": Array [
+                    "hello",
+                  ],
+                  "metadata": "",
+                  "ref": "G0a5Az3Q",
+                  "remoteSyncId": "",
+                  "syncId": 1,
+                },
+                Object {
+                  "baseRef": "G0a5Az3Q",
+                  "delta": Array [
+                    "hello",
+                    "hello world",
+                  ],
+                  "metadata": "",
+                  "ref": "VXV5D7z7",
+                  "remoteSyncId": "",
+                  "syncId": 2,
+                },
+                Object {
+                  "baseRef": "VXV5D7z7",
+                  "delta": Array [
+                    "hello world",
+                    "hello there",
+                  ],
+                  "metadata": "",
+                  "ref": "YFy1LPs2",
+                  "remoteSyncId": "",
+                  "syncId": 3,
+                },
+                Object {
+                  "baseRef": "VXV5D7z7",
+                  "delta": Array [
+                    "hello world",
+                    "oh hello",
+                  ],
+                  "metadata": "",
+                  "ref": "aG60Gm4o",
+                  "remoteSyncId": "",
+                  "syncId": 4,
+                },
+              ],
+              "heads": Array [
+                Object {
+                  "ref": "YFy1LPs2",
+                },
+                Object {
+                  "ref": "aG60Gm4o",
+                },
+              ],
+              "remotes": Array [
+                Object {
+                  "localStoreId": "test-doc-store",
+                },
+              ],
+            }
+          `);
   });
 
   it('adds metadata via addStoreMetadata', async () => {
@@ -256,54 +256,54 @@ Object {
     await client2.shutdown();
 
     await expect(dumpDatabase(docId)).resolves.toMatchInlineSnapshot(`
-Object {
-  "commits": Array [
-    Object {
-      "baseRef": undefined,
-      "delta": Array [
-        "hello",
-      ],
-      "metadata": Object {
-        "clientStore": Object {
-          "commitIndex": 1,
-          "localStoreId": "test-doc-store",
-        },
-        "hello": "world",
-      },
-      "ref": "G0a5Az3Q",
-      "remoteSyncId": "",
-      "syncId": 1,
-    },
-    Object {
-      "baseRef": "G0a5Az3Q",
-      "delta": Array [
-        "hello",
-        "hello there",
-      ],
-      "metadata": Object {
-        "clientStore": Object {
-          "commitIndex": 2,
-          "localStoreId": "test-doc-store",
-        },
-        "hello": "world",
-      },
-      "ref": "HwWFgzWO",
-      "remoteSyncId": "",
-      "syncId": 2,
-    },
-  ],
-  "heads": Array [
-    Object {
-      "ref": "HwWFgzWO",
-    },
-  ],
-  "remotes": Array [
-    Object {
-      "localStoreId": "test-doc-store",
-    },
-  ],
-}
-`);
+            Object {
+              "commits": Array [
+                Object {
+                  "baseRef": undefined,
+                  "delta": Array [
+                    "hello",
+                  ],
+                  "metadata": Object {
+                    "clientStore": Object {
+                      "commitIndex": 1,
+                      "localStoreId": "test-doc-store",
+                    },
+                    "hello": "world",
+                  },
+                  "ref": "G0a5Az3Q",
+                  "remoteSyncId": "",
+                  "syncId": 1,
+                },
+                Object {
+                  "baseRef": "G0a5Az3Q",
+                  "delta": Array [
+                    "hello",
+                    "hello there",
+                  ],
+                  "metadata": Object {
+                    "clientStore": Object {
+                      "commitIndex": 2,
+                      "localStoreId": "test-doc-store",
+                    },
+                    "hello": "world",
+                  },
+                  "ref": "HwWFgzWO",
+                  "remoteSyncId": "",
+                  "syncId": 2,
+                },
+              ],
+              "heads": Array [
+                Object {
+                  "ref": "HwWFgzWO",
+                },
+              ],
+              "remotes": Array [
+                Object {
+                  "localStoreId": "test-doc-store",
+                },
+              ],
+            }
+          `);
   });
 
   it('deletes indexed db with deleteDocDatabase', async () => {
@@ -315,13 +315,13 @@ Object {
     await client1.shutdown();
 
     await expect(getIdbDatabases()).resolves.toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "name": "trimerge-sync:test-doc-delete",
-          "version": 2,
-        },
-      ]
-    `);
+                  Array [
+                    Object {
+                      "name": "trimerge-sync:test-doc-delete",
+                      "version": 2,
+                    },
+                  ]
+              `);
 
     await deleteDocDatabase(docId);
 
@@ -370,55 +370,55 @@ Object {
     await client1.shutdown();
 
     await expect(dumpDatabase(docId)).resolves.toMatchInlineSnapshot(`
-Object {
-  "commits": Array [
-    Object {
-      "baseRef": undefined,
-      "delta": Array [
-        "hello remote",
-      ],
-      "metadata": "",
-      "ref": "F2C9k7m0",
-      "remoteSyncId": "foo",
-      "syncId": 1,
-    },
-  ],
-  "heads": Array [
-    Object {
-      "ref": "F2C9k7m0",
-    },
-  ],
-  "remotes": Array [
-    Object {
-      "lastSyncCursor": "foo",
-      "localStoreId": "test-doc-store",
-    },
-  ],
-}
-`);
+            Object {
+              "commits": Array [
+                Object {
+                  "baseRef": undefined,
+                  "delta": Array [
+                    "hello remote",
+                  ],
+                  "metadata": "",
+                  "ref": "F2C9k7m0",
+                  "remoteSyncId": "foo",
+                  "syncId": 1,
+                },
+              ],
+              "heads": Array [
+                Object {
+                  "ref": "F2C9k7m0",
+                },
+              ],
+              "remotes": Array [
+                Object {
+                  "lastSyncCursor": "foo",
+                  "localStoreId": "test-doc-store",
+                },
+              ],
+            }
+          `);
     await resetDocRemoteSyncData(docId);
     await expect(dumpDatabase(docId)).resolves.toMatchInlineSnapshot(`
-Object {
-  "commits": Array [
-    Object {
-      "baseRef": undefined,
-      "delta": Array [
-        "hello remote",
-      ],
-      "metadata": "",
-      "ref": "F2C9k7m0",
-      "remoteSyncId": "",
-      "syncId": 1,
-    },
-  ],
-  "heads": Array [
-    Object {
-      "ref": "F2C9k7m0",
-    },
-  ],
-  "remotes": Array [],
-}
-`);
+            Object {
+              "commits": Array [
+                Object {
+                  "baseRef": undefined,
+                  "delta": Array [
+                    "hello remote",
+                  ],
+                  "metadata": "",
+                  "ref": "F2C9k7m0",
+                  "remoteSyncId": "",
+                  "syncId": 1,
+                },
+              ],
+              "heads": Array [
+                Object {
+                  "ref": "F2C9k7m0",
+                },
+              ],
+              "remotes": Array [],
+            }
+          `);
 
     const client2 = makeTestClient(
       'test',
@@ -432,32 +432,32 @@ Object {
     expect(client2.doc).toEqual('hello remote');
     await client2.shutdown();
     await expect(dumpDatabase(docId)).resolves.toMatchInlineSnapshot(`
-Object {
-  "commits": Array [
-    Object {
-      "baseRef": undefined,
-      "delta": Array [
-        "hello remote",
-      ],
-      "metadata": "",
-      "ref": "F2C9k7m0",
-      "remoteSyncId": "foo",
-      "syncId": 1,
-    },
-  ],
-  "heads": Array [
-    Object {
-      "ref": "F2C9k7m0",
-    },
-  ],
-  "remotes": Array [
-    Object {
-      "lastSyncCursor": "foo",
-      "localStoreId": "test-doc-store",
-    },
-  ],
-}
-`);
+            Object {
+              "commits": Array [
+                Object {
+                  "baseRef": undefined,
+                  "delta": Array [
+                    "hello remote",
+                  ],
+                  "metadata": "",
+                  "ref": "F2C9k7m0",
+                  "remoteSyncId": "foo",
+                  "syncId": 1,
+                },
+              ],
+              "heads": Array [
+                Object {
+                  "ref": "F2C9k7m0",
+                },
+              ],
+              "remotes": Array [
+                Object {
+                  "lastSyncCursor": "foo",
+                  "localStoreId": "test-doc-store",
+                },
+              ],
+            }
+          `);
   });
 
   it('works offline then with remote', async () => {
@@ -485,43 +485,43 @@ Object {
     await client2.shutdown();
 
     await expect(dumpDatabase(docId)).resolves.toMatchInlineSnapshot(`
-Object {
-  "commits": Array [
-    Object {
-      "baseRef": undefined,
-      "delta": Array [
-        "hello offline remote",
-      ],
-      "metadata": "",
-      "ref": "QBwr4r32",
-      "remoteSyncId": "foo",
-      "syncId": 1,
-    },
-    Object {
-      "baseRef": "QBwr4r32",
-      "delta": Array [
-        "hello offline remote",
-        "hello online remote",
-      ],
-      "metadata": "",
-      "ref": "YSkdCqy1",
-      "remoteSyncId": "foo",
-      "syncId": 2,
-    },
-  ],
-  "heads": Array [
-    Object {
-      "ref": "YSkdCqy1",
-    },
-  ],
-  "remotes": Array [
-    Object {
-      "lastSyncCursor": "foo",
-      "localStoreId": "test-doc-store",
-    },
-  ],
-}
-`);
+            Object {
+              "commits": Array [
+                Object {
+                  "baseRef": undefined,
+                  "delta": Array [
+                    "hello offline remote",
+                  ],
+                  "metadata": "",
+                  "ref": "QBwr4r32",
+                  "remoteSyncId": "foo",
+                  "syncId": 1,
+                },
+                Object {
+                  "baseRef": "QBwr4r32",
+                  "delta": Array [
+                    "hello offline remote",
+                    "hello online remote",
+                  ],
+                  "metadata": "",
+                  "ref": "YSkdCqy1",
+                  "remoteSyncId": "foo",
+                  "syncId": 2,
+                },
+              ],
+              "heads": Array [
+                Object {
+                  "ref": "YSkdCqy1",
+                },
+              ],
+              "remotes": Array [
+                Object {
+                  "lastSyncCursor": "foo",
+                  "localStoreId": "test-doc-store",
+                },
+              ],
+            }
+          `);
   });
 
   it('works offline then with remote 2', async () => {
@@ -538,99 +538,99 @@ Object {
     await timeout(100);
     await client.shutdown();
 
-    const commits: Commit<any, any>[] = [];
+    const commitMap = new Map<string, Commit<any, any>>();
     const client2 = makeTestClient(
       'test',
       '2',
       docId,
       'test-doc-store',
-      getMockRemoteForCommits(commits),
+      getMockRemoteWithMap(commitMap),
     );
     // Wait for write
     await timeout(100);
 
     expect(client2.doc).toEqual(6);
     expect(client2.syncStatus).toMatchInlineSnapshot(`
-Object {
-  "localRead": "ready",
-  "localSave": "ready",
-  "remoteConnect": "online",
-  "remoteRead": "ready",
-  "remoteSave": "ready",
-}
-`);
+      Object {
+        "localRead": "ready",
+        "localSave": "ready",
+        "remoteConnect": "online",
+        "remoteRead": "ready",
+        "remoteSave": "ready",
+      }
+    `);
 
     await client2.shutdown();
 
-    expect(commits).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "baseRef": undefined,
-    "delta": Array [
-      1,
-    ],
-    "metadata": "",
-    "ref": "N5uy2QOO",
-    "remoteSyncId": "",
-    "syncId": 1,
-  },
-  Object {
-    "baseRef": "N5uy2QOO",
-    "delta": Array [
-      1,
-      2,
-    ],
-    "metadata": "",
-    "ref": "F55ccS6M",
-    "remoteSyncId": "",
-    "syncId": 2,
-  },
-  Object {
-    "baseRef": "F55ccS6M",
-    "delta": Array [
-      2,
-      3,
-    ],
-    "metadata": "",
-    "ref": "uBHlRZDM",
-    "remoteSyncId": "",
-    "syncId": 3,
-  },
-  Object {
-    "baseRef": "uBHlRZDM",
-    "delta": Array [
-      3,
-      4,
-    ],
-    "metadata": "",
-    "ref": "CujSo7BT",
-    "remoteSyncId": "",
-    "syncId": 4,
-  },
-  Object {
-    "baseRef": "CujSo7BT",
-    "delta": Array [
-      4,
-      5,
-    ],
-    "metadata": "",
-    "ref": "bXqUP_u1",
-    "remoteSyncId": "",
-    "syncId": 5,
-  },
-  Object {
-    "baseRef": "bXqUP_u1",
-    "delta": Array [
-      5,
-      6,
-    ],
-    "metadata": "",
-    "ref": "5mFFausi",
-    "remoteSyncId": "",
-    "syncId": 6,
-  },
-]
-`);
+    expect(Array.from(commitMap.values())).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "baseRef": undefined,
+          "delta": Array [
+            1,
+          ],
+          "metadata": "",
+          "ref": "N5uy2QOO",
+          "remoteSyncId": "",
+          "syncId": 1,
+        },
+        Object {
+          "baseRef": "N5uy2QOO",
+          "delta": Array [
+            1,
+            2,
+          ],
+          "metadata": "",
+          "ref": "F55ccS6M",
+          "remoteSyncId": "",
+          "syncId": 2,
+        },
+        Object {
+          "baseRef": "F55ccS6M",
+          "delta": Array [
+            2,
+            3,
+          ],
+          "metadata": "",
+          "ref": "uBHlRZDM",
+          "remoteSyncId": "",
+          "syncId": 3,
+        },
+        Object {
+          "baseRef": "uBHlRZDM",
+          "delta": Array [
+            3,
+            4,
+          ],
+          "metadata": "",
+          "ref": "CujSo7BT",
+          "remoteSyncId": "",
+          "syncId": 4,
+        },
+        Object {
+          "baseRef": "CujSo7BT",
+          "delta": Array [
+            4,
+            5,
+          ],
+          "metadata": "",
+          "ref": "bXqUP_u1",
+          "remoteSyncId": "",
+          "syncId": 5,
+        },
+        Object {
+          "baseRef": "bXqUP_u1",
+          "delta": Array [
+            5,
+            6,
+          ],
+          "metadata": "",
+          "ref": "5mFFausi",
+          "remoteSyncId": "",
+          "syncId": 6,
+        },
+      ]
+    `);
   });
 
   it('updates metadata from remote', async () => {
@@ -640,7 +640,7 @@ Array [
       '1',
       docId,
       'test-doc-store',
-      getMockRemoteForCommits(undefined, (commit) => ({
+      getMockRemoteWithMap(undefined, (commit) => ({
         newMetadata: { fromRemote: true, ref: commit.ref },
         oldMetadata: commit.metadata,
       })),
@@ -654,71 +654,178 @@ Array [
     await client.shutdown();
 
     await expect(dumpDatabase(docId)).resolves.toMatchInlineSnapshot(`
-Object {
-  "commits": Array [
-    Object {
-      "baseRef": "N5uy2QOO",
-      "delta": Array [
-        1,
-        2,
-      ],
-      "metadata": Object {
-        "newMetadata": Object {
-          "fromRemote": true,
-          "ref": "F55ccS6M",
-        },
-        "oldMetadata": "there",
-      },
-      "ref": "F55ccS6M",
-      "remoteSyncId": "foo",
-      "syncId": 2,
-    },
-    Object {
-      "baseRef": undefined,
-      "delta": Array [
-        1,
-      ],
-      "metadata": Object {
-        "newMetadata": Object {
-          "fromRemote": true,
-          "ref": "N5uy2QOO",
-        },
-        "oldMetadata": "hi",
-      },
-      "ref": "N5uy2QOO",
-      "remoteSyncId": "foo",
-      "syncId": 1,
-    },
-    Object {
-      "baseRef": "F55ccS6M",
-      "delta": Array [
-        2,
-        3,
-      ],
-      "metadata": Object {
-        "newMetadata": Object {
-          "fromRemote": true,
-          "ref": "uBHlRZDM",
-        },
-        "oldMetadata": "sup?",
-      },
-      "ref": "uBHlRZDM",
-      "remoteSyncId": "foo",
-      "syncId": 3,
-    },
-  ],
-  "heads": Array [
-    Object {
-      "ref": "uBHlRZDM",
-    },
-  ],
-  "remotes": Array [
-    Object {
-      "lastSyncCursor": "foo",
-      "localStoreId": "test-doc-store",
-    },
-  ],
-}
-`);
+            Object {
+              "commits": Array [
+                Object {
+                  "baseRef": "N5uy2QOO",
+                  "delta": Array [
+                    1,
+                    2,
+                  ],
+                  "metadata": Object {
+                    "newMetadata": Object {
+                      "fromRemote": true,
+                      "ref": "F55ccS6M",
+                    },
+                    "oldMetadata": "there",
+                  },
+                  "ref": "F55ccS6M",
+                  "remoteSyncId": "foo",
+                  "syncId": 2,
+                },
+                Object {
+                  "baseRef": undefined,
+                  "delta": Array [
+                    1,
+                  ],
+                  "metadata": Object {
+                    "newMetadata": Object {
+                      "fromRemote": true,
+                      "ref": "N5uy2QOO",
+                    },
+                    "oldMetadata": "hi",
+                  },
+                  "ref": "N5uy2QOO",
+                  "remoteSyncId": "foo",
+                  "syncId": 1,
+                },
+                Object {
+                  "baseRef": "F55ccS6M",
+                  "delta": Array [
+                    2,
+                    3,
+                  ],
+                  "metadata": Object {
+                    "newMetadata": Object {
+                      "fromRemote": true,
+                      "ref": "uBHlRZDM",
+                    },
+                    "oldMetadata": "sup?",
+                  },
+                  "ref": "uBHlRZDM",
+                  "remoteSyncId": "foo",
+                  "syncId": 3,
+                },
+              ],
+              "heads": Array [
+                Object {
+                  "ref": "uBHlRZDM",
+                },
+              ],
+              "remotes": Array [
+                Object {
+                  "lastSyncCursor": "foo",
+                  "localStoreId": "test-doc-store",
+                },
+              ],
+            }
+          `);
+  });
+  it('updates metadata from remote with two users', async () => {
+    const mockRemote = getMockRemoteWithMap(new Map(), (commit) => ({
+      newMetadata: { fromRemote: 1, ref: commit.ref },
+      oldMetadata: commit.metadata,
+    }));
+    const client1 = makeTestClient(
+      'test',
+      '1',
+      'test-doc-remoteA',
+      'test-doc-store',
+      mockRemote,
+    );
+    const client2 = makeTestClient(
+      'test',
+      '2',
+      'test-doc-remoteB',
+      'test-doc-store',
+      mockRemote,
+    );
+
+    // In this test, both users make the exact same edit, so we want to
+    // settled on the first one that makes it to the remote
+    client1.updateDoc('hello', 'client 1');
+    client2.updateDoc('hello', 'client 2');
+
+    // Wait for read
+    await timeout(100);
+
+    expect(client1.doc).toEqual('hello');
+    expect(client2.doc).toEqual('hello');
+
+    // Wait for write
+    await timeout(100);
+
+    await client1.shutdown();
+    await client2.shutdown();
+
+    await expect(dumpDatabase('test-doc-remoteA')).resolves
+      .toMatchInlineSnapshot(`
+            Object {
+              "commits": Array [
+                Object {
+                  "baseRef": undefined,
+                  "delta": Array [
+                    "hello",
+                  ],
+                  "metadata": Object {
+                    "newMetadata": Object {
+                      "fromRemote": 1,
+                      "ref": "G0a5Az3Q",
+                    },
+                    "oldMetadata": "client 1",
+                  },
+                  "ref": "G0a5Az3Q",
+                  "remoteSyncId": "foo",
+                  "syncId": 1,
+                },
+              ],
+              "heads": Array [
+                Object {
+                  "ref": "G0a5Az3Q",
+                },
+              ],
+              "remotes": Array [
+                Object {
+                  "lastSyncCursor": "foo",
+                  "localStoreId": "test-doc-store",
+                },
+              ],
+            }
+          `);
+
+    await expect(dumpDatabase('test-doc-remoteB')).resolves
+      .toMatchInlineSnapshot(`
+            Object {
+              "commits": Array [
+                Object {
+                  "baseRef": undefined,
+                  "delta": Array [
+                    "hello",
+                  ],
+                  "metadata": Object {
+                    "newMetadata": Object {
+                      "fromRemote": 1,
+                      "ref": "G0a5Az3Q",
+                    },
+                    "oldMetadata": "client 1",
+                  },
+                  "ref": "G0a5Az3Q",
+                  "remoteSyncId": "foo",
+                  "syncId": 1,
+                },
+              ],
+              "heads": Array [
+                Object {
+                  "ref": "G0a5Az3Q",
+                },
+              ],
+              "remotes": Array [
+                Object {
+                  "lastSyncCursor": "foo",
+                  "localStoreId": "test-doc-store",
+                },
+              ],
+            }
+          `);
   });
 });

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
@@ -9,7 +9,6 @@ import {
   CommitsEvent,
   OnEventFn,
   RemoteSyncInfo,
-  ServerCommit,
   isMergeCommit,
   CommitAck,
 } from 'trimerge-sync';
@@ -221,7 +220,7 @@ class IndexedDbBackend<
   }
 
   protected async addCommits(
-    commits: readonly ServerCommit<EditMetadata, Delta>[],
+    commits: readonly Commit<EditMetadata, Delta>[],
     lastSyncCursor: string | undefined,
   ): Promise<AckCommitsEvent> {
     const db = await this.db;
@@ -244,7 +243,7 @@ class IndexedDbBackend<
     const refs = new Map<string, boolean>();
     const refErrors: AckRefErrors = {};
     async function commitExistsAlready(
-      commit: Commit<unknown, unknown>,
+      commit: Commit,
       error?: string,
     ): Promise<boolean> {
       const existingCommit = await commitsDb.get(commit.ref);

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
@@ -96,7 +96,7 @@ export function getIDBPDatabase<EditMetadata, Delta>(
   return createIndexedDb(getDatabaseName(docId));
 }
 export type AddStoreMetadataFn<EditMetadata> = (
-  metadata: EditMetadata,
+  commit: Commit<EditMetadata>,
   localStoreId: string,
   commitIndex: number,
 ) => EditMetadata;
@@ -319,7 +319,7 @@ class IndexedDbBackend<
             if (this.addStoreMetadata) {
               const localStoreId = await this.localStoreId;
               commit.metadata = this.addStoreMetadata(
-                commit.metadata,
+                commit,
                 localStoreId,
                 commitIndex,
               );

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
@@ -258,7 +258,7 @@ class IndexedDbBackend<
 
     for (const commit of commits) {
       const syncId = ++syncCounter;
-      const { ref, baseRef, } = commit;
+      const { ref, baseRef } = commit;
       let mergeRef: string | undefined;
       if (isMergeCommit(commit)) {
         mergeRef = commit.mergeRef;
@@ -357,7 +357,7 @@ interface TrimergeSyncDbSchema extends DBSchema {
   };
   commits: {
     key: string;
-    value: ServerCommit<any, any> & {
+    value: Commit<any, any> & {
       syncId: number;
       remoteSyncId: string;
     };

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -98,10 +98,10 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, Presence>
   protected abstract addCommits(
     commits: readonly Commit<EditMetadata, Delta>[],
     remoteSyncId?: string,
-  ): Promise<AckCommitsEvent>;
+  ): Promise<AckCommitsEvent<EditMetadata>>;
 
   protected abstract acknowledgeRemoteCommits(
-    refs: readonly CommitAck[],
+    refs: readonly CommitAck<EditMetadata>[],
     remoteSyncId: string,
   ): Promise<void>;
 

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -29,8 +29,8 @@ export type NetworkSettings = Readonly<
   } & LeaderSettings
 >;
 
-export type BroadcastEvent<EditMetadata, Delta, Presence> = {
-  event: SyncEvent<EditMetadata, Delta, Presence>;
+export type BroadcastEvent<CommitMetadata, Delta, Presence> = {
+  event: SyncEvent<CommitMetadata, Delta, Presence>;
   remoteOrigin: boolean;
 };
 
@@ -41,15 +41,15 @@ const DEFAULT_SETTINGS: NetworkSettings = {
   ...DEFAULT_LEADER_SETTINGS,
 };
 
-export abstract class AbstractLocalStore<EditMetadata, Delta, Presence>
-  implements LocalStore<EditMetadata, Delta, Presence>
+export abstract class AbstractLocalStore<CommitMetadata, Delta, Presence>
+  implements LocalStore<CommitMetadata, Delta, Presence>
 {
   private closed = false;
   private presence: ClientPresenceRef<Presence> = {
     ref: undefined,
     presence: undefined,
   };
-  private remote: Remote<EditMetadata, Delta, Presence> | undefined;
+  private remote: Remote<CommitMetadata, Delta, Presence> | undefined;
   private reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
   private reconnectDelayMs: number;
   private remoteSyncState: RemoteStateEvent = {
@@ -68,8 +68,8 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, Presence>
   protected constructor(
     protected readonly userId: string,
     protected readonly clientId: string,
-    private readonly onEvent: OnEventFn<EditMetadata, Delta, Presence>,
-    private readonly getRemote?: GetRemoteFn<EditMetadata, Delta, Presence>,
+    private readonly onEvent: OnEventFn<CommitMetadata, Delta, Presence>,
+    private readonly getRemote?: GetRemoteFn<CommitMetadata, Delta, Presence>,
     networkSettings: Partial<NetworkSettings> = {},
   ) {
     this.networkSettings = { ...DEFAULT_SETTINGS, ...networkSettings };
@@ -84,24 +84,24 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, Presence>
    * Send to all *other* local clients
    */
   protected abstract broadcastLocal(
-    event: BroadcastEvent<EditMetadata, Delta, Presence>,
+    event: BroadcastEvent<CommitMetadata, Delta, Presence>,
   ): Promise<void>;
 
   protected abstract getLocalCommits(): AsyncIterableIterator<
-    CommitsEvent<EditMetadata, Delta, Presence>
+    CommitsEvent<CommitMetadata, Delta, Presence>
   >;
 
   protected abstract getCommitsForRemote(): AsyncIterableIterator<
-    CommitsEvent<EditMetadata, Delta, Presence>
+    CommitsEvent<CommitMetadata, Delta, Presence>
   >;
 
   protected abstract addCommits(
-    commits: readonly Commit<EditMetadata, Delta>[],
+    commits: readonly Commit<CommitMetadata, Delta>[],
     remoteSyncId?: string,
-  ): Promise<AckCommitsEvent<EditMetadata>>;
+  ): Promise<AckCommitsEvent<CommitMetadata>>;
 
   protected abstract acknowledgeRemoteCommits(
-    refs: readonly CommitAck<EditMetadata>[],
+    refs: readonly CommitAck<CommitMetadata>[],
     remoteSyncId: string,
   ): Promise<void>;
 
@@ -127,7 +127,7 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, Presence>
   }
 
   protected processEvent = async (
-    event: SyncEvent<EditMetadata, Delta, Presence>,
+    event: SyncEvent<CommitMetadata, Delta, Presence>,
     // Three sources of events: local broadcast, remote broadcast, and remote via local broadcast
     origin: 'local' | 'remote' | 'remote-via-local',
   ): Promise<void> => {
@@ -232,7 +232,7 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, Presence>
   protected readonly onLocalBroadcastEvent = ({
     event,
     remoteOrigin,
-  }: BroadcastEvent<EditMetadata, Delta, Presence>): void => {
+  }: BroadcastEvent<CommitMetadata, Delta, Presence>): void => {
     this.localQueue
       .add(() =>
         this.processEvent(event, remoteOrigin ? 'remote-via-local' : 'local'),
@@ -375,7 +375,7 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, Presence>
     };
   }
   protected async sendEvent(
-    event: SyncEvent<EditMetadata, Delta, Presence>,
+    event: SyncEvent<CommitMetadata, Delta, Presence>,
     {
       remote = false,
       local = false,
@@ -442,7 +442,7 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, Presence>
     });
   }
   update(
-    commits: Commit<EditMetadata, Delta>[],
+    commits: Commit<CommitMetadata, Delta>[],
     presence: ClientPresenceRef<Presence> | undefined,
   ): void {
     if (this.closed) {
@@ -454,7 +454,7 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, Presence>
   }
 
   private async doUpdate(
-    commits: Commit<EditMetadata, Delta>[],
+    commits: Commit<CommitMetadata, Delta>[],
     presenceRef: ClientPresenceRef<Presence> | undefined,
   ): Promise<void> {
     if (presenceRef) {

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -97,7 +97,7 @@ export abstract class AbstractLocalStore<CommitMetadata, Delta, Presence>
 
   protected abstract addCommits(
     commits: readonly Commit<CommitMetadata, Delta>[],
-    remoteSyncId?: string,
+    remoteSyncId: string | undefined,
   ): Promise<AckCommitsEvent<CommitMetadata>>;
 
   protected abstract acknowledgeRemoteCommits(
@@ -464,7 +464,7 @@ export abstract class AbstractLocalStore<CommitMetadata, Delta, Presence>
       await this.setRemoteState({ type: 'remote-state', save: 'pending' });
     }
 
-    const ack = await this.addCommits(commits);
+    const ack = await this.addCommits(commits, undefined);
     await this.sendEvent(ack, { self: true });
     const clientInfo: ClientInfo<Presence> | undefined = presenceRef && {
       ...presenceRef,

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -1,4 +1,4 @@
-import { TrimergeClient } from './TrimergeClient';
+import { AddNewCommitMetadataFn, TrimergeClient } from './TrimergeClient';
 import { timeout } from './lib/Timeout';
 import { OnStoreEventFn, SyncEvent } from './types';
 import { Differ } from './differ';
@@ -12,7 +12,9 @@ const differ: Differ<any, any, any, any> = {
   computeRef: () => 'hash',
 };
 
-function makeTrimergeClient(): {
+function makeTrimergeClient(
+  addNewCommitMetadata?: AddNewCommitMetadataFn<any>,
+): {
   client: TrimergeClient<any, any, any, any, any>;
   onEvent: OnStoreEventFn<any, any, any>;
 } {
@@ -29,6 +31,7 @@ function makeTrimergeClient(): {
       };
     },
     differ,
+    addNewCommitMetadata,
   );
   if (!onEvent) {
     throw new Error('could not get onEvent');
@@ -37,12 +40,48 @@ function makeTrimergeClient(): {
 }
 
 describe('TrimergeClient', () => {
+  it('adds metadata', async () => {
+    const { client } = makeTrimergeClient(
+      (metadata, commitRef, userId, clientId) => {
+        return {
+          message: metadata,
+          added: 'on client',
+          userId,
+          clientId,
+          commitRef,
+        };
+      },
+    );
+    client.updateDoc('hello', 'hi');
+    expect(client.getCommit('hash')).toMatchInlineSnapshot(`
+Object {
+  "baseRef": undefined,
+  "delta": null,
+  "metadata": Object {
+    "added": "on client",
+    "clientId": "",
+    "commitRef": "hash",
+    "message": "hi",
+    "userId": "",
+  },
+  "ref": "hash",
+}
+`);
+  });
+
   it('handles bad getCommit', async () => {
     const { client } = makeTrimergeClient();
     client.updateDoc('hello', 'hi');
     client.updateDoc('hello2', 'hi');
     client.updateDoc('hello3', 'hi');
-    await timeout(100);
+    expect(client.getCommit('hash')).toMatchInlineSnapshot(`
+Object {
+  "baseRef": undefined,
+  "delta": null,
+  "metadata": "hi",
+  "ref": "hash",
+}
+`);
     expect(() => client.getCommit('xxx')).toThrowError(`unknown ref "xxx"`);
   });
 

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -7,7 +7,7 @@ import { migrate } from './testLib/MergeUtils';
 const differ: Differ<any, any, any, any> = {
   migrate,
   diff: () => null,
-  autoMerge: () => null,
+  mergeAllBranches: () => null,
   patch: () => null,
   computeRef: () => 'hash',
 };

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -7,7 +7,7 @@ import { migrate } from './testLib/MergeUtils';
 const differ: Differ<any, any, any, any> = {
   migrate,
   diff: () => null,
-  merge: () => ({ doc: undefined, editMetadata: undefined }),
+  autoMerge: () => null,
   patch: () => null,
   computeRef: () => 'hash',
 };
@@ -53,7 +53,6 @@ describe('TrimergeClient', () => {
         type: 'commits',
         commits: [
           {
-            userId: '',
             ref: 'a',
             baseRef: 'unknown',
             metadata: '',
@@ -69,7 +68,6 @@ describe('TrimergeClient', () => {
         type: 'commits',
         commits: [
           {
-            userId: '',
             ref: 'a',
             mergeRef: 'unknown',
             metadata: '',

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -223,7 +223,7 @@ export class TrimergeClient<
     this.emitClientListChange();
   }
 
-  private getCommit = (ref: string) => {
+  getCommit = (ref: string) => {
     const commit = this.commits.get(ref);
     if (commit) {
       return commit;

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -68,7 +68,6 @@ export class TrimergeClient<
   private tempCommits = new Map<string, Commit<EditMetadata, Delta>>();
   private unsyncedCommits: Commit<EditMetadata, Delta>[] = [];
 
-  private selfFullId: string;
   private newPresence: ClientInfo<Presence> | undefined;
 
   private syncState: SyncStatus = {
@@ -89,7 +88,6 @@ export class TrimergeClient<
     >,
     private readonly differ: Differ<SavedDoc, LatestDoc, EditMetadata, Delta>,
   ) {
-    this.selfFullId = getFullId(userId, clientId);
     this.store = getLocalStore(userId, clientId, this.onEvent);
     this.setClientInfo({
       userId,

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -232,7 +232,7 @@ export class TrimergeClient<
     const commitDoc: CommitDoc<SavedDoc, EditMetadata> = {
       ref,
       doc: this.differ.patch(baseValue, delta),
-      metadata: metadata,
+      metadata,
     };
     this.docs.set(ref, commitDoc);
     return commitDoc;

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -2,7 +2,13 @@ import { Delta } from 'jsondiffpatch';
 import { TrimergeClient } from './TrimergeClient';
 import { Differ } from './differ';
 import { MemoryStore } from './testLib/MemoryStore';
-import { computeRef, diff, merge, migrate, patch } from './testLib/MergeUtils';
+import {
+  computeRef,
+  diff,
+  mergeAllBranches,
+  migrate,
+  patch,
+} from './testLib/MergeUtils';
 import { getBasicGraph } from './testLib/GraphVisualizers';
 import { ClientInfo } from './types';
 import { timeout } from './lib/Timeout';
@@ -17,7 +23,7 @@ const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
   diff,
   patch,
   computeRef,
-  merge,
+  mergeAllBranches,
 };
 
 function newStore() {

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -100,20 +100,20 @@ describe('TrimergeClient: 2 users', () => {
     expect(basicGraph(store, client)).toMatchInlineSnapshot(`
 Array [
   Object {
-    "graph": "undefined -> DuQe--Vh",
-    "step": "User a: initialize",
+    "graph": "undefined -> Zob0dMmD",
+    "step": "initialize",
     "value": Object {},
   },
   Object {
-    "graph": "DuQe--Vh -> u0wBto6f",
-    "step": "User a: add hello",
+    "graph": "Zob0dMmD -> leySPlIR",
+    "step": "add hello",
     "value": Object {
       "hello": "world",
     },
   },
   Object {
-    "graph": "u0wBto6f -> YYUSBDXS",
-    "step": "User a: change hello",
+    "graph": "leySPlIR -> x_n2sT7P",
+    "step": "change hello",
     "value": Object {
       "hello": "vorld",
     },
@@ -612,34 +612,34 @@ Array [
     expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
 Array [
   Object {
-    "graph": "undefined -> DuQe--Vh",
-    "step": "User a: initialize",
+    "graph": "undefined -> Zob0dMmD",
+    "step": "initialize",
     "value": Object {},
   },
   Object {
-    "graph": "DuQe--Vh -> u0wBto6f",
-    "step": "User a: add hello",
+    "graph": "Zob0dMmD -> leySPlIR",
+    "step": "add hello",
     "value": Object {
       "hello": "world",
     },
   },
   Object {
-    "graph": "DuQe--Vh -> SU0_JahJ",
-    "step": "User b: add world",
+    "graph": "Zob0dMmD -> JQGldkEn",
+    "step": "add world",
     "value": Object {
       "world": "world",
     },
   },
   Object {
-    "graph": "u0wBto6f -> YYUSBDXS",
-    "step": "User a: change hello",
+    "graph": "leySPlIR -> x_n2sT7P",
+    "step": "change hello",
     "value": Object {
       "hello": "vorld",
     },
   },
   Object {
-    "graph": "SU0_JahJ -> ZiYUF2m8",
-    "step": "User b: change world",
+    "graph": "JQGldkEn -> ImI6Nmiz",
+    "step": "change world",
     "value": Object {
       "world": "vorld",
     },
@@ -666,28 +666,28 @@ Array [
     expect(client2.doc).toEqual({ hello: 'vorld' });
 
     expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "graph": "undefined -> DuQe--Vh",
-          "step": "User a: initialize",
-          "value": Object {},
-        },
-        Object {
-          "graph": "DuQe--Vh -> u0wBto6f",
-          "step": "User a: add hello",
-          "value": Object {
-            "hello": "world",
-          },
-        },
-        Object {
-          "graph": "u0wBto6f -> YYUSBDXS",
-          "step": "User a: change hello",
-          "value": Object {
-            "hello": "vorld",
-          },
-        },
-      ]
-    `);
+Array [
+  Object {
+    "graph": "undefined -> Zob0dMmD",
+    "step": "initialize",
+    "value": Object {},
+  },
+  Object {
+    "graph": "Zob0dMmD -> leySPlIR",
+    "step": "add hello",
+    "value": Object {
+      "hello": "world",
+    },
+  },
+  Object {
+    "graph": "leySPlIR -> x_n2sT7P",
+    "step": "change hello",
+    "value": Object {
+      "hello": "vorld",
+    },
+  },
+]
+`);
   });
 
   it('subscription works', async () => {
@@ -719,27 +719,27 @@ Array [
     expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
 Array [
   Object {
-    "graph": "undefined -> DuQe--Vh",
-    "step": "User a: initialize",
+    "graph": "undefined -> Zob0dMmD",
+    "step": "initialize",
     "value": Object {},
   },
   Object {
-    "graph": "DuQe--Vh -> u0wBto6f",
-    "step": "User a: add hello",
+    "graph": "Zob0dMmD -> leySPlIR",
+    "step": "add hello",
     "value": Object {
       "hello": "world",
     },
   },
   Object {
-    "graph": "u0wBto6f -> YYUSBDXS",
-    "step": "User a: change hello",
+    "graph": "leySPlIR -> x_n2sT7P",
+    "step": "change hello",
     "value": Object {
       "hello": "vorld",
     },
   },
   Object {
-    "graph": "YYUSBDXS -> iSZbPHuf",
-    "step": "User a: change hello again",
+    "graph": "x_n2sT7P -> 38Fdqmoz",
+    "step": "change hello again",
     "value": Object {
       "hello": "there",
     },
@@ -801,202 +801,202 @@ Array [
     expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
 Array [
   Object {
-    "graph": "undefined -> DuQe--Vh",
-    "step": "User a: initialize",
+    "graph": "undefined -> Zob0dMmD",
+    "step": "initialize",
     "value": Object {},
   },
   Object {
-    "graph": "DuQe--Vh -> u0wBto6f",
-    "step": "User a: add hello",
+    "graph": "Zob0dMmD -> leySPlIR",
+    "step": "add hello",
     "value": Object {
       "hello": "world",
     },
   },
   Object {
-    "graph": "u0wBto6f -> VS2jghNi",
-    "step": "User a: typing",
+    "graph": "leySPlIR -> YAy0M_J2",
+    "step": "typing",
     "value": Object {
       "hello": "world. t",
     },
   },
   Object {
-    "graph": "VS2jghNi -> 0fvI2ESx",
-    "step": "User a: typing",
+    "graph": "YAy0M_J2 -> LsIxqujJ",
+    "step": "typing",
     "value": Object {
       "hello": "world. th",
     },
   },
   Object {
-    "graph": "0fvI2ESx -> Jz2-R6rz",
-    "step": "User a: typing",
+    "graph": "LsIxqujJ -> yoPegGx6",
+    "step": "typing",
     "value": Object {
       "hello": "world. thi",
     },
   },
   Object {
-    "graph": "Jz2-R6rz -> -bTKiTst",
-    "step": "User a: typing",
+    "graph": "yoPegGx6 -> eTLOHYa-",
+    "step": "typing",
     "value": Object {
       "hello": "world. this",
     },
   },
   Object {
-    "graph": "-bTKiTst -> GaWb8t2f",
-    "step": "User a: typing",
+    "graph": "eTLOHYa- -> WDzPFBwe",
+    "step": "typing",
     "value": Object {
       "hello": "world. this ",
     },
   },
   Object {
-    "graph": "GaWb8t2f -> 9J_xBqJ4",
-    "step": "User a: typing",
+    "graph": "WDzPFBwe -> YoyNjiZ6",
+    "step": "typing",
     "value": Object {
       "hello": "world. this i",
     },
   },
   Object {
-    "graph": "9J_xBqJ4 -> SYH3X4jm",
-    "step": "User a: typing",
+    "graph": "YoyNjiZ6 -> rOUBm7c2",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is",
     },
   },
   Object {
-    "graph": "SYH3X4jm -> Nl0PNGuX",
-    "step": "User a: typing",
+    "graph": "rOUBm7c2 -> MsplY0xo",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is ",
     },
   },
   Object {
-    "graph": "Nl0PNGuX -> vlZhl6Vh",
-    "step": "User a: typing",
+    "graph": "MsplY0xo -> JnbUEhpb",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a",
     },
   },
   Object {
-    "graph": "vlZhl6Vh -> YxT5Gm6R",
-    "step": "User a: typing",
+    "graph": "JnbUEhpb -> POK9sZXI",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a t",
     },
   },
   Object {
-    "graph": "YxT5Gm6R -> F0g2iLQv",
-    "step": "User a: typing",
+    "graph": "POK9sZXI -> yEO3XYgv",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a te",
     },
   },
   Object {
-    "graph": "F0g2iLQv -> vKey2nks",
-    "step": "User a: typing",
+    "graph": "yEO3XYgv -> VIhrAVTG",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a tes",
     },
   },
   Object {
-    "graph": "vKey2nks -> C9Ub6hg6",
-    "step": "User a: typing",
+    "graph": "VIhrAVTG -> 9HSyQTMd",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test",
     },
   },
   Object {
-    "graph": "C9Ub6hg6 -> ObcwRxBk",
-    "step": "User a: typing",
+    "graph": "9HSyQTMd -> xGjtRo_F",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test ",
     },
   },
   Object {
-    "graph": "ObcwRxBk -> Y8mdIN_L",
-    "step": "User a: typing",
+    "graph": "xGjtRo_F -> GFUqLq42",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test o",
     },
   },
   Object {
-    "graph": "Y8mdIN_L -> L000b_2W",
-    "step": "User a: typing",
+    "graph": "GFUqLq42 -> 8Zpd5VpF",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test of",
     },
   },
   Object {
-    "graph": "L000b_2W -> tYpujZ6D",
-    "step": "User a: typing",
+    "graph": "8Zpd5VpF -> 0JCZFqxq",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test of ",
     },
   },
   Object {
-    "graph": "tYpujZ6D -> -SKX2OVN",
-    "step": "User a: typing",
+    "graph": "0JCZFqxq -> 5Y4GtM8z",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test of c",
     },
   },
   Object {
-    "graph": "-SKX2OVN -> ffe6ZCmD",
-    "step": "User a: typing",
+    "graph": "5Y4GtM8z -> W-adW2a-",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test of ch",
     },
   },
   Object {
-    "graph": "ffe6ZCmD -> 8PtNr3hx",
-    "step": "User a: typing",
+    "graph": "W-adW2a- -> 1nf6gXl1",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test of cha",
     },
   },
   Object {
-    "graph": "8PtNr3hx -> oLFFrO2p",
-    "step": "User a: typing",
+    "graph": "1nf6gXl1 -> xF9W97WS",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test of char",
     },
   },
   Object {
-    "graph": "oLFFrO2p -> 8Xt-akSw",
-    "step": "User a: typing",
+    "graph": "xF9W97WS -> E8TIq05x",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test of chara",
     },
   },
   Object {
-    "graph": "8Xt-akSw -> UU5J3Qq2",
-    "step": "User a: typing",
+    "graph": "E8TIq05x -> 3hCls5tY",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test of charac",
     },
   },
   Object {
-    "graph": "UU5J3Qq2 -> Oo2NTgQE",
-    "step": "User a: typing",
+    "graph": "3hCls5tY -> Hl2TeGle",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test of charact",
     },
   },
   Object {
-    "graph": "Oo2NTgQE -> ci7d46HK",
-    "step": "User a: typing",
+    "graph": "Hl2TeGle -> NXbxkJK2",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test of characte",
     },
   },
   Object {
-    "graph": "ci7d46HK -> 7_amDpeg",
-    "step": "User a: typing",
+    "graph": "NXbxkJK2 -> Uc41cdXS",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test of character",
     },
   },
   Object {
-    "graph": "7_amDpeg -> dKj2TVjC",
-    "step": "User a: typing",
+    "graph": "Uc41cdXS -> QNhbrQRR",
+    "step": "typing",
     "value": Object {
       "hello": "world. this is a test of character.",
     },

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -13,31 +13,30 @@ import { getBasicGraph } from './testLib/GraphVisualizers';
 import { ClientInfo } from './types';
 import { timeout } from './lib/Timeout';
 
-type TestCommitMetadata = string;
+type TestEditMetadata = string;
 type TestSavedDoc = any;
 type TestDoc = any;
 type TestPresence = any;
 
-const differ: Differ<TestSavedDoc, TestDoc, TestCommitMetadata, TestPresence> =
-  {
-    migrate,
-    diff,
-    patch,
-    computeRef,
-    mergeAllBranches,
-  };
+const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
+  migrate,
+  diff,
+  patch,
+  computeRef,
+  mergeAllBranches,
+};
 
 function newStore() {
-  return new MemoryStore<TestCommitMetadata, Delta, TestPresence>();
+  return new MemoryStore<TestEditMetadata, Delta, TestPresence>();
 }
 
 function makeClient(
   userId: string,
-  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
 ): TrimergeClient<
   TestSavedDoc,
   TestDoc,
-  TestCommitMetadata,
+  TestEditMetadata,
   Delta,
   TestPresence
 > {
@@ -45,11 +44,11 @@ function makeClient(
 }
 
 function basicGraph(
-  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
   client1: TrimergeClient<
     TestSavedDoc,
     TestDoc,
-    TestCommitMetadata,
+    TestEditMetadata,
     Delta,
     TestPresence
   >,
@@ -65,7 +64,7 @@ function sortedClients(
   client: TrimergeClient<
     TestSavedDoc,
     TestDoc,
-    TestCommitMetadata,
+    TestEditMetadata,
     Delta,
     TestPresence
   >,

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -13,30 +13,31 @@ import { getBasicGraph } from './testLib/GraphVisualizers';
 import { ClientInfo } from './types';
 import { timeout } from './lib/Timeout';
 
-type TestEditMetadata = string;
+type TestCommitMetadata = string;
 type TestSavedDoc = any;
 type TestDoc = any;
 type TestPresence = any;
 
-const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
-  migrate,
-  diff,
-  patch,
-  computeRef,
-  mergeAllBranches,
-};
+const differ: Differ<TestSavedDoc, TestDoc, TestCommitMetadata, TestPresence> =
+  {
+    migrate,
+    diff,
+    patch,
+    computeRef,
+    mergeAllBranches,
+  };
 
 function newStore() {
-  return new MemoryStore<TestEditMetadata, Delta, TestPresence>();
+  return new MemoryStore<TestCommitMetadata, Delta, TestPresence>();
 }
 
 function makeClient(
   userId: string,
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
 ): TrimergeClient<
   TestSavedDoc,
   TestDoc,
-  TestEditMetadata,
+  TestCommitMetadata,
   Delta,
   TestPresence
 > {
@@ -44,11 +45,11 @@ function makeClient(
 }
 
 function basicGraph(
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
   client1: TrimergeClient<
     TestSavedDoc,
     TestDoc,
-    TestEditMetadata,
+    TestCommitMetadata,
     Delta,
     TestPresence
   >,
@@ -64,7 +65,7 @@ function sortedClients(
   client: TrimergeClient<
     TestSavedDoc,
     TestDoc,
-    TestEditMetadata,
+    TestCommitMetadata,
     Delta,
     TestPresence
   >,

--- a/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
@@ -5,30 +5,32 @@ import { MemoryStore } from './testLib/MemoryStore';
 import { diff, mergeAllBranches, migrate, patch } from './testLib/MergeUtils';
 import { getBasicGraph } from './testLib/GraphVisualizers';
 
-type TestEditMetadata = { ref: string; message: string };
+type TestCommitMetadata = { ref: string; message: string };
 type TestSavedDoc = any;
 type TestDoc = any;
 type TestPresence = any;
 
-const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
-  migrate,
-  diff,
-  patch,
-  computeRef: (baseRef, mergeRef, delta, editMetadata) => editMetadata.ref,
-  mergeAllBranches,
-};
+const differ: Differ<TestSavedDoc, TestDoc, TestCommitMetadata, TestPresence> =
+  {
+    migrate,
+    diff,
+    patch,
+    computeRef: (baseRef, mergeRef, delta, CommitMetadata) =>
+      CommitMetadata.ref,
+    mergeAllBranches,
+  };
 
 function newStore() {
-  return new MemoryStore<TestEditMetadata, Delta, TestPresence>();
+  return new MemoryStore<TestCommitMetadata, Delta, TestPresence>();
 }
 
 function makeClient(
   userId: string,
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
 ): TrimergeClient<
   TestSavedDoc,
   TestDoc,
-  TestEditMetadata,
+  TestCommitMetadata,
   Delta,
   TestPresence
 > {
@@ -40,11 +42,11 @@ function timeout() {
 }
 
 function basicGraph(
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
   clientA: TrimergeClient<
     TestSavedDoc,
     TestDoc,
-    TestEditMetadata,
+    TestCommitMetadata,
     Delta,
     TestPresence
   >,

--- a/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
@@ -2,7 +2,13 @@ import { Delta } from 'jsondiffpatch';
 import { TrimergeClient } from './TrimergeClient';
 import { Differ } from './differ';
 import { MemoryStore } from './testLib/MemoryStore';
-import { diff, mergeAllBranches, migrate, patch } from './testLib/MergeUtils';
+import {
+  diff,
+  mergeAllBranches,
+  migrate,
+  patch,
+  computeRef,
+} from './testLib/MergeUtils';
 import { getBasicGraph } from './testLib/GraphVisualizers';
 
 type TestCommitMetadata = { ref: string; message: string };
@@ -15,8 +21,7 @@ const differ: Differ<TestSavedDoc, TestDoc, TestCommitMetadata, TestPresence> =
     migrate,
     diff,
     patch,
-    computeRef: (baseRef, mergeRef, delta, CommitMetadata) =>
-      CommitMetadata.ref,
+    computeRef,
     mergeAllBranches,
   };
 
@@ -88,29 +93,29 @@ describe('TrimergeClient: 3 users', () => {
     expect(basicGraph(store, clientA)).toMatchInlineSnapshot(`
 Array [
   Object {
-    "graph": "undefined -> ROOT",
-    "step": "User a: init",
+    "graph": "undefined -> wK5f8__5",
+    "step": "init",
     "value": Object {
       "text": "",
     },
   },
   Object {
-    "graph": "ROOT -> a1",
-    "step": "User a: set text",
+    "graph": "wK5f8__5 -> 8n57Fn1Z",
+    "step": "set text",
     "value": Object {
       "text": "a",
     },
   },
   Object {
-    "graph": "ROOT -> b1",
-    "step": "User b: set text",
+    "graph": "wK5f8__5 -> 97kyoTPd",
+    "step": "set text",
     "value": Object {
       "text": "b",
     },
   },
   Object {
-    "graph": "ROOT -> c1",
-    "step": "User c: set text",
+    "graph": "wK5f8__5 -> TL7mKxsx",
+    "step": "set text",
     "value": Object {
       "text": "c",
     },
@@ -168,44 +173,44 @@ Array [
     expect(basicGraph(store, clientA)).toMatchInlineSnapshot(`
 Array [
   Object {
-    "graph": "undefined -> a1",
-    "step": "User a: add hello",
+    "graph": "undefined -> HgR3uUrD",
+    "step": "add hello",
     "value": Object {
       "hello": "world",
     },
   },
   Object {
-    "graph": "undefined -> b1",
-    "step": "User b: add world",
+    "graph": "undefined -> AUJdfMae",
+    "step": "add world",
     "value": Object {
       "world": "world",
     },
   },
   Object {
-    "graph": "a1 -> a2",
-    "step": "User a: change hello",
+    "graph": "HgR3uUrD -> eaef2Px0",
+    "step": "change hello",
     "value": Object {
       "hello": "vorld",
     },
   },
   Object {
-    "graph": "b1 -> b2",
-    "step": "User b: change world",
+    "graph": "AUJdfMae -> qOgOVi10",
+    "step": "change world",
     "value": Object {
       "world": "vorld",
     },
   },
   Object {
-    "graph": "(a2 + b2) w/ base=undefined -> (a2+b2)",
-    "step": "User c: merge",
+    "graph": "(eaef2Px0 + qOgOVi10) w/ base=unknown -> yHC1lA3q",
+    "step": "merge",
     "value": Object {
       "hello": "vorld",
       "world": "vorld",
     },
   },
   Object {
-    "graph": "(a2+b2) -> c1",
-    "step": "User c: change hello",
+    "graph": "yHC1lA3q -> 7BcdoBW0",
+    "step": "change hello",
     "value": Object {
       "hello": "world",
       "world": "vorld",

--- a/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
@@ -11,31 +11,30 @@ import {
 } from './testLib/MergeUtils';
 import { getBasicGraph } from './testLib/GraphVisualizers';
 
-type TestCommitMetadata = { ref: string; message: string };
+type TestEditMetadata = { ref: string; message: string };
 type TestSavedDoc = any;
 type TestDoc = any;
 type TestPresence = any;
 
-const differ: Differ<TestSavedDoc, TestDoc, TestCommitMetadata, TestPresence> =
-  {
-    migrate,
-    diff,
-    patch,
-    computeRef,
-    mergeAllBranches,
-  };
+const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
+  migrate,
+  diff,
+  patch,
+  computeRef,
+  mergeAllBranches,
+};
 
 function newStore() {
-  return new MemoryStore<TestCommitMetadata, Delta, TestPresence>();
+  return new MemoryStore<TestEditMetadata, Delta, TestPresence>();
 }
 
 function makeClient(
   userId: string,
-  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
 ): TrimergeClient<
   TestSavedDoc,
   TestDoc,
-  TestCommitMetadata,
+  TestEditMetadata,
   Delta,
   TestPresence
 > {
@@ -47,11 +46,11 @@ function timeout() {
 }
 
 function basicGraph(
-  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
   clientA: TrimergeClient<
     TestSavedDoc,
     TestDoc,
-    TestCommitMetadata,
+    TestEditMetadata,
     Delta,
     TestPresence
   >,

--- a/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
@@ -2,7 +2,7 @@ import { Delta } from 'jsondiffpatch';
 import { TrimergeClient } from './TrimergeClient';
 import { Differ } from './differ';
 import { MemoryStore } from './testLib/MemoryStore';
-import { diff, merge, migrate, patch } from './testLib/MergeUtils';
+import { diff, mergeAllBranches, migrate, patch } from './testLib/MergeUtils';
 import { getBasicGraph } from './testLib/GraphVisualizers';
 
 type TestEditMetadata = { ref: string; message: string };
@@ -15,7 +15,7 @@ const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
   diff,
   patch,
   computeRef: (baseRef, mergeRef, delta, editMetadata) => editMetadata.ref,
-  merge,
+  mergeAllBranches,
 };
 
 function newStore() {

--- a/packages/trimerge-sync/src/TrimergeClient_Fuzz.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Fuzz.test.ts
@@ -2,7 +2,13 @@ import { Delta } from 'jsondiffpatch';
 import { TrimergeClient } from './TrimergeClient';
 import { Differ } from './differ';
 import { MemoryStore } from './testLib/MemoryStore';
-import { computeRef, diff, merge, migrate, patch } from './testLib/MergeUtils';
+import {
+  computeRef,
+  diff,
+  mergeAllBranches,
+  migrate,
+  patch,
+} from './testLib/MergeUtils';
 import { timeout } from './lib/Timeout';
 
 jest.setTimeout(10_000);
@@ -17,7 +23,7 @@ const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
   diff,
   patch,
   computeRef,
-  merge,
+  mergeAllBranches,
 };
 
 function newStore() {

--- a/packages/trimerge-sync/src/TrimergeClient_Fuzz.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Fuzz.test.ts
@@ -13,31 +13,30 @@ import { timeout } from './lib/Timeout';
 
 jest.setTimeout(10_000);
 
-type TestCommitMetadata = any;
+type TestEditMetadata = any;
 type TestSavedDoc = any;
 type TestDoc = any;
 type TestPresence = any;
 
-const differ: Differ<TestSavedDoc, TestDoc, TestCommitMetadata, TestPresence> =
-  {
-    migrate,
-    diff,
-    patch,
-    computeRef,
-    mergeAllBranches,
-  };
+const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
+  migrate,
+  diff,
+  patch,
+  computeRef,
+  mergeAllBranches,
+};
 
 function newStore() {
-  return new MemoryStore<TestCommitMetadata, Delta, TestPresence>();
+  return new MemoryStore<TestEditMetadata, Delta, TestPresence>();
 }
 
 function makeClient(
   userId: string,
-  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
 ): TrimergeClient<
   TestSavedDoc,
   TestDoc,
-  TestCommitMetadata,
+  TestEditMetadata,
   Delta,
   TestPresence
 > {

--- a/packages/trimerge-sync/src/TrimergeClient_Fuzz.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Fuzz.test.ts
@@ -13,30 +13,31 @@ import { timeout } from './lib/Timeout';
 
 jest.setTimeout(10_000);
 
-type TestEditMetadata = any;
+type TestCommitMetadata = any;
 type TestSavedDoc = any;
 type TestDoc = any;
 type TestPresence = any;
 
-const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
-  migrate,
-  diff,
-  patch,
-  computeRef,
-  mergeAllBranches,
-};
+const differ: Differ<TestSavedDoc, TestDoc, TestCommitMetadata, TestPresence> =
+  {
+    migrate,
+    diff,
+    patch,
+    computeRef,
+    mergeAllBranches,
+  };
 
 function newStore() {
-  return new MemoryStore<TestEditMetadata, Delta, TestPresence>();
+  return new MemoryStore<TestCommitMetadata, Delta, TestPresence>();
 }
 
 function makeClient(
   userId: string,
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
 ): TrimergeClient<
   TestSavedDoc,
   TestDoc,
-  TestEditMetadata,
+  TestCommitMetadata,
   Delta,
   TestPresence
 > {

--- a/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
@@ -78,8 +78,8 @@ describe('TrimergeClient: Migration', () => {
     expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
 Array [
   Object {
-    "graph": "undefined -> Z-zhYWBg",
-    "step": "User a: initialize",
+    "graph": "undefined -> wkRuq_cr",
+    "step": "initialize",
     "value": Object {
       "field": 123,
       "v": 1,
@@ -97,8 +97,8 @@ Array [
     expect(basicGraph(store, client2)).toMatchInlineSnapshot(`
 Array [
   Object {
-    "graph": "undefined -> Z-zhYWBg",
-    "step": "User a: initialize",
+    "graph": "undefined -> wkRuq_cr",
+    "step": "initialize",
     "value": Object {
       "field": 123,
       "v": 1,
@@ -115,24 +115,24 @@ Array [
     expect(basicGraph(store, client2)).toMatchInlineSnapshot(`
 Array [
   Object {
-    "graph": "undefined -> Z-zhYWBg",
-    "step": "User a: initialize",
+    "graph": "undefined -> wkRuq_cr",
+    "step": "initialize",
     "value": Object {
       "field": 123,
       "v": 1,
     },
   },
   Object {
-    "graph": "Z-zhYWBg -> wjdpLZeO",
-    "step": "User a: migrated to v2",
+    "graph": "wkRuq_cr -> -gOdQHo5",
+    "step": "migrated to v2",
     "value": Object {
       "field": "123",
       "v": 2,
     },
   },
   Object {
-    "graph": "wjdpLZeO -> UzG9E1u9",
-    "step": "User a: update field",
+    "graph": "-gOdQHo5 -> nr3tJSIE",
+    "step": "update field",
     "value": Object {
       "field": "456",
       "v": 2,
@@ -169,16 +169,16 @@ Array [
     expect(basicGraph(store, client2)).toMatchInlineSnapshot(`
 Array [
   Object {
-    "graph": "undefined -> Z-zhYWBg",
-    "step": "User a: initialize",
+    "graph": "undefined -> wkRuq_cr",
+    "step": "initialize",
     "value": Object {
       "field": 123,
       "v": 1,
     },
   },
   Object {
-    "graph": "Z-zhYWBg -> 2gIafKP_",
-    "step": "User a: update field",
+    "graph": "wkRuq_cr -> _AA1V6TC",
+    "step": "update field",
     "value": Object {
       "field": 456,
       "v": 1,

--- a/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
@@ -10,21 +10,21 @@ import {
 import { getBasicGraph } from './testLib/GraphVisualizers';
 import { timeout } from './lib/Timeout';
 
-type TestEditMetadata = string;
+type TestCommitMetadata = string;
 type DocV1 = { v: 1; field: number };
 type DocV2 = { v: 2; field: string };
 type TestPresence = any;
 
 function newStore() {
-  return new MemoryStore<TestEditMetadata, Delta, TestPresence>();
+  return new MemoryStore<TestCommitMetadata, Delta, TestPresence>();
 }
 
 function makeClientV1(
   userId: string,
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
-): TrimergeClient<DocV1, DocV1, TestEditMetadata, Delta, TestPresence> {
+  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
+): TrimergeClient<DocV1, DocV1, TestCommitMetadata, Delta, TestPresence> {
   return new TrimergeClient(userId, 'test', store.getLocalStore, {
-    migrate: (doc, editMetadata) => ({ doc, metadata }),
+    migrate: (doc, CommitMetadata) => ({ doc, metadata }),
     diff,
     patch: (priorOrNext, delta) => patch(priorOrNext as any, delta),
     computeRef,
@@ -33,10 +33,16 @@ function makeClientV1(
 }
 function makeClientV2(
   userId: string,
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
-): TrimergeClient<DocV1 | DocV2, DocV2, TestEditMetadata, Delta, TestPresence> {
+  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
+): TrimergeClient<
+  DocV1 | DocV2,
+  DocV2,
+  TestCommitMetadata,
+  Delta,
+  TestPresence
+> {
   return new TrimergeClient(userId, 'test', store.getLocalStore, {
-    migrate: (doc, editMetadata) => {
+    migrate: (doc, CommitMetadata) => {
       switch (doc.v) {
         case 1:
           return {
@@ -55,7 +61,7 @@ function makeClientV2(
 }
 
 function basicGraph(
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
   client1: TrimergeClient<any, any, any, any, any>,
 ) {
   return getBasicGraph(

--- a/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
@@ -1,7 +1,12 @@
 import { Delta } from 'jsondiffpatch';
 import { TrimergeClient } from './TrimergeClient';
 import { MemoryStore } from './testLib/MemoryStore';
-import { computeRef, diff, merge, patch } from './testLib/MergeUtils';
+import {
+  computeRef,
+  diff,
+  mergeAllBranches,
+  patch,
+} from './testLib/MergeUtils';
 import { getBasicGraph } from './testLib/GraphVisualizers';
 import { timeout } from './lib/Timeout';
 
@@ -23,7 +28,7 @@ function makeClientV1(
     diff,
     patch: (priorOrNext, delta) => patch(priorOrNext as any, delta),
     computeRef,
-    merge,
+    mergeAllBranches,
   });
 }
 function makeClientV2(
@@ -45,7 +50,7 @@ function makeClientV2(
     diff,
     patch: (priorOrNext, delta) => patch(priorOrNext as any, delta),
     computeRef,
-    merge,
+    mergeAllBranches,
   });
 }
 

--- a/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
@@ -10,19 +10,19 @@ import {
 import { getBasicGraph } from './testLib/GraphVisualizers';
 import { timeout } from './lib/Timeout';
 
-type TestCommitMetadata = string;
+type TestEditMetadata = string;
 type DocV1 = { v: 1; field: number };
 type DocV2 = { v: 2; field: string };
 type TestPresence = any;
 
 function newStore() {
-  return new MemoryStore<TestCommitMetadata, Delta, TestPresence>();
+  return new MemoryStore<TestEditMetadata, Delta, TestPresence>();
 }
 
 function makeClientV1(
   userId: string,
-  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
-): TrimergeClient<DocV1, DocV1, TestCommitMetadata, Delta, TestPresence> {
+  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+): TrimergeClient<DocV1, DocV1, TestEditMetadata, Delta, TestPresence> {
   return new TrimergeClient(userId, 'test', store.getLocalStore, {
     migrate: (doc, metadata) => ({ doc, metadata }),
     diff,
@@ -33,14 +33,8 @@ function makeClientV1(
 }
 function makeClientV2(
   userId: string,
-  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
-): TrimergeClient<
-  DocV1 | DocV2,
-  DocV2,
-  TestCommitMetadata,
-  Delta,
-  TestPresence
-> {
+  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+): TrimergeClient<DocV1 | DocV2, DocV2, TestEditMetadata, Delta, TestPresence> {
   return new TrimergeClient(userId, 'test', store.getLocalStore, {
     migrate: (doc, metadata) => {
       switch (doc.v) {
@@ -61,7 +55,7 @@ function makeClientV2(
 }
 
 function basicGraph(
-  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
   client1: TrimergeClient<any, any, any, any, any>,
 ) {
   return getBasicGraph(

--- a/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
@@ -19,7 +19,7 @@ function makeClientV1(
   store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
 ): TrimergeClient<DocV1, DocV1, TestEditMetadata, Delta, TestPresence> {
   return new TrimergeClient(userId, 'test', store.getLocalStore, {
-    migrate: (doc, editMetadata) => ({ doc, editMetadata }),
+    migrate: (doc, editMetadata) => ({ doc, metadata }),
     diff,
     patch: (priorOrNext, delta) => patch(priorOrNext as any, delta),
     computeRef,
@@ -36,10 +36,10 @@ function makeClientV2(
         case 1:
           return {
             doc: { v: 2, field: String(doc.field) },
-            editMetadata: 'migrated to v2',
+            metadata: 'migrated to v2',
           };
         case 2:
-          return { doc, editMetadata };
+          return { doc, metadata };
       }
     },
     diff,

--- a/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
@@ -24,7 +24,7 @@ function makeClientV1(
   store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
 ): TrimergeClient<DocV1, DocV1, TestCommitMetadata, Delta, TestPresence> {
   return new TrimergeClient(userId, 'test', store.getLocalStore, {
-    migrate: (doc, CommitMetadata) => ({ doc, metadata }),
+    migrate: (doc, metadata) => ({ doc, metadata }),
     diff,
     patch: (priorOrNext, delta) => patch(priorOrNext as any, delta),
     computeRef,
@@ -42,7 +42,7 @@ function makeClientV2(
   TestPresence
 > {
   return new TrimergeClient(userId, 'test', store.getLocalStore, {
-    migrate: (doc, CommitMetadata) => {
+    migrate: (doc, metadata) => {
       switch (doc.v) {
         case 1:
           return {

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -121,13 +121,13 @@ describe('Remote sync', () => {
     expect(localGraph1).toMatchInlineSnapshot(`
 Array [
   Object {
-    "graph": "undefined -> DuQe--Vh",
-    "step": "User a: initialize",
+    "graph": "undefined -> Zob0dMmD",
+    "step": "initialize",
     "value": Object {},
   },
   Object {
-    "graph": "DuQe--Vh -> u0wBto6f",
-    "step": "User a: add hello",
+    "graph": "Zob0dMmD -> leySPlIR",
+    "step": "add hello",
     "value": Object {
       "hello": "world",
     },
@@ -272,62 +272,62 @@ Array [
     expect(localGraph1).toMatchInlineSnapshot(`
 Array [
   Object {
-    "graph": "undefined -> DuQe--Vh",
-    "step": "User a: initialize",
+    "graph": "undefined -> Zob0dMmD",
+    "step": "initialize",
     "value": Object {},
   },
   Object {
-    "graph": "DuQe--Vh -> u0wBto6f",
-    "step": "User a: add hello",
+    "graph": "Zob0dMmD -> leySPlIR",
+    "step": "add hello",
     "value": Object {
       "hello": "world",
     },
   },
   Object {
-    "graph": "u0wBto6f -> mtMnDodx",
-    "step": "User a: edit hello",
+    "graph": "leySPlIR -> DWZJPKBc",
+    "step": "edit hello",
     "value": Object {
       "hello": "world 2",
     },
   },
   Object {
-    "graph": "mtMnDodx -> tB2Oxxss",
-    "step": "User a: edit hello",
+    "graph": "DWZJPKBc -> EM9w-Vme",
+    "step": "edit hello",
     "value": Object {
       "hello": "world 3",
     },
   },
   Object {
-    "graph": "tB2Oxxss -> ltIl6khP",
-    "step": "User a: edit hello",
+    "graph": "EM9w-Vme -> bPTFg9aG",
+    "step": "edit hello",
     "value": Object {
       "hello": "world 4",
     },
   },
   Object {
-    "graph": "ltIl6khP -> 6_CORFe7",
-    "step": "User a: edit hello",
+    "graph": "bPTFg9aG -> SZgOrzaG",
+    "step": "edit hello",
     "value": Object {
       "hello": "world 5",
     },
   },
   Object {
-    "graph": "6_CORFe7 -> OhiKsT4g",
-    "step": "User a: edit hello",
+    "graph": "SZgOrzaG -> s9y6mchq",
+    "step": "edit hello",
     "value": Object {
       "hello": "world 6",
     },
   },
   Object {
-    "graph": "OhiKsT4g -> bTzlNzXZ",
-    "step": "User a: edit hello",
+    "graph": "s9y6mchq -> DnqoAp6m",
+    "step": "edit hello",
     "value": Object {
       "hello": "world 7",
     },
   },
   Object {
-    "graph": "bTzlNzXZ -> ilW_0_ne",
-    "step": "User a: edit hello",
+    "graph": "DnqoAp6m -> _fOHZjAT",
+    "step": "edit hello",
     "value": Object {
       "hello": "world 8",
     },
@@ -508,7 +508,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "DuQe--Vh",
+        "ref": "Zob0dMmD",
         "self": true,
         "userId": "test",
       },
@@ -522,7 +522,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "DuQe--Vh",
+        "ref": "Zob0dMmD",
         "self": true,
         "userId": "test",
       },
@@ -536,7 +536,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "u0wBto6f",
+        "ref": "leySPlIR",
         "self": true,
         "userId": "test",
       },
@@ -550,7 +550,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "u0wBto6f",
+        "ref": "leySPlIR",
         "self": true,
         "userId": "test",
       },
@@ -564,7 +564,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "u0wBto6f",
+        "ref": "leySPlIR",
         "self": true,
         "userId": "test",
       },
@@ -609,7 +609,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "u0wBto6f",
+        "ref": "leySPlIR",
         "userId": "test",
       },
     ],
@@ -1064,44 +1064,44 @@ Array [
     const graph1 = basicGraph(store1, client1);
     const graph2 = basicGraph(store2, client1);
     expect(graph1).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "graph": "undefined -> DuQe--Vh",
-          "step": "User a: initialize",
-          "value": Object {},
-        },
-        Object {
-          "graph": "DuQe--Vh -> u0wBto6f",
-          "step": "User a: add hello",
-          "value": Object {
-            "hello": "world",
-          },
-        },
-        Object {
-          "graph": "u0wBto6f -> YYUSBDXS",
-          "step": "User a: change hello",
-          "value": Object {
-            "hello": "vorld",
-          },
-        },
-        Object {
-          "graph": "YYUSBDXS -> YFIigfVr",
-          "step": "User b: add world",
-          "value": Object {
-            "hello": "vorld",
-            "world": "world",
-          },
-        },
-        Object {
-          "graph": "YFIigfVr -> 3duBmH5E",
-          "step": "User b: change world",
-          "value": Object {
-            "hello": "vorld",
-            "world": "vorld",
-          },
-        },
-      ]
-    `);
+Array [
+  Object {
+    "graph": "undefined -> Zob0dMmD",
+    "step": "initialize",
+    "value": Object {},
+  },
+  Object {
+    "graph": "Zob0dMmD -> leySPlIR",
+    "step": "add hello",
+    "value": Object {
+      "hello": "world",
+    },
+  },
+  Object {
+    "graph": "leySPlIR -> x_n2sT7P",
+    "step": "change hello",
+    "value": Object {
+      "hello": "vorld",
+    },
+  },
+  Object {
+    "graph": "x_n2sT7P -> iOywLlrW",
+    "step": "add world",
+    "value": Object {
+      "hello": "vorld",
+      "world": "world",
+    },
+  },
+  Object {
+    "graph": "iOywLlrW -> ZLVXz73q",
+    "step": "change world",
+    "value": Object {
+      "hello": "vorld",
+      "world": "vorld",
+    },
+  },
+]
+`);
     expect(graph2).toEqual(graph1);
 
     await client1.shutdown();
@@ -1381,7 +1381,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "DuQe--Vh",
+        "ref": "Zob0dMmD",
         "self": true,
         "userId": "a",
       },
@@ -1395,7 +1395,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "DuQe--Vh",
+        "ref": "Zob0dMmD",
         "self": true,
         "userId": "a",
       },
@@ -1409,7 +1409,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "u0wBto6f",
+        "ref": "leySPlIR",
         "self": true,
         "userId": "a",
       },
@@ -1423,7 +1423,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "u0wBto6f",
+        "ref": "leySPlIR",
         "self": true,
         "userId": "a",
       },
@@ -1437,7 +1437,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "YYUSBDXS",
+        "ref": "x_n2sT7P",
         "self": true,
         "userId": "a",
       },
@@ -1451,7 +1451,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "YYUSBDXS",
+        "ref": "x_n2sT7P",
         "self": true,
         "userId": "a",
       },
@@ -1465,7 +1465,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "YYUSBDXS",
+        "ref": "x_n2sT7P",
         "self": true,
         "userId": "a",
       },
@@ -1485,14 +1485,14 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "YYUSBDXS",
+        "ref": "x_n2sT7P",
         "self": true,
         "userId": "a",
       },
       Object {
         "clientId": "b",
         "presence": undefined,
-        "ref": "YFIigfVr",
+        "ref": "iOywLlrW",
         "userId": "b",
       },
     ],
@@ -1505,14 +1505,14 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "YYUSBDXS",
+        "ref": "x_n2sT7P",
         "self": true,
         "userId": "a",
       },
       Object {
         "clientId": "b",
         "presence": undefined,
-        "ref": "3duBmH5E",
+        "ref": "ZLVXz73q",
         "userId": "b",
       },
     ],
@@ -1525,7 +1525,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "YYUSBDXS",
+        "ref": "x_n2sT7P",
         "self": true,
         "userId": "a",
       },
@@ -1564,7 +1564,7 @@ Array [
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "YYUSBDXS",
+        "ref": "x_n2sT7P",
         "userId": "a",
       },
     ],
@@ -1577,14 +1577,14 @@ Array [
       Object {
         "clientId": "b",
         "presence": undefined,
-        "ref": "YFIigfVr",
+        "ref": "iOywLlrW",
         "self": true,
         "userId": "b",
       },
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "YYUSBDXS",
+        "ref": "x_n2sT7P",
         "userId": "a",
       },
     ],
@@ -1597,14 +1597,14 @@ Array [
       Object {
         "clientId": "b",
         "presence": undefined,
-        "ref": "YFIigfVr",
+        "ref": "iOywLlrW",
         "self": true,
         "userId": "b",
       },
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "YYUSBDXS",
+        "ref": "x_n2sT7P",
         "userId": "a",
       },
     ],
@@ -1617,14 +1617,14 @@ Array [
       Object {
         "clientId": "b",
         "presence": undefined,
-        "ref": "3duBmH5E",
+        "ref": "ZLVXz73q",
         "self": true,
         "userId": "b",
       },
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "YYUSBDXS",
+        "ref": "x_n2sT7P",
         "userId": "a",
       },
     ],
@@ -1637,14 +1637,14 @@ Array [
       Object {
         "clientId": "b",
         "presence": undefined,
-        "ref": "3duBmH5E",
+        "ref": "ZLVXz73q",
         "self": true,
         "userId": "b",
       },
       Object {
         "clientId": "a",
         "presence": undefined,
-        "ref": "YYUSBDXS",
+        "ref": "x_n2sT7P",
         "userId": "a",
       },
     ],
@@ -1657,7 +1657,7 @@ Array [
       Object {
         "clientId": "b",
         "presence": undefined,
-        "ref": "3duBmH5E",
+        "ref": "ZLVXz73q",
         "self": true,
         "userId": "b",
       },

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -14,20 +14,21 @@ import { SyncStatus } from './types';
 import { timeout } from './lib/Timeout';
 import { resetAll } from './testLib/MemoryBroadcastChannel';
 
-type TestEditMetadata = string;
+type TestCommitMetadata = string;
 type TestSavedDoc = any;
 type TestDoc = any;
 type TestPresence = any;
 
-const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
-  migrate,
-  diff,
-  patch,
-  computeRef,
-  mergeAllBranches,
-};
+const differ: Differ<TestSavedDoc, TestDoc, TestCommitMetadata, TestPresence> =
+  {
+    migrate,
+    diff,
+    patch,
+    computeRef,
+    mergeAllBranches,
+  };
 
-const stores = new Set<MemoryStore<TestEditMetadata, Delta, TestPresence>>();
+const stores = new Set<MemoryStore<TestCommitMetadata, Delta, TestPresence>>();
 
 afterEach(async () => {
   for (const store of stores) {
@@ -38,10 +39,10 @@ afterEach(async () => {
 });
 
 function newStore(
-  remote?: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+  remote?: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
   online?: boolean,
 ) {
-  const store = new MemoryStore<TestEditMetadata, Delta, TestPresence>(
+  const store = new MemoryStore<TestCommitMetadata, Delta, TestPresence>(
     undefined,
     remote?.getRemote,
     online,
@@ -53,11 +54,11 @@ function newStore(
 function makeClient(
   userId: string,
   clientId: string,
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
 ): TrimergeClient<
   TestSavedDoc,
   TestDoc,
-  TestEditMetadata,
+  TestCommitMetadata,
   Delta,
   TestPresence
 > {
@@ -65,11 +66,11 @@ function makeClient(
 }
 
 function basicGraph(
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
   client1: TrimergeClient<
     TestSavedDoc,
     TestDoc,
-    TestEditMetadata,
+    TestCommitMetadata,
     Delta,
     TestPresence
   >,
@@ -85,7 +86,7 @@ function basicClients(
   client1: TrimergeClient<
     TestSavedDoc,
     TestDoc,
-    TestEditMetadata,
+    TestCommitMetadata,
     Delta,
     TestPresence
   >,

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -14,21 +14,20 @@ import { SyncStatus } from './types';
 import { timeout } from './lib/Timeout';
 import { resetAll } from './testLib/MemoryBroadcastChannel';
 
-type TestCommitMetadata = string;
+type TestEditMetadata = string;
 type TestSavedDoc = any;
 type TestDoc = any;
 type TestPresence = any;
 
-const differ: Differ<TestSavedDoc, TestDoc, TestCommitMetadata, TestPresence> =
-  {
-    migrate,
-    diff,
-    patch,
-    computeRef,
-    mergeAllBranches,
-  };
+const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
+  migrate,
+  diff,
+  patch,
+  computeRef,
+  mergeAllBranches,
+};
 
-const stores = new Set<MemoryStore<TestCommitMetadata, Delta, TestPresence>>();
+const stores = new Set<MemoryStore<TestEditMetadata, Delta, TestPresence>>();
 
 afterEach(async () => {
   for (const store of stores) {
@@ -39,10 +38,10 @@ afterEach(async () => {
 });
 
 function newStore(
-  remote?: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
+  remote?: MemoryStore<TestEditMetadata, Delta, TestPresence>,
   online?: boolean,
 ) {
-  const store = new MemoryStore<TestCommitMetadata, Delta, TestPresence>(
+  const store = new MemoryStore<TestEditMetadata, Delta, TestPresence>(
     undefined,
     remote?.getRemote,
     online,
@@ -54,11 +53,11 @@ function newStore(
 function makeClient(
   userId: string,
   clientId: string,
-  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
 ): TrimergeClient<
   TestSavedDoc,
   TestDoc,
-  TestCommitMetadata,
+  TestEditMetadata,
   Delta,
   TestPresence
 > {
@@ -66,11 +65,11 @@ function makeClient(
 }
 
 function basicGraph(
-  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
   client1: TrimergeClient<
     TestSavedDoc,
     TestDoc,
-    TestCommitMetadata,
+    TestEditMetadata,
     Delta,
     TestPresence
   >,
@@ -86,7 +85,7 @@ function basicClients(
   client1: TrimergeClient<
     TestSavedDoc,
     TestDoc,
-    TestCommitMetadata,
+    TestEditMetadata,
     Delta,
     TestPresence
   >,

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -1,4 +1,10 @@
-import { computeRef, diff, merge, migrate, patch } from './testLib/MergeUtils';
+import {
+  computeRef,
+  diff,
+  mergeAllBranches,
+  migrate,
+  patch,
+} from './testLib/MergeUtils';
 import { Differ } from './differ';
 import { MemoryStore } from './testLib/MemoryStore';
 import { Delta } from 'jsondiffpatch';
@@ -18,7 +24,7 @@ const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
   diff,
   patch,
   computeRef,
-  merge,
+  mergeAllBranches,
 };
 
 const stores = new Set<MemoryStore<TestEditMetadata, Delta, TestPresence>>();

--- a/packages/trimerge-sync/src/auto-branch-merger.ts
+++ b/packages/trimerge-sync/src/auto-branch-merger.ts
@@ -1,4 +1,4 @@
-import { AutoMergeFn, CommitDoc, DocAndMetadata } from './differ';
+import { MergeAllBranchesFn, CommitDoc, DocAndMetadata } from './differ';
 import { mergeHeads, SortRefsFn } from './merge-heads';
 
 export type MergeResult<LatestDoc, EditMetadata> = {
@@ -11,20 +11,20 @@ export type MergeDocFn<LatestDoc, EditMetadata> = (
   right: CommitDoc<LatestDoc, EditMetadata>,
 ) => MergeResult<LatestDoc, EditMetadata>;
 
-export function makeHeadMerger<LatestDoc, EditMetadata>(
+export function makeAutoBranchMerger<LatestDoc, EditMetadata>(
   sortRefs: SortRefsFn,
   merge: MergeDocFn<LatestDoc, EditMetadata>,
-): AutoMergeFn<LatestDoc, EditMetadata> {
-  return (headRefs, getCommitInfo, getMigratedDoc, addMerge) => {
+): MergeAllBranchesFn<LatestDoc, EditMetadata> {
+  return (headRefs, { addMerge, getCommitInfo, computeLatestDoc }) => {
     mergeHeads(
       headRefs,
       sortRefs,
       getCommitInfo,
       (baseRef, leftRef, rightRef) => {
         const migratedBase =
-          baseRef !== undefined ? getMigratedDoc(baseRef) : undefined;
-        const migratedLeft = getMigratedDoc(leftRef);
-        const migratedRight = getMigratedDoc(rightRef);
+          baseRef !== undefined ? computeLatestDoc(baseRef) : undefined;
+        const migratedLeft = computeLatestDoc(leftRef);
+        const migratedRight = computeLatestDoc(rightRef);
 
         const {
           doc,

--- a/packages/trimerge-sync/src/auto-branch-merger.ts
+++ b/packages/trimerge-sync/src/auto-branch-merger.ts
@@ -1,20 +1,20 @@
 import { MergeAllBranchesFn, CommitDoc, DocAndMetadata } from './differ';
 import { mergeHeads, SortRefsFn } from './merge-heads';
 
-export type MergeResult<LatestDoc, EditMetadata> = {
+export type MergeResult<LatestDoc, CommitMetadata> = {
   temp?: boolean;
-} & DocAndMetadata<LatestDoc, EditMetadata>;
+} & DocAndMetadata<LatestDoc, CommitMetadata>;
 
-export type MergeDocFn<LatestDoc, EditMetadata> = (
-  base: CommitDoc<LatestDoc, EditMetadata> | undefined,
-  left: CommitDoc<LatestDoc, EditMetadata>,
-  right: CommitDoc<LatestDoc, EditMetadata>,
-) => MergeResult<LatestDoc, EditMetadata>;
+export type MergeDocFn<LatestDoc, CommitMetadata> = (
+  base: CommitDoc<LatestDoc, CommitMetadata> | undefined,
+  left: CommitDoc<LatestDoc, CommitMetadata>,
+  right: CommitDoc<LatestDoc, CommitMetadata>,
+) => MergeResult<LatestDoc, CommitMetadata>;
 
-export function makeAutoBranchMerger<LatestDoc, EditMetadata>(
+export function makeAutoBranchMerger<LatestDoc, CommitMetadata>(
   sortRefs: SortRefsFn,
-  merge: MergeDocFn<LatestDoc, EditMetadata>,
-): MergeAllBranchesFn<LatestDoc, EditMetadata> {
+  merge: MergeDocFn<LatestDoc, CommitMetadata>,
+): MergeAllBranchesFn<LatestDoc, CommitMetadata> {
   return (headRefs, { addMerge, getCommitInfo, computeLatestDoc }) => {
     mergeHeads(
       headRefs,

--- a/packages/trimerge-sync/src/auto-merge-heads.ts
+++ b/packages/trimerge-sync/src/auto-merge-heads.ts
@@ -1,0 +1,45 @@
+import { AutoMergeFn, CommitDoc, DocAndMetadata } from './differ';
+import { mergeHeads, SortRefsFn } from './merge-heads';
+
+export type MergeResult<LatestDoc, EditMetadata> = {
+  temp?: boolean;
+} & DocAndMetadata<LatestDoc, EditMetadata>;
+
+export type MergeDocFn<LatestDoc, EditMetadata> = (
+  base: CommitDoc<LatestDoc, EditMetadata> | undefined,
+  left: CommitDoc<LatestDoc, EditMetadata>,
+  right: CommitDoc<LatestDoc, EditMetadata>,
+) => MergeResult<LatestDoc, EditMetadata>;
+
+export function makeHeadMerger<LatestDoc, EditMetadata>(
+  sortRefs: SortRefsFn,
+  merge: MergeDocFn<LatestDoc, EditMetadata>,
+): AutoMergeFn<LatestDoc, EditMetadata> {
+  return (headRefs, getCommitInfo, getMigratedDoc, addMerge) => {
+    mergeHeads(
+      headRefs,
+      sortRefs,
+      getCommitInfo,
+      (baseRef, leftRef, rightRef) => {
+        const migratedBase =
+          baseRef !== undefined ? getMigratedDoc(baseRef) : undefined;
+        const migratedLeft = getMigratedDoc(leftRef);
+        const migratedRight = getMigratedDoc(rightRef);
+
+        const {
+          doc,
+          metadata,
+          temp = true,
+        } = merge(migratedBase, migratedLeft, migratedRight);
+
+        return addMerge(
+          doc,
+          metadata,
+          temp,
+          migratedLeft.ref,
+          migratedRight.ref,
+        );
+      },
+    );
+  };
+}

--- a/packages/trimerge-sync/src/differ.test.ts
+++ b/packages/trimerge-sync/src/differ.test.ts
@@ -8,7 +8,7 @@ describe('migrate type tests', () => {
     type LatestDoc = DocV2;
     const migrate: MigrateDocFn<SavedDoc, LatestDoc, string> = (
       doc,
-      editMetadata,
+      metadata,
     ) => {
       switch (doc.version) {
         case 1:
@@ -22,7 +22,7 @@ describe('migrate type tests', () => {
     const v2Doc: DocV2 = { version: 2, b: 12 };
     expect(migrate(v1Doc, 'v1')).toEqual({
       doc: v2Doc,
-      editMetadata: 'migrate',
+      metadata: 'migrate',
     });
     expect(migrate(v2Doc, 'v2').doc).toBe(v2Doc);
 

--- a/packages/trimerge-sync/src/differ.test.ts
+++ b/packages/trimerge-sync/src/differ.test.ts
@@ -12,10 +12,10 @@ describe('migrate type tests', () => {
     ) => {
       switch (doc.version) {
         case 1:
-          return { doc: { version: 2, b: doc.a }, editMetadata: 'migrate' };
+          return { doc: { version: 2, b: doc.a }, metadata: 'migrate' };
         case 2:
           // Up to date
-          return { doc, editMetadata };
+          return { doc, metadata };
       }
     };
     const v1Doc: DocV1 = { version: 1, a: 12 };

--- a/packages/trimerge-sync/src/differ.ts
+++ b/packages/trimerge-sync/src/differ.ts
@@ -16,46 +16,42 @@ export type PatchFn<SavedDoc, Delta> = (
   delta: Delta | undefined,
 ) => SavedDoc;
 
-export type DocAndMetadata<Doc, CommitMetadata> = {
+export type DocAndMetadata<Doc, EditMetadata> = {
   doc: Doc;
-  metadata: CommitMetadata;
+  metadata: EditMetadata;
 };
-export type CommitDoc<Doc, CommitMetadata> = {
+export type CommitDoc<Doc, EditMetadata> = {
   ref: string;
-} & DocAndMetadata<Doc, CommitMetadata>;
+} & DocAndMetadata<Doc, EditMetadata>;
 
-export type MigrateDocFn<
-  SavedDoc,
-  LatestDoc extends SavedDoc,
-  CommitMetadata,
-> = (
+export type MigrateDocFn<SavedDoc, LatestDoc extends SavedDoc, EditMetadata> = (
   doc: SavedDoc,
-  metadata: CommitMetadata,
-) => DocAndMetadata<LatestDoc, CommitMetadata>;
+  metadata: EditMetadata,
+) => DocAndMetadata<LatestDoc, EditMetadata>;
 
-export type MergeHelpers<LatestDoc, CommitMetadata> = {
+export type MergeHelpers<LatestDoc, EditMetadata> = {
   getCommitInfo(ref: string): CommitInfo;
-  computeLatestDoc(ref: string): CommitDoc<LatestDoc, CommitMetadata>;
+  computeLatestDoc(ref: string): CommitDoc<LatestDoc, EditMetadata>;
   addMerge(
     doc: LatestDoc,
-    metadata: CommitMetadata,
+    metadata: EditMetadata,
     temp: boolean,
     leftRef: string,
     rightRef: string,
   ): string;
 };
-export type MergeAllBranchesFn<LatestDoc, CommitMetadata> = (
+export type MergeAllBranchesFn<LatestDoc, EditMetadata> = (
   branchHeadRefs: string[],
-  helpers: MergeHelpers<LatestDoc, CommitMetadata>,
+  helpers: MergeHelpers<LatestDoc, EditMetadata>,
 ) => void;
 
 export interface Differ<
   SavedDoc,
   LatestDoc extends SavedDoc,
-  CommitMetadata,
+  EditMetadata,
   Delta,
 > {
-  readonly migrate: MigrateDocFn<SavedDoc, LatestDoc, CommitMetadata>;
+  readonly migrate: MigrateDocFn<SavedDoc, LatestDoc, EditMetadata>;
 
   /** Calculate the ref string for a given edit */
   readonly computeRef: ComputeRefFn<Delta>;
@@ -67,5 +63,5 @@ export interface Differ<
   readonly patch: PatchFn<SavedDoc, Delta>;
 
   /** Merge all head commits */
-  readonly mergeAllBranches: MergeAllBranchesFn<LatestDoc, CommitMetadata>;
+  readonly mergeAllBranches: MergeAllBranchesFn<LatestDoc, EditMetadata>;
 }

--- a/packages/trimerge-sync/src/differ.ts
+++ b/packages/trimerge-sync/src/differ.ts
@@ -30,17 +30,20 @@ export type MigrateDocFn<SavedDoc, LatestDoc extends SavedDoc, EditMetadata> = (
   editMetadata: EditMetadata,
 ) => DocAndMetadata<LatestDoc, EditMetadata>;
 
-export type AutoMergeFn<LatestDoc, EditMetadata> = (
-  headRefs: string[],
-  getCommitInfo: (ref: string) => CommitInfo,
-  getMigratedDoc: (ref: string) => CommitDoc<LatestDoc, EditMetadata>,
-  addMerge: (
+export type MergeHelpers<LatestDoc, EditMetadata> = {
+  getCommitInfo(ref: string): CommitInfo;
+  computeLatestDoc(ref: string): CommitDoc<LatestDoc, EditMetadata>;
+  addMerge(
     doc: LatestDoc,
     editMetadata: EditMetadata,
     temp: boolean,
     leftRef: string,
     rightRef: string,
-  ) => string,
+  ): string;
+};
+export type MergeAllBranchesFn<LatestDoc, EditMetadata> = (
+  branchHeadRefs: string[],
+  helpers: MergeHelpers<LatestDoc, EditMetadata>,
 ) => void;
 
 export interface Differ<
@@ -60,6 +63,6 @@ export interface Differ<
   /** Apply a patch from one Doc to another */
   readonly patch: PatchFn<SavedDoc, Delta>;
 
-  /** Auto-merge head commits */
-  readonly autoMerge: AutoMergeFn<LatestDoc, EditMetadata>;
+  /** Merge all head commits */
+  readonly mergeAllBranches: MergeAllBranchesFn<LatestDoc, EditMetadata>;
 }

--- a/packages/trimerge-sync/src/differ.ts
+++ b/packages/trimerge-sync/src/differ.ts
@@ -1,3 +1,6 @@
+import { GetCommitFn, MergeCommitsFn, SortRefsFn } from './merge-heads';
+import { CommitInfo } from './types';
+
 export type ComputeRefFn<Delta, EditMetadata> = (
   baseRef: string | undefined,
   mergeRef: string | undefined,
@@ -38,6 +41,19 @@ export type MigrateDocFn<SavedDoc, LatestDoc extends SavedDoc, EditMetadata> = (
   editMetadata: EditMetadata,
 ) => DocAndMetadata<LatestDoc, EditMetadata>;
 
+export type AutoMergeFn<LatestDoc, EditMetadata> = (
+  headRefs: string[],
+  getCommitInfo: (ref: string) => CommitInfo,
+  getMigratedDoc: (ref: string) => CommitDoc<LatestDoc, EditMetadata>,
+  addMerge: (
+    doc: LatestDoc,
+    editMetadata: EditMetadata,
+    temp: boolean,
+    leftRef: string,
+    rightRef: string,
+  ) => string,
+) => number;
+
 export interface Differ<
   SavedDoc,
   LatestDoc extends SavedDoc,
@@ -55,6 +71,6 @@ export interface Differ<
   /** Apply a patch from one Doc to another */
   readonly patch: PatchFn<SavedDoc, Delta>;
 
-  /** Three-way-merge function */
-  readonly merge: MergeDocFn<LatestDoc, EditMetadata>;
+  /** Auto-merge head commits */
+  readonly autoMerge: AutoMergeFn<LatestDoc, EditMetadata>;
 }

--- a/packages/trimerge-sync/src/differ.ts
+++ b/packages/trimerge-sync/src/differ.ts
@@ -1,4 +1,3 @@
-import { GetCommitFn, MergeCommitsFn, SortRefsFn } from './merge-heads';
 import { CommitInfo } from './types';
 
 export type ComputeRefFn<Delta, EditMetadata> = (
@@ -20,21 +19,11 @@ export type PatchFn<SavedDoc, Delta> = (
 
 export type DocAndMetadata<Doc, EditMetadata> = {
   doc: Doc;
-  editMetadata: EditMetadata;
+  metadata: EditMetadata;
 };
 export type CommitDoc<Doc, EditMetadata> = {
   ref: string;
 } & DocAndMetadata<Doc, EditMetadata>;
-
-export type MergeResult<LatestDoc, EditMetadata> = {
-  temp?: boolean;
-} & DocAndMetadata<LatestDoc, EditMetadata>;
-
-export type MergeDocFn<LatestDoc, EditMetadata> = (
-  base: CommitDoc<LatestDoc, EditMetadata> | undefined,
-  left: CommitDoc<LatestDoc, EditMetadata>,
-  right: CommitDoc<LatestDoc, EditMetadata>,
-) => MergeResult<LatestDoc, EditMetadata>;
 
 export type MigrateDocFn<SavedDoc, LatestDoc extends SavedDoc, EditMetadata> = (
   doc: SavedDoc,
@@ -52,7 +41,7 @@ export type AutoMergeFn<LatestDoc, EditMetadata> = (
     leftRef: string,
     rightRef: string,
   ) => string,
-) => number;
+) => void;
 
 export interface Differ<
   SavedDoc,

--- a/packages/trimerge-sync/src/differ.ts
+++ b/packages/trimerge-sync/src/differ.ts
@@ -1,10 +1,9 @@
 import { CommitInfo } from './types';
 
-export type ComputeRefFn<Delta, EditMetadata> = (
+export type ComputeRefFn<Delta> = (
   baseRef: string | undefined,
   mergeRef: string | undefined,
   delta: Delta | undefined,
-  editMetadata: EditMetadata,
 ) => string;
 
 export type DiffFn<SavedDoc, Delta> = (
@@ -17,45 +16,49 @@ export type PatchFn<SavedDoc, Delta> = (
   delta: Delta | undefined,
 ) => SavedDoc;
 
-export type DocAndMetadata<Doc, EditMetadata> = {
+export type DocAndMetadata<Doc, CommitMetadata> = {
   doc: Doc;
-  metadata: EditMetadata;
+  metadata: CommitMetadata;
 };
-export type CommitDoc<Doc, EditMetadata> = {
+export type CommitDoc<Doc, CommitMetadata> = {
   ref: string;
-} & DocAndMetadata<Doc, EditMetadata>;
+} & DocAndMetadata<Doc, CommitMetadata>;
 
-export type MigrateDocFn<SavedDoc, LatestDoc extends SavedDoc, EditMetadata> = (
+export type MigrateDocFn<
+  SavedDoc,
+  LatestDoc extends SavedDoc,
+  CommitMetadata,
+> = (
   doc: SavedDoc,
-  editMetadata: EditMetadata,
-) => DocAndMetadata<LatestDoc, EditMetadata>;
+  metadata: CommitMetadata,
+) => DocAndMetadata<LatestDoc, CommitMetadata>;
 
-export type MergeHelpers<LatestDoc, EditMetadata> = {
+export type MergeHelpers<LatestDoc, CommitMetadata> = {
   getCommitInfo(ref: string): CommitInfo;
-  computeLatestDoc(ref: string): CommitDoc<LatestDoc, EditMetadata>;
+  computeLatestDoc(ref: string): CommitDoc<LatestDoc, CommitMetadata>;
   addMerge(
     doc: LatestDoc,
-    editMetadata: EditMetadata,
+    metadata: CommitMetadata,
     temp: boolean,
     leftRef: string,
     rightRef: string,
   ): string;
 };
-export type MergeAllBranchesFn<LatestDoc, EditMetadata> = (
+export type MergeAllBranchesFn<LatestDoc, CommitMetadata> = (
   branchHeadRefs: string[],
-  helpers: MergeHelpers<LatestDoc, EditMetadata>,
+  helpers: MergeHelpers<LatestDoc, CommitMetadata>,
 ) => void;
 
 export interface Differ<
   SavedDoc,
   LatestDoc extends SavedDoc,
-  EditMetadata,
+  CommitMetadata,
   Delta,
 > {
-  readonly migrate: MigrateDocFn<SavedDoc, LatestDoc, EditMetadata>;
+  readonly migrate: MigrateDocFn<SavedDoc, LatestDoc, CommitMetadata>;
 
   /** Calculate the ref string for a given edit */
-  readonly computeRef: ComputeRefFn<Delta, EditMetadata>;
+  readonly computeRef: ComputeRefFn<Delta>;
 
   /** Computed the difference between two Docs */
   readonly diff: DiffFn<SavedDoc, Delta>;
@@ -64,5 +67,5 @@ export interface Differ<
   readonly patch: PatchFn<SavedDoc, Delta>;
 
   /** Merge all head commits */
-  readonly mergeAllBranches: MergeAllBranchesFn<LatestDoc, EditMetadata>;
+  readonly mergeAllBranches: MergeAllBranchesFn<LatestDoc, CommitMetadata>;
 }

--- a/packages/trimerge-sync/src/index.ts
+++ b/packages/trimerge-sync/src/index.ts
@@ -4,3 +4,5 @@ export * from './types';
 export * from './AbstractLocalStore';
 export * from './validateCommits';
 export * from './lib/PromiseQueue';
+export { MergeDocFn } from './auto-merge-heads';
+export { MergeResult } from './auto-merge-heads';

--- a/packages/trimerge-sync/src/index.ts
+++ b/packages/trimerge-sync/src/index.ts
@@ -4,5 +4,4 @@ export * from './types';
 export * from './AbstractLocalStore';
 export * from './validateCommits';
 export * from './lib/PromiseQueue';
-export { MergeDocFn } from './auto-merge-heads';
-export { MergeResult } from './auto-merge-heads';
+export * from './auto-merge-heads';

--- a/packages/trimerge-sync/src/index.ts
+++ b/packages/trimerge-sync/src/index.ts
@@ -4,4 +4,4 @@ export * from './types';
 export * from './AbstractLocalStore';
 export * from './validateCommits';
 export * from './lib/PromiseQueue';
-export * from './auto-branch-merger';
+export * from './merge-all-helper';

--- a/packages/trimerge-sync/src/index.ts
+++ b/packages/trimerge-sync/src/index.ts
@@ -4,4 +4,4 @@ export * from './types';
 export * from './AbstractLocalStore';
 export * from './validateCommits';
 export * from './lib/PromiseQueue';
-export * from './auto-merge-heads';
+export * from './auto-branch-merger';

--- a/packages/trimerge-sync/src/lib/Commits.ts
+++ b/packages/trimerge-sync/src/lib/Commits.ts
@@ -4,7 +4,6 @@ export type CommitRefs = {
   ref: string;
   baseRef?: string;
   mergeRef?: string;
-  mergeBaseRef?: string;
 };
 
 // used for getting any possible refs from a general commit, refs that do not apply will be undefined.

--- a/packages/trimerge-sync/src/merge-all-helper.ts
+++ b/packages/trimerge-sync/src/merge-all-helper.ts
@@ -1,20 +1,20 @@
 import { MergeAllBranchesFn, CommitDoc, DocAndMetadata } from './differ';
 import { mergeHeads, SortRefsFn } from './merge-heads';
 
-export type MergeResult<LatestDoc, CommitMetadata> = {
+export type MergeResult<LatestDoc, EditMetadata> = {
   temp?: boolean;
-} & DocAndMetadata<LatestDoc, CommitMetadata>;
+} & DocAndMetadata<LatestDoc, EditMetadata>;
 
-export type MergeDocFn<LatestDoc, CommitMetadata> = (
-  base: CommitDoc<LatestDoc, CommitMetadata> | undefined,
-  left: CommitDoc<LatestDoc, CommitMetadata>,
-  right: CommitDoc<LatestDoc, CommitMetadata>,
-) => MergeResult<LatestDoc, CommitMetadata>;
+export type MergeDocFn<LatestDoc, EditMetadata> = (
+  base: CommitDoc<LatestDoc, EditMetadata> | undefined,
+  left: CommitDoc<LatestDoc, EditMetadata>,
+  right: CommitDoc<LatestDoc, EditMetadata>,
+) => MergeResult<LatestDoc, EditMetadata>;
 
-export function makeMergeAllBranchesFn<LatestDoc, CommitMetadata>(
+export function makeMergeAllBranchesFn<LatestDoc, EditMetadata>(
   sortRefs: SortRefsFn,
-  merge: MergeDocFn<LatestDoc, CommitMetadata>,
-): MergeAllBranchesFn<LatestDoc, CommitMetadata> {
+  merge: MergeDocFn<LatestDoc, EditMetadata>,
+): MergeAllBranchesFn<LatestDoc, EditMetadata> {
   return (headRefs, { addMerge, getCommitInfo, computeLatestDoc }) => {
     mergeHeads(
       headRefs,

--- a/packages/trimerge-sync/src/merge-all-helper.ts
+++ b/packages/trimerge-sync/src/merge-all-helper.ts
@@ -11,7 +11,7 @@ export type MergeDocFn<LatestDoc, CommitMetadata> = (
   right: CommitDoc<LatestDoc, CommitMetadata>,
 ) => MergeResult<LatestDoc, CommitMetadata>;
 
-export function makeAutoBranchMerger<LatestDoc, CommitMetadata>(
+export function makeMergeAllBranchesFn<LatestDoc, CommitMetadata>(
   sortRefs: SortRefsFn,
   merge: MergeDocFn<LatestDoc, CommitMetadata>,
 ): MergeAllBranchesFn<LatestDoc, CommitMetadata> {

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
@@ -12,31 +12,30 @@ import {
 import { getBasicGraph, getDotGraph } from './GraphVisualizers';
 import { timeout } from '../lib/Timeout';
 
-type TestCommitMetadata = string;
+type TestEditMetadata = string;
 type TestSavedDoc = any;
 type TestDoc = any;
 type TestPresence = any;
 
-const differ: Differ<TestSavedDoc, TestDoc, TestCommitMetadata, TestPresence> =
-  {
-    migrate,
-    diff,
-    patch,
-    computeRef,
-    mergeAllBranches,
-  };
+const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
+  migrate,
+  diff,
+  patch,
+  computeRef,
+  mergeAllBranches,
+};
 
 function newStore() {
-  return new MemoryStore<TestCommitMetadata, Delta, TestPresence>();
+  return new MemoryStore<TestEditMetadata, Delta, TestPresence>();
 }
 
 function makeClient(
   userId: string,
-  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
 ): TrimergeClient<
   TestSavedDoc,
   TestDoc,
-  TestCommitMetadata,
+  TestEditMetadata,
   Delta,
   TestPresence
 > {
@@ -44,11 +43,11 @@ function makeClient(
 }
 
 function basicGraph(
-  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
   client1: TrimergeClient<
     TestSavedDoc,
     TestDoc,
-    TestCommitMetadata,
+    TestEditMetadata,
     Delta,
     TestPresence
   >,
@@ -61,11 +60,11 @@ function basicGraph(
 }
 
 function dotGraph(
-  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
   client1: TrimergeClient<
     TestSavedDoc,
     TestDoc,
-    TestCommitMetadata,
+    TestEditMetadata,
     Delta,
     TestPresence
   >,

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
@@ -12,30 +12,31 @@ import {
 import { getBasicGraph, getDotGraph } from './GraphVisualizers';
 import { timeout } from '../lib/Timeout';
 
-type TestEditMetadata = string;
+type TestCommitMetadata = string;
 type TestSavedDoc = any;
 type TestDoc = any;
 type TestPresence = any;
 
-const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
-  migrate,
-  diff,
-  patch,
-  computeRef,
-  mergeAllBranches,
-};
+const differ: Differ<TestSavedDoc, TestDoc, TestCommitMetadata, TestPresence> =
+  {
+    migrate,
+    diff,
+    patch,
+    computeRef,
+    mergeAllBranches,
+  };
 
 function newStore() {
-  return new MemoryStore<TestEditMetadata, Delta, TestPresence>();
+  return new MemoryStore<TestCommitMetadata, Delta, TestPresence>();
 }
 
 function makeClient(
   userId: string,
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
 ): TrimergeClient<
   TestSavedDoc,
   TestDoc,
-  TestEditMetadata,
+  TestCommitMetadata,
   Delta,
   TestPresence
 > {
@@ -43,11 +44,11 @@ function makeClient(
 }
 
 function basicGraph(
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
   client1: TrimergeClient<
     TestSavedDoc,
     TestDoc,
-    TestEditMetadata,
+    TestCommitMetadata,
     Delta,
     TestPresence
   >,
@@ -60,11 +61,11 @@ function basicGraph(
 }
 
 function dotGraph(
-  store: MemoryStore<TestEditMetadata, Delta, TestPresence>,
+  store: MemoryStore<TestCommitMetadata, Delta, TestPresence>,
   client1: TrimergeClient<
     TestSavedDoc,
     TestDoc,
-    TestEditMetadata,
+    TestCommitMetadata,
     Delta,
     TestPresence
   >,

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
@@ -2,7 +2,13 @@ import { Delta } from 'jsondiffpatch';
 import { TrimergeClient } from '../TrimergeClient';
 import { Differ } from '../differ';
 import { MemoryStore } from './MemoryStore';
-import { computeRef, diff, merge, migrate, patch } from './MergeUtils';
+import {
+  computeRef,
+  diff,
+  mergeAllBranches,
+  migrate,
+  patch,
+} from './MergeUtils';
 import { getBasicGraph, getDotGraph } from './GraphVisualizers';
 import { timeout } from '../lib/Timeout';
 
@@ -16,7 +22,7 @@ const differ: Differ<TestSavedDoc, TestDoc, TestEditMetadata, TestPresence> = {
   diff,
   patch,
   computeRef,
-  merge,
+  mergeAllBranches,
 };
 
 function newStore() {

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
@@ -88,22 +88,22 @@ describe('GraphVisualizers', () => {
     expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
 Array [
   Object {
-    "graph": "undefined -> 9m0LhHdt",
-    "step": "User a: initialize",
+    "graph": "undefined -> X1xFORPw",
+    "step": "initialize",
     "value": Object {
       "hello": "1",
     },
   },
   Object {
-    "graph": "undefined -> E2BlVX80",
-    "step": "User b: initialize",
+    "graph": "undefined -> OscPQkG7",
+    "step": "initialize",
     "value": Object {
       "world": "2",
     },
   },
   Object {
-    "graph": "E2BlVX80 -> yxbBldSG",
-    "step": "User b: initialize",
+    "graph": "OscPQkG7 -> F7kQ39Rs",
+    "step": "initialize",
     "value": Object {
       "world": "3",
     },
@@ -112,10 +112,10 @@ Array [
 `);
     expect(dotGraph(store, client1)).toMatchInlineSnapshot(`
 "digraph {
-\\"9m0LhHdt\\" [shape=ellipse, label=\\"initialize\\"]
-\\"E2BlVX80\\" [shape=ellipse, label=\\"initialize\\"]
-\\"yxbBldSG\\" [shape=ellipse, label=\\"initialize\\"]
-\\"E2BlVX80\\" -> \\"yxbBldSG\\" [label=\\"User b: [object Object]\\"]
+\\"X1xFORPw\\" [shape=ellipse, label=\\"initialize\\"]
+\\"OscPQkG7\\" [shape=ellipse, label=\\"initialize\\"]
+\\"F7kQ39Rs\\" [shape=ellipse, label=\\"initialize\\"]
+\\"OscPQkG7\\" -> \\"F7kQ39Rs\\" [label={\\"world\\":\\"3\\"}]
 }"
 `);
   });

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.ts
@@ -6,10 +6,10 @@ type BasicGraphItem = {
   step: string;
   value: any;
 };
-export function getBasicGraph<EditMetadata>(
-  commits: Iterable<Commit<EditMetadata, unknown>>,
-  getEditLabel: (commit: Commit<EditMetadata, unknown>) => string,
-  getValue: (commit: Commit<EditMetadata, unknown>) => any,
+export function getBasicGraph<CommitMetadata>(
+  commits: Iterable<Commit<CommitMetadata, unknown>>,
+  getEditLabel: (commit: Commit<CommitMetadata, unknown>) => string,
+  getValue: (commit: Commit<CommitMetadata, unknown>) => any,
 ): BasicGraphItem[] {
   const result = [];
   for (const commit of commits) {
@@ -32,10 +32,10 @@ export function getBasicGraph<EditMetadata>(
   return result;
 }
 
-export function getDotGraph<EditMetadata>(
-  commits: Iterable<Commit<EditMetadata, unknown>>,
-  getEditLabel: (commit: Commit<EditMetadata, any>) => string,
-  getValue: (commit: Commit<EditMetadata, any>) => string,
+export function getDotGraph<CommitMetadata>(
+  commits: Iterable<Commit<CommitMetadata, unknown>>,
+  getEditLabel: (commit: Commit<CommitMetadata, any>) => string,
+  getValue: (commit: Commit<CommitMetadata, any>) => string,
 ): string {
   const lines: string[] = ['digraph {'];
   for (const commit of commits) {

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.ts
@@ -6,10 +6,10 @@ type BasicGraphItem = {
   step: string;
   value: any;
 };
-export function getBasicGraph<CommitMetadata>(
-  commits: Iterable<Commit<CommitMetadata, unknown>>,
-  getEditLabel: (commit: Commit<CommitMetadata, unknown>) => string,
-  getValue: (commit: Commit<CommitMetadata, unknown>) => any,
+export function getBasicGraph<EditMetadata>(
+  commits: Iterable<Commit<EditMetadata, unknown>>,
+  getEditLabel: (commit: Commit<EditMetadata, unknown>) => string,
+  getValue: (commit: Commit<EditMetadata, unknown>) => any,
 ): BasicGraphItem[] {
   const result = [];
   for (const commit of commits) {
@@ -31,10 +31,10 @@ export function getBasicGraph<CommitMetadata>(
   return result;
 }
 
-export function getDotGraph<CommitMetadata>(
-  commits: Iterable<Commit<CommitMetadata, unknown>>,
-  getEditLabel: (commit: Commit<CommitMetadata, any>) => string,
-  getValue: (commit: Commit<CommitMetadata, any>) => string,
+export function getDotGraph<EditMetadata>(
+  commits: Iterable<Commit<EditMetadata, unknown>>,
+  getEditLabel: (commit: Commit<EditMetadata, any>) => string,
+  getValue: (commit: Commit<EditMetadata, any>) => string,
 ): string {
   const lines: string[] = ['digraph {'];
   for (const commit of commits) {

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.ts
@@ -13,18 +13,17 @@ export function getBasicGraph<CommitMetadata>(
 ): BasicGraphItem[] {
   const result = [];
   for (const commit of commits) {
-    const userId = commit.userId;
-    const { ref, baseRef, mergeBaseRef, mergeRef } = asCommitRefs(commit);
+    const { ref, baseRef, mergeRef } = asCommitRefs(commit);
     if (mergeRef) {
       result.push({
-        graph: `(${baseRef} + ${mergeRef}) w/ base=${mergeBaseRef} -> ${ref}`,
-        step: `User ${userId}: merge`,
+        graph: `(${baseRef} + ${mergeRef}) w/ base=${'unknown'} -> ${ref}`,
+        step: `merge`,
         value: getValue(commit),
       });
     } else {
       result.push({
         graph: `${baseRef} -> ${ref}`,
-        step: `User ${userId}: ${getEditLabel(commit)}`,
+        step: getEditLabel(commit),
         value: getValue(commit),
       });
     }
@@ -47,14 +46,11 @@ export function getDotGraph<CommitMetadata>(
     if (commit.baseRef) {
       if (isMergeCommit(commit)) {
         lines.push(`"${commit.baseRef}" -> "${commit.ref}" [label=left]`);
-        lines.push(
-          `"${commit.mergeBaseRef}" -> "${commit.ref}" [style=dashed, label=base]`,
-        );
         lines.push(`"${commit.mergeRef}" -> "${commit.ref}" [label=right]`);
       } else {
         lines.push(
           `"${commit.baseRef}" -> "${commit.ref}" [label=${JSON.stringify(
-            `User ${commit.userId}: ${getEditLabel(commit)}`,
+            getEditLabel(commit),
           )}]`,
         );
       }

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
@@ -15,7 +15,6 @@ describe('MemoryLocalStore', () => {
     local.update(
       [
         {
-          userId: 'test',
           ref: 'test1',
           metadata: undefined,
         },
@@ -34,7 +33,6 @@ Array [
         Object {
           "metadata": undefined,
           "ref": "test1",
-          "userId": "test",
         },
       ],
       "syncId": "0",
@@ -85,7 +83,6 @@ Array [
     local.update(
       [
         {
-          userId: 'test',
           ref: 'test2',
           metadata: undefined,
         },
@@ -100,7 +97,6 @@ Array [
         Object {
           "metadata": undefined,
           "ref": "test1",
-          "userId": "test",
         },
       ],
       "syncId": "0",

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
@@ -46,7 +46,7 @@ export class MemoryLocalStore<
   protected addCommits(
     commits: Commit<EditMetadata, Delta>[],
     remoteSyncId?: string,
-  ): Promise<AckCommitsEvent> {
+  ): Promise<AckCommitsEvent<EditMetadata>> {
     return this.store.addCommits(commits, remoteSyncId);
   }
 

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
@@ -12,21 +12,21 @@ import {
 import { MemoryStore } from './MemoryStore';
 
 export class MemoryLocalStore<
-  EditMetadata,
+  CommitMetadata,
   Delta,
   Presence,
-> extends AbstractLocalStore<EditMetadata, Delta, Presence> {
+> extends AbstractLocalStore<CommitMetadata, Delta, Presence> {
   private _closed = false;
   public readonly channel: MemoryBroadcastChannel<
-    BroadcastEvent<EditMetadata, Delta, Presence>
+    BroadcastEvent<CommitMetadata, Delta, Presence>
   >;
 
   constructor(
-    private readonly store: MemoryStore<EditMetadata, Delta, Presence>,
+    private readonly store: MemoryStore<CommitMetadata, Delta, Presence>,
     userId: string,
     clientId: string,
-    onEvent: OnEventFn<EditMetadata, Delta, Presence>,
-    getRemote?: GetRemoteFn<EditMetadata, Delta, Presence>,
+    onEvent: OnEventFn<CommitMetadata, Delta, Presence>,
+    getRemote?: GetRemoteFn<CommitMetadata, Delta, Presence>,
   ) {
     super(userId, clientId, onEvent, getRemote, {
       initialDelayMs: 0,
@@ -44,7 +44,7 @@ export class MemoryLocalStore<
   }
 
   protected addCommits(
-    commits: Commit<EditMetadata, Delta>[],
+    commits: Commit<CommitMetadata, Delta>[],
     remoteSyncId?: string,
   ): Promise<AckCommitsEvent> {
     return this.store.addCommits(commits, remoteSyncId);
@@ -58,7 +58,7 @@ export class MemoryLocalStore<
   }
 
   protected async broadcastLocal(
-    event: BroadcastEvent<EditMetadata, Delta, Presence>,
+    event: BroadcastEvent<CommitMetadata, Delta, Presence>,
   ): Promise<void> {
     if (this._closed) {
       return;
@@ -67,13 +67,13 @@ export class MemoryLocalStore<
   }
 
   protected async *getLocalCommits(): AsyncIterableIterator<
-    CommitsEvent<EditMetadata, Delta, Presence>
+    CommitsEvent<CommitMetadata, Delta, Presence>
   > {
     yield await this.store.getLocalCommitsEvent();
   }
 
   protected getCommitsForRemote(): AsyncIterableIterator<
-    CommitsEvent<EditMetadata, Delta, Presence>
+    CommitsEvent<CommitMetadata, Delta, Presence>
   > {
     return this.store.getCommitsForRemote();
   }

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
@@ -12,21 +12,21 @@ import {
 import { MemoryStore } from './MemoryStore';
 
 export class MemoryLocalStore<
-  CommitMetadata,
+  EditMetadata,
   Delta,
   Presence,
-> extends AbstractLocalStore<CommitMetadata, Delta, Presence> {
+> extends AbstractLocalStore<EditMetadata, Delta, Presence> {
   private _closed = false;
   public readonly channel: MemoryBroadcastChannel<
-    BroadcastEvent<CommitMetadata, Delta, Presence>
+    BroadcastEvent<EditMetadata, Delta, Presence>
   >;
 
   constructor(
-    private readonly store: MemoryStore<CommitMetadata, Delta, Presence>,
+    private readonly store: MemoryStore<EditMetadata, Delta, Presence>,
     userId: string,
     clientId: string,
-    onEvent: OnStoreEventFn<CommitMetadata, Delta, Presence>,
-    getRemote?: GetRemoteFn<CommitMetadata, Delta, Presence>,
+    onEvent: OnStoreEventFn<EditMetadata, Delta, Presence>,
+    getRemote?: GetRemoteFn<EditMetadata, Delta, Presence>,
   ) {
     super(userId, clientId, onEvent, getRemote, {
       initialDelayMs: 0,
@@ -44,7 +44,7 @@ export class MemoryLocalStore<
   }
 
   protected addCommits(
-    commits: Commit<CommitMetadata, Delta>[],
+    commits: Commit<EditMetadata, Delta>[],
     remoteSyncId?: string,
   ): Promise<AckCommitsEvent> {
     return this.store.addCommits(commits, remoteSyncId);
@@ -58,7 +58,7 @@ export class MemoryLocalStore<
   }
 
   protected async broadcastLocal(
-    event: BroadcastEvent<CommitMetadata, Delta, Presence>,
+    event: BroadcastEvent<EditMetadata, Delta, Presence>,
   ): Promise<void> {
     if (this._closed) {
       return;
@@ -67,13 +67,13 @@ export class MemoryLocalStore<
   }
 
   protected async *getLocalCommits(): AsyncIterableIterator<
-    CommitsEvent<CommitMetadata, Delta, Presence>
+    CommitsEvent<EditMetadata, Delta, Presence>
   > {
     yield await this.store.getLocalCommitsEvent();
   }
 
   protected getCommitsForRemote(): AsyncIterableIterator<
-    CommitsEvent<CommitMetadata, Delta, Presence>
+    CommitsEvent<EditMetadata, Delta, Presence>
   > {
     return this.store.getCommitsForRemote();
   }

--- a/packages/trimerge-sync/src/testLib/MemoryRemote.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryRemote.ts
@@ -102,7 +102,7 @@ export class MemoryRemote<EditMetadata, Delta, Presence>
   }
   protected addCommits(
     commits: readonly Commit<EditMetadata, Delta>[],
-  ): Promise<AckCommitsEvent> {
+  ): Promise<AckCommitsEvent<EditMetadata>> {
     return this.store.addCommits(commits);
   }
 

--- a/packages/trimerge-sync/src/testLib/MemoryRemote.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryRemote.ts
@@ -11,18 +11,18 @@ import {
 import { MemoryStore } from './MemoryStore';
 import { PromiseQueue } from '../lib/PromiseQueue';
 
-export class MemoryRemote<EditMetadata, Delta, Presence>
-  implements Remote<EditMetadata, Delta, Presence>
+export class MemoryRemote<CommitMetadata, Delta, Presence>
+  implements Remote<CommitMetadata, Delta, Presence>
 {
   private readonly remoteQueue = new PromiseQueue();
   private closed = false;
   private readonly clientStoreId: string;
 
   constructor(
-    private readonly store: MemoryStore<EditMetadata, Delta, Presence>,
+    private readonly store: MemoryStore<CommitMetadata, Delta, Presence>,
     private readonly userId: string,
     { lastSyncCursor, localStoreId }: RemoteSyncInfo,
-    private readonly onEvent: OnEventFn<EditMetadata, Delta, Presence>,
+    private readonly onEvent: OnEventFn<CommitMetadata, Delta, Presence>,
   ) {
     this.clientStoreId = localStoreId;
     this.sendInitialEvents(lastSyncCursor).catch(
@@ -31,7 +31,7 @@ export class MemoryRemote<EditMetadata, Delta, Presence>
   }
 
   private async handle(
-    event: SyncEvent<EditMetadata, Delta, Presence>,
+    event: SyncEvent<CommitMetadata, Delta, Presence>,
   ): Promise<void> {
     if (this.closed) {
       return;
@@ -56,12 +56,12 @@ export class MemoryRemote<EditMetadata, Delta, Presence>
     }
   }
 
-  send(event: SyncEvent<EditMetadata, Delta, Presence>): void {
+  send(event: SyncEvent<CommitMetadata, Delta, Presence>): void {
     this.remoteQueue
       .add(() => this.handle(event))
       .catch(this.handleAsError('internal'));
   }
-  private receive(event: SyncEvent<EditMetadata, Delta, Presence>): void {
+  private receive(event: SyncEvent<CommitMetadata, Delta, Presence>): void {
     this.remoteQueue
       .add(async () => this.onEvent(event))
       .catch(this.handleAsError('internal'));
@@ -101,13 +101,13 @@ export class MemoryRemote<EditMetadata, Delta, Presence>
     return (error: Error) => this.fail(error.message, code);
   }
   protected addCommits(
-    commits: readonly Commit<EditMetadata, Delta>[],
+    commits: readonly Commit<CommitMetadata, Delta>[],
   ): Promise<AckCommitsEvent> {
     return this.store.addCommits(commits);
   }
 
   protected async broadcast(
-    event: SyncEvent<EditMetadata, Delta, Presence>,
+    event: SyncEvent<CommitMetadata, Delta, Presence>,
   ): Promise<void> {
     for (const remote of this.store.remotes) {
       // Don't send to other clients with the same userId/clientStoreId pair
@@ -123,7 +123,7 @@ export class MemoryRemote<EditMetadata, Delta, Presence>
 
   protected async *getCommits(
     lastSyncCursor: string | undefined,
-  ): AsyncIterableIterator<CommitsEvent<EditMetadata, Delta, Presence>> {
+  ): AsyncIterableIterator<CommitsEvent<CommitMetadata, Delta, Presence>> {
     yield await this.store.getLocalCommitsEvent(lastSyncCursor);
   }
 }

--- a/packages/trimerge-sync/src/testLib/MemoryStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryStore.ts
@@ -20,16 +20,16 @@ function randomId() {
   return generate({ words: 3, alliterative: true }).dashed;
 }
 
-export class MemoryStore<CommitMetadata, Delta, Presence> {
-  public readonly remotes: MemoryRemote<CommitMetadata, Delta, Presence>[] = [];
-  private commits: Commit<CommitMetadata, Delta>[] = [];
+export class MemoryStore<EditMetadata, Delta, Presence> {
+  public readonly remotes: MemoryRemote<EditMetadata, Delta, Presence>[] = [];
+  private commits: Commit<EditMetadata, Delta>[] = [];
   private localCommitRefs = new Set<string>();
   private syncedCommits = new Set<string>();
   private readonly localStoreId = randomId();
   private lastRemoteSyncCursor: string | undefined;
   private queue = new PromiseQueue();
   private readonly localStores: MemoryLocalStore<
-    CommitMetadata,
+    EditMetadata,
     Delta,
     Presence
   >[] = [];
@@ -38,11 +38,11 @@ export class MemoryStore<CommitMetadata, Delta, Presence> {
 
   constructor(
     public readonly channelName: string = randomId(),
-    private readonly getRemoteFn?: GetRemoteFn<CommitMetadata, Delta, Presence>,
+    private readonly getRemoteFn?: GetRemoteFn<EditMetadata, Delta, Presence>,
     public online = true,
   ) {}
 
-  public getCommits(): readonly Commit<CommitMetadata, Delta>[] {
+  public getCommits(): readonly Commit<EditMetadata, Delta>[] {
     return this.commits;
   }
 
@@ -56,7 +56,7 @@ export class MemoryStore<CommitMetadata, Delta, Presence> {
     }
   }
 
-  getLocalStore: GetLocalStoreFn<CommitMetadata, Delta, Presence> = (
+  getLocalStore: GetLocalStoreFn<EditMetadata, Delta, Presence> = (
     userId,
     clientId,
     onEvent,
@@ -72,7 +72,7 @@ export class MemoryStore<CommitMetadata, Delta, Presence> {
     return store;
   };
 
-  getRemote: GetRemoteFn<CommitMetadata, Delta, Presence> = (
+  getRemote: GetRemoteFn<EditMetadata, Delta, Presence> = (
     userId: string,
     remoteSyncInfo,
     onEvent,
@@ -86,7 +86,7 @@ export class MemoryStore<CommitMetadata, Delta, Presence> {
   };
 
   addCommits(
-    commits: readonly Commit<CommitMetadata, Delta>[],
+    commits: readonly Commit<EditMetadata, Delta>[],
     remoteSyncId?: string,
   ): Promise<AckCommitsEvent> {
     return this.queue.add(async () => {
@@ -126,7 +126,7 @@ export class MemoryStore<CommitMetadata, Delta, Presence> {
 
   getLocalCommitsEvent(
     startSyncCursor?: string,
-  ): Promise<CommitsEvent<CommitMetadata, Delta, Presence>> {
+  ): Promise<CommitsEvent<EditMetadata, Delta, Presence>> {
     return this.queue.add(async () => ({
       type: 'commits',
       commits:
@@ -144,7 +144,7 @@ export class MemoryStore<CommitMetadata, Delta, Presence> {
   }
 
   async *getCommitsForRemote(): AsyncIterableIterator<
-    CommitsEvent<CommitMetadata, Delta, Presence>
+    CommitsEvent<EditMetadata, Delta, Presence>
   > {
     const commits = await this.queue.add(async () =>
       this.commits.filter(({ ref }) => !this.syncedCommits.has(ref)),

--- a/packages/trimerge-sync/src/testLib/MemoryStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryStore.ts
@@ -88,7 +88,7 @@ export class MemoryStore<EditMetadata, Delta, Presence> {
   addCommits(
     commits: readonly Commit<EditMetadata, Delta>[],
     remoteSyncId?: string,
-  ): Promise<AckCommitsEvent> {
+  ): Promise<AckCommitsEvent<EditMetadata>> {
     return this.queue.add(async () => {
       const refs = new Set<string>();
       for (const commit of commits) {

--- a/packages/trimerge-sync/src/testLib/MemoryStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryStore.ts
@@ -20,16 +20,16 @@ function randomId() {
   return generate({ words: 3, alliterative: true }).dashed;
 }
 
-export class MemoryStore<EditMetadata, Delta, Presence> {
-  public readonly remotes: MemoryRemote<EditMetadata, Delta, Presence>[] = [];
-  private commits: Commit<EditMetadata, Delta>[] = [];
+export class MemoryStore<CommitMetadata, Delta, Presence> {
+  public readonly remotes: MemoryRemote<CommitMetadata, Delta, Presence>[] = [];
+  private commits: Commit<CommitMetadata, Delta>[] = [];
   private localCommitRefs = new Set<string>();
   private syncedCommits = new Set<string>();
   private readonly localStoreId = randomId();
   private lastRemoteSyncCursor: string | undefined;
   private queue = new PromiseQueue();
   private readonly localStores: MemoryLocalStore<
-    EditMetadata,
+    CommitMetadata,
     Delta,
     Presence
   >[] = [];
@@ -38,11 +38,11 @@ export class MemoryStore<EditMetadata, Delta, Presence> {
 
   constructor(
     public readonly channelName: string = randomId(),
-    private readonly getRemoteFn?: GetRemoteFn<EditMetadata, Delta, Presence>,
+    private readonly getRemoteFn?: GetRemoteFn<CommitMetadata, Delta, Presence>,
     public online = true,
   ) {}
 
-  public getCommits(): readonly Commit<EditMetadata, Delta>[] {
+  public getCommits(): readonly Commit<CommitMetadata, Delta>[] {
     return this.commits;
   }
 
@@ -56,7 +56,7 @@ export class MemoryStore<EditMetadata, Delta, Presence> {
     }
   }
 
-  getLocalStore: GetLocalStoreFn<EditMetadata, Delta, Presence> = (
+  getLocalStore: GetLocalStoreFn<CommitMetadata, Delta, Presence> = (
     userId,
     clientId,
     onEvent,
@@ -72,7 +72,7 @@ export class MemoryStore<EditMetadata, Delta, Presence> {
     return store;
   };
 
-  getRemote: GetRemoteFn<EditMetadata, Delta, Presence> = (
+  getRemote: GetRemoteFn<CommitMetadata, Delta, Presence> = (
     userId: string,
     remoteSyncInfo,
     onEvent,
@@ -86,7 +86,7 @@ export class MemoryStore<EditMetadata, Delta, Presence> {
   };
 
   addCommits(
-    commits: readonly Commit<EditMetadata, Delta>[],
+    commits: readonly Commit<CommitMetadata, Delta>[],
     remoteSyncId?: string,
   ): Promise<AckCommitsEvent> {
     return this.queue.add(async () => {
@@ -126,7 +126,7 @@ export class MemoryStore<EditMetadata, Delta, Presence> {
 
   getLocalCommitsEvent(
     startSyncCursor?: string,
-  ): Promise<CommitsEvent<EditMetadata, Delta, Presence>> {
+  ): Promise<CommitsEvent<CommitMetadata, Delta, Presence>> {
     return this.queue.add(async () => ({
       type: 'commits',
       commits:
@@ -144,7 +144,7 @@ export class MemoryStore<EditMetadata, Delta, Presence> {
   }
 
   async *getCommitsForRemote(): AsyncIterableIterator<
-    CommitsEvent<EditMetadata, Delta, Presence>
+    CommitsEvent<CommitMetadata, Delta, Presence>
   > {
     const commits = await this.queue.add(async () =>
       this.commits.filter(({ ref }) => !this.syncedCommits.has(ref)),

--- a/packages/trimerge-sync/src/testLib/MergeUtils.ts
+++ b/packages/trimerge-sync/src/testLib/MergeUtils.ts
@@ -9,7 +9,7 @@ import { create, Delta } from 'jsondiffpatch';
 import { DocAndMetadata } from '../differ';
 import { produce } from 'immer';
 import { computeRef as computeShaRef } from 'trimerge-sync-hash';
-import { MergeDocFn } from '../auto-merge-heads';
+import { MergeDocFn } from '../auto-branch-merger';
 
 const trimergeObjects = combineMergers(
   trimergeEquality,

--- a/packages/trimerge-sync/src/testLib/MergeUtils.ts
+++ b/packages/trimerge-sync/src/testLib/MergeUtils.ts
@@ -6,10 +6,10 @@ import {
   trimergeString,
 } from 'trimerge';
 import { create, Delta } from 'jsondiffpatch';
-import { DocAndMetadata } from '../differ';
+import { DocAndMetadata, MergeAllBranchesFn } from '../differ';
 import { produce } from 'immer';
 import { computeRef as computeShaRef } from 'trimerge-sync-hash';
-import { MergeDocFn } from '../auto-branch-merger';
+import { makeAutoBranchMerger, MergeDocFn } from '../auto-branch-merger';
 
 const trimergeObjects = combineMergers(
   trimergeEquality,
@@ -23,6 +23,10 @@ export const merge: MergeDocFn<any, any> = (base, left, right) => ({
     message: `merge`,
   },
 });
+
+export const mergeAllBranches: MergeAllBranchesFn<any, any> =
+  makeAutoBranchMerger((a, b) => (a < b ? -1 : 1), merge);
+
 export const jdp = create({ textDiff: { minLength: 20 } });
 
 export function patch<T>(base: T, delta: Delta | undefined): T {

--- a/packages/trimerge-sync/src/testLib/MergeUtils.ts
+++ b/packages/trimerge-sync/src/testLib/MergeUtils.ts
@@ -9,7 +9,7 @@ import { create, Delta } from 'jsondiffpatch';
 import { DocAndMetadata, MergeAllBranchesFn } from '../differ';
 import { produce } from 'immer';
 import { computeRef as computeShaRef } from 'trimerge-sync-hash';
-import { makeAutoBranchMerger, MergeDocFn } from '../auto-branch-merger';
+import { makeMergeAllBranchesFn, MergeDocFn } from '../merge-all-helper';
 
 const trimergeObjects = combineMergers(
   trimergeEquality,
@@ -25,7 +25,7 @@ export const merge: MergeDocFn<any, any> = (base, left, right) => ({
 });
 
 export const mergeAllBranches: MergeAllBranchesFn<any, any> =
-  makeAutoBranchMerger((a, b) => (a < b ? -1 : 1), merge);
+  makeMergeAllBranchesFn((a, b) => (a < b ? -1 : 1), merge);
 
 export const jdp = create({ textDiff: { minLength: 20 } });
 

--- a/packages/trimerge-sync/src/testLib/MergeUtils.ts
+++ b/packages/trimerge-sync/src/testLib/MergeUtils.ts
@@ -41,10 +41,10 @@ export function diff<T>(left: T, right: T) {
 }
 
 // Simple no-op migration for unit tests
-export function migrate<Doc, EditMetadata>(
+export function migrate<Doc, CommitMetadata>(
   doc: Doc,
-  editMetadata: EditMetadata,
-): DocAndMetadata<Doc, EditMetadata> {
+  metadata: CommitMetadata,
+): DocAndMetadata<Doc, CommitMetadata> {
   return { doc, metadata };
 }
 
@@ -52,7 +52,6 @@ export function computeRef(
   baseRef: string | undefined,
   mergeRef: string | undefined,
   delta: any,
-  editMetadata: any,
 ): string {
-  return computeShaRef(baseRef, mergeRef, delta, editMetadata).slice(0, 8);
+  return computeShaRef(baseRef, mergeRef, delta).slice(0, 8);
 }

--- a/packages/trimerge-sync/src/testLib/MergeUtils.ts
+++ b/packages/trimerge-sync/src/testLib/MergeUtils.ts
@@ -41,10 +41,10 @@ export function diff<T>(left: T, right: T) {
 }
 
 // Simple no-op migration for unit tests
-export function migrate<Doc, CommitMetadata>(
+export function migrate<Doc, EditMetadata>(
   doc: Doc,
-  metadata: CommitMetadata,
-): DocAndMetadata<Doc, CommitMetadata> {
+  metadata: EditMetadata,
+): DocAndMetadata<Doc, EditMetadata> {
   return { doc, metadata };
 }
 

--- a/packages/trimerge-sync/src/testLib/MergeUtils.ts
+++ b/packages/trimerge-sync/src/testLib/MergeUtils.ts
@@ -6,9 +6,10 @@ import {
   trimergeString,
 } from 'trimerge';
 import { create, Delta } from 'jsondiffpatch';
-import { MergeDocFn, DocAndMetadata } from '../differ';
+import { DocAndMetadata } from '../differ';
 import { produce } from 'immer';
 import { computeRef as computeShaRef } from 'trimerge-sync-hash';
+import { MergeDocFn } from '../auto-merge-heads';
 
 const trimergeObjects = combineMergers(
   trimergeEquality,
@@ -17,7 +18,7 @@ const trimergeObjects = combineMergers(
 );
 export const merge: MergeDocFn<any, any> = (base, left, right) => ({
   doc: trimergeObjects(base?.doc, left.doc, right.doc),
-  editMetadata: {
+  metadata: {
     ref: `(${left.ref}+${right.ref})`,
     message: `merge`,
   },
@@ -40,7 +41,7 @@ export function migrate<Doc, EditMetadata>(
   doc: Doc,
   editMetadata: EditMetadata,
 ): DocAndMetadata<Doc, EditMetadata> {
-  return { doc, editMetadata };
+  return { doc, metadata };
 }
 
 export function computeRef(

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -10,7 +10,8 @@ export type ErrorCode =
 export type BaseCommit<EditMetadata = unknown, Delta = unknown> = {
   ref: string;
 
-  // The ref of the commit that this commit is based on
+  // The ref of the parent commit that the delta was based on
+  // or undefined if it's an initial document commit
   baseRef?: string;
 
   // a structure defining the differences between baseRef and this commit
@@ -111,18 +112,14 @@ export type InitEvent =
       auth: unknown;
     };
 
-export type CommitAck = {
+export type CommitAck<EditMetadata> = {
   ref: string;
+  metadata?: EditMetadata;
 };
-
-export type ServerCommit<EditMetadata, Delta> = Commit<EditMetadata, Delta>;
 
 export type CommitsEvent<EditMetadata, Delta, Presence> = {
   type: 'commits';
-  commits: readonly (
-    | ServerCommit<EditMetadata, Delta>
-    | Commit<EditMetadata, Delta>
-  )[];
+  commits: readonly Commit<EditMetadata, Delta>[];
   clientInfo?: ClientInfo<Presence>;
   syncId?: string;
 };
@@ -142,9 +139,9 @@ export type AckCommitError = {
   message?: string;
 };
 export type AckRefErrors = Record<string, AckCommitError>;
-export type AckCommitsEvent = {
+export type AckCommitsEvent<EditMetadata> = {
   type: 'ack';
-  acks: readonly CommitAck[];
+  acks: readonly CommitAck<EditMetadata>[];
   refErrors?: AckRefErrors;
   syncId: string;
 };
@@ -185,7 +182,7 @@ export type SyncEvent<EditMetadata, Delta, Presence> = Readonly<
   | CommitsEvent<EditMetadata, Delta, Presence>
   | ReadyEvent
   | LeaderEvent
-  | AckCommitsEvent
+  | AckCommitsEvent<EditMetadata>
   | ClientJoinEvent<Presence>
   | ClientPresenceEvent<Presence>
   | ClientLeaveEvent

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -112,7 +112,7 @@ export type InitEvent =
       auth: unknown;
     };
 
-export type CommitAck<EditMetadata> = {
+export type CommitAck<EditMetadata = unknown> = {
   ref: string;
   metadata?: EditMetadata;
 };
@@ -139,7 +139,7 @@ export type AckCommitError = {
   message?: string;
 };
 export type AckRefErrors = Record<string, AckCommitError>;
-export type AckCommitsEvent<EditMetadata> = {
+export type AckCommitsEvent<EditMetadata = unknown> = {
   type: 'ack';
   acks: readonly CommitAck<EditMetadata>[];
   refErrors?: AckRefErrors;

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -37,10 +37,10 @@ export type MergeCommit<EditMetadata = unknown, Delta = unknown> = BaseCommit<
   mergeRef: string;
 };
 
-export function isMergeCommit(
-  commit: Commit<unknown, unknown>,
-): commit is MergeCommit<unknown, unknown> {
-  return (commit as MergeCommit<unknown, unknown>).mergeRef !== undefined;
+export function isMergeCommit<EditMetadata = unknown, Delta = unknown>(
+  commit: Commit<EditMetadata, Delta>,
+): commit is MergeCommit<EditMetadata, Delta> {
+  return (commit as MergeCommit).mergeRef !== undefined;
 }
 
 export type CommitInfo = {

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -97,13 +97,6 @@ export type LocalClientInfo<Presence> = ClientInfo<Presence> & {
 };
 export type ClientList<Presence> = readonly LocalClientInfo<Presence>[];
 
-export type ClientMetadata = {
-  client: {
-    id: string;
-    timestamp: string;
-  };
-};
-
 export type InitEvent =
   | {
       type: 'init';

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -7,7 +7,7 @@ export type ErrorCode =
   | 'bad-request'
   | 'unauthorized';
 
-export type BaseCommit<EditMetadata = unknown, Delta = unknown> = {
+export type BaseCommit<CommitMetadata = unknown, Delta = unknown> = {
   ref: string;
 
   // The ref of the parent commit that the delta was based on
@@ -18,16 +18,16 @@ export type BaseCommit<EditMetadata = unknown, Delta = unknown> = {
   delta?: Delta;
 
   // application-specific metadata about the commit
-  metadata: EditMetadata;
+  metadata: CommitMetadata;
 };
 
-export type EditCommit<EditMetadata = unknown, Delta = unknown> = BaseCommit<
-  EditMetadata,
+export type EditCommit<CommitMetadata = unknown, Delta = unknown> = BaseCommit<
+  CommitMetadata,
   Delta
 >;
 
-export type MergeCommit<EditMetadata = unknown, Delta = unknown> = BaseCommit<
-  EditMetadata,
+export type MergeCommit<CommitMetadata = unknown, Delta = unknown> = BaseCommit<
+  CommitMetadata,
   Delta
 > & {
   // primary parent of the merge commit
@@ -37,9 +37,9 @@ export type MergeCommit<EditMetadata = unknown, Delta = unknown> = BaseCommit<
   mergeRef: string;
 };
 
-export function isMergeCommit<EditMetadata = unknown, Delta = unknown>(
-  commit: Commit<EditMetadata, Delta>,
-): commit is MergeCommit<EditMetadata, Delta> {
+export function isMergeCommit<CommitMetadata = unknown, Delta = unknown>(
+  commit: Commit<CommitMetadata, Delta>,
+): commit is MergeCommit<CommitMetadata, Delta> {
   return (commit as MergeCommit).mergeRef !== undefined;
 }
 
@@ -49,9 +49,9 @@ export type CommitInfo = {
   mergeRef?: string;
 };
 
-export type Commit<EditMetadata = unknown, Delta = unknown> =
-  | MergeCommit<EditMetadata, Delta>
-  | EditCommit<EditMetadata, Delta>;
+export type Commit<CommitMetadata = unknown, Delta = unknown> =
+  | MergeCommit<CommitMetadata, Delta>
+  | EditCommit<CommitMetadata, Delta>;
 
 export type LocalReadStatus =
   | 'loading' /** reading state from disk */
@@ -97,6 +97,13 @@ export type LocalClientInfo<Presence> = ClientInfo<Presence> & {
 };
 export type ClientList<Presence> = readonly LocalClientInfo<Presence>[];
 
+export type ClientMetadata = {
+  client: {
+    id: string;
+    timestamp: string;
+  };
+};
+
 export type InitEvent =
   | {
       type: 'init';
@@ -112,14 +119,14 @@ export type InitEvent =
       auth: unknown;
     };
 
-export type CommitAck<EditMetadata = unknown> = {
+export type CommitAck<CommitMetadata = unknown> = {
   ref: string;
-  metadata?: EditMetadata;
+  metadata?: CommitMetadata;
 };
 
-export type CommitsEvent<EditMetadata, Delta, Presence> = {
+export type CommitsEvent<CommitMetadata, Delta, Presence> = {
   type: 'commits';
-  commits: readonly Commit<EditMetadata, Delta>[];
+  commits: readonly Commit<CommitMetadata, Delta>[];
   clientInfo?: ClientInfo<Presence>;
   syncId?: string;
 };
@@ -139,9 +146,9 @@ export type AckCommitError = {
   message?: string;
 };
 export type AckRefErrors = Record<string, AckCommitError>;
-export type AckCommitsEvent<EditMetadata = unknown> = {
+export type AckCommitsEvent<CommitMetadata = unknown> = {
   type: 'ack';
-  acks: readonly CommitAck<EditMetadata>[];
+  acks: readonly CommitAck<CommitMetadata>[];
   refErrors?: AckRefErrors;
   syncId: string;
 };
@@ -177,12 +184,12 @@ export type LeaderEvent = {
   action: 'request' | 'current' | 'accept' | 'withdraw';
   clientId: string;
 };
-export type SyncEvent<EditMetadata, Delta, Presence> = Readonly<
+export type SyncEvent<CommitMetadata, Delta, Presence> = Readonly<
   | InitEvent
-  | CommitsEvent<EditMetadata, Delta, Presence>
+  | CommitsEvent<CommitMetadata, Delta, Presence>
   | ReadyEvent
   | LeaderEvent
-  | AckCommitsEvent<EditMetadata>
+  | AckCommitsEvent<CommitMetadata>
   | ClientJoinEvent<Presence>
   | ClientPresenceEvent<Presence>
   | ClientLeaveEvent
@@ -190,39 +197,39 @@ export type SyncEvent<EditMetadata, Delta, Presence> = Readonly<
   | ErrorEvent
 >;
 
-export type OnEventFn<EditMetadata, Delta, Presence> = (
-  event: SyncEvent<EditMetadata, Delta, Presence>,
+export type OnEventFn<CommitMetadata, Delta, Presence> = (
+  event: SyncEvent<CommitMetadata, Delta, Presence>,
 ) => void;
 
-export type GetLocalStoreFn<EditMetadata, Delta, Presence> = (
+export type GetLocalStoreFn<CommitMetadata, Delta, Presence> = (
   userId: string,
   clientId: string,
-  onEvent: OnEventFn<EditMetadata, Delta, Presence>,
-) => LocalStore<EditMetadata, Delta, Presence>;
+  onEvent: OnEventFn<CommitMetadata, Delta, Presence>,
+) => LocalStore<CommitMetadata, Delta, Presence>;
 
 export type RemoteSyncInfo = {
   localStoreId: string;
   lastSyncCursor: string | undefined;
 };
 
-export type GetRemoteFn<EditMetadata, Delta, Presence> = (
+export type GetRemoteFn<CommitMetadata, Delta, Presence> = (
   userId: string,
   remoteSyncInfo: RemoteSyncInfo,
-  onEvent: OnEventFn<EditMetadata, Delta, Presence>,
+  onEvent: OnEventFn<CommitMetadata, Delta, Presence>,
 ) =>
-  | Remote<EditMetadata, Delta, Presence>
-  | Promise<Remote<EditMetadata, Delta, Presence>>;
+  | Remote<CommitMetadata, Delta, Presence>
+  | Promise<Remote<CommitMetadata, Delta, Presence>>;
 
-export interface LocalStore<EditMetadata, Delta, Presence> {
+export interface LocalStore<CommitMetadata, Delta, Presence> {
   update(
-    commits: Commit<EditMetadata, Delta>[],
+    commits: Commit<CommitMetadata, Delta>[],
     presence: ClientPresenceRef<Presence> | undefined,
   ): void;
   isRemoteLeader: boolean;
   shutdown(): void | Promise<void>;
 }
 
-export interface Remote<EditMetadata, Delta, Presence> {
-  send(event: SyncEvent<EditMetadata, Delta, Presence>): void;
+export interface Remote<CommitMetadata, Delta, Presence> {
+  send(event: SyncEvent<CommitMetadata, Delta, Presence>): void;
   shutdown(): void | Promise<void>;
 }

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -7,7 +7,7 @@ export type ErrorCode =
   | 'bad-request'
   | 'unauthorized';
 
-export type BaseCommit<CommitMetadata = unknown, Delta = unknown> = {
+export type BaseCommit<EditMetadata = unknown, Delta = unknown> = {
   ref: string;
 
   // The ref of the parent commit that the delta was based on
@@ -18,16 +18,16 @@ export type BaseCommit<CommitMetadata = unknown, Delta = unknown> = {
   delta?: Delta;
 
   // application-specific metadata about the commit
-  metadata: CommitMetadata;
+  metadata: EditMetadata;
 };
 
-export type EditCommit<CommitMetadata = unknown, Delta = unknown> = BaseCommit<
-  CommitMetadata,
+export type EditCommit<EditMetadata = unknown, Delta = unknown> = BaseCommit<
+  EditMetadata,
   Delta
 >;
 
-export type MergeCommit<CommitMetadata = unknown, Delta = unknown> = BaseCommit<
-  CommitMetadata,
+export type MergeCommit<EditMetadata = unknown, Delta = unknown> = BaseCommit<
+  EditMetadata,
   Delta
 > & {
   // primary parent of the merge commit
@@ -37,9 +37,9 @@ export type MergeCommit<CommitMetadata = unknown, Delta = unknown> = BaseCommit<
   mergeRef: string;
 };
 
-export function isMergeCommit<CommitMetadata = unknown, Delta = unknown>(
-  commit: Commit<CommitMetadata, Delta>,
-): commit is MergeCommit<CommitMetadata, Delta> {
+export function isMergeCommit<EditMetadata = unknown, Delta = unknown>(
+  commit: Commit<EditMetadata, Delta>,
+): commit is MergeCommit<EditMetadata, Delta> {
   return (commit as MergeCommit).mergeRef !== undefined;
 }
 
@@ -49,9 +49,9 @@ export type CommitInfo = {
   mergeRef?: string;
 };
 
-export type Commit<CommitMetadata = unknown, Delta = unknown> =
-  | MergeCommit<CommitMetadata, Delta>
-  | EditCommit<CommitMetadata, Delta>;
+export type Commit<EditMetadata = unknown, Delta = unknown> =
+  | MergeCommit<EditMetadata, Delta>
+  | EditCommit<EditMetadata, Delta>;
 
 export type LocalReadStatus =
   | 'loading' /** reading state from disk */
@@ -112,14 +112,14 @@ export type InitEvent =
       auth: unknown;
     };
 
-export type CommitAck<CommitMetadata = unknown> = {
+export type CommitAck<EditMetadata = unknown> = {
   ref: string;
-  metadata?: CommitMetadata;
+  metadata?: EditMetadata;
 };
 
-export type CommitsEvent<CommitMetadata, Delta, Presence> = {
+export type CommitsEvent<EditMetadata, Delta, Presence> = {
   type: 'commits';
-  commits: readonly Commit<CommitMetadata, Delta>[];
+  commits: readonly Commit<EditMetadata, Delta>[];
   clientInfo?: ClientInfo<Presence>;
   syncId?: string;
 };
@@ -139,9 +139,9 @@ export type AckCommitError = {
   message?: string;
 };
 export type AckRefErrors = Record<string, AckCommitError>;
-export type AckCommitsEvent<CommitMetadata = unknown> = {
+export type AckCommitsEvent<EditMetadata = unknown> = {
   type: 'ack';
-  acks: readonly CommitAck<CommitMetadata>[];
+  acks: readonly CommitAck<EditMetadata>[];
   refErrors?: AckRefErrors;
   syncId: string;
 };
@@ -177,12 +177,12 @@ export type LeaderEvent = {
   action: 'request' | 'current' | 'accept' | 'withdraw';
   clientId: string;
 };
-export type SyncEvent<CommitMetadata, Delta, Presence> = Readonly<
+export type SyncEvent<EditMetadata, Delta, Presence> = Readonly<
   | InitEvent
-  | CommitsEvent<CommitMetadata, Delta, Presence>
+  | CommitsEvent<EditMetadata, Delta, Presence>
   | ReadyEvent
   | LeaderEvent
-  | AckCommitsEvent<CommitMetadata>
+  | AckCommitsEvent<EditMetadata>
   | ClientJoinEvent<Presence>
   | ClientPresenceEvent<Presence>
   | ClientLeaveEvent
@@ -190,44 +190,44 @@ export type SyncEvent<CommitMetadata, Delta, Presence> = Readonly<
   | ErrorEvent
 >;
 
-export type OnStoreEventFn<CommitMetadata, Delta, Presence> = (
-  event: SyncEvent<CommitMetadata, Delta, Presence>,
+export type OnStoreEventFn<EditMetadata, Delta, Presence> = (
+  event: SyncEvent<EditMetadata, Delta, Presence>,
   remoteOrigin: boolean,
 ) => void;
 
-export type OnRemoteEventFn<CommitMetadata, Delta, Presence> = (
-  event: SyncEvent<CommitMetadata, Delta, Presence>,
+export type OnRemoteEventFn<EditMetadata, Delta, Presence> = (
+  event: SyncEvent<EditMetadata, Delta, Presence>,
 ) => void;
 
-export type GetLocalStoreFn<CommitMetadata, Delta, Presence> = (
+export type GetLocalStoreFn<EditMetadata, Delta, Presence> = (
   userId: string,
   clientId: string,
-  onEvent: OnStoreEventFn<CommitMetadata, Delta, Presence>,
-) => LocalStore<CommitMetadata, Delta, Presence>;
+  onEvent: OnStoreEventFn<EditMetadata, Delta, Presence>,
+) => LocalStore<EditMetadata, Delta, Presence>;
 
 export type RemoteSyncInfo = {
   localStoreId: string;
   lastSyncCursor: string | undefined;
 };
 
-export type GetRemoteFn<CommitMetadata, Delta, Presence> = (
+export type GetRemoteFn<EditMetadata, Delta, Presence> = (
   userId: string,
   remoteSyncInfo: RemoteSyncInfo,
-  onRemoteEvent: OnRemoteEventFn<CommitMetadata, Delta, Presence>,
+  onRemoteEvent: OnRemoteEventFn<EditMetadata, Delta, Presence>,
 ) =>
-  | Remote<CommitMetadata, Delta, Presence>
-  | Promise<Remote<CommitMetadata, Delta, Presence>>;
+  | Remote<EditMetadata, Delta, Presence>
+  | Promise<Remote<EditMetadata, Delta, Presence>>;
 
-export interface LocalStore<CommitMetadata, Delta, Presence> {
+export interface LocalStore<EditMetadata, Delta, Presence> {
   update(
-    commits: Commit<CommitMetadata, Delta>[],
+    commits: Commit<EditMetadata, Delta>[],
     presence: ClientPresenceRef<Presence> | undefined,
   ): void;
   isRemoteLeader: boolean;
   shutdown(): void | Promise<void>;
 }
 
-export interface Remote<CommitMetadata, Delta, Presence> {
-  send(event: SyncEvent<CommitMetadata, Delta, Presence>): void;
+export interface Remote<EditMetadata, Delta, Presence> {
+  send(event: SyncEvent<EditMetadata, Delta, Presence>): void;
   shutdown(): void | Promise<void>;
 }

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -7,23 +7,25 @@ export type ErrorCode =
   | 'bad-request'
   | 'unauthorized';
 
-export type BaseCommit<EditMetadata, Delta> = {
-  userId: string;
+export type BaseCommit<EditMetadata = unknown, Delta = unknown> = {
   ref: string;
+
+  // The ref of the commit that this commit is based on
+  baseRef?: string;
 
   // a structure defining the differences between baseRef and this commit
   delta?: Delta;
 
-  // application specific metadata about the commit
+  // application-specific metadata about the commit
   metadata: EditMetadata;
-
-  // The ref of the commit that this commit is based on
-  baseRef?: string;
 };
 
-export type EditCommit<EditMetadata, Delta> = BaseCommit<EditMetadata, Delta>;
+export type EditCommit<EditMetadata = unknown, Delta = unknown> = BaseCommit<
+  EditMetadata,
+  Delta
+>;
 
-export type MergeCommit<EditMetadata, Delta> = BaseCommit<
+export type MergeCommit<EditMetadata = unknown, Delta = unknown> = BaseCommit<
   EditMetadata,
   Delta
 > & {
@@ -32,10 +34,6 @@ export type MergeCommit<EditMetadata, Delta> = BaseCommit<
 
   // secondary parent of the merge commit
   mergeRef: string;
-
-  // the most recent common ancestor of the baseRef and mergeRef,
-  // can be undefined if multiple clients are editing the same new document.
-  mergeBaseRef?: string;
 };
 
 export function isMergeCommit(
@@ -44,7 +42,13 @@ export function isMergeCommit(
   return (commit as MergeCommit<unknown, unknown>).mergeRef !== undefined;
 }
 
-export type Commit<EditMetadata, Delta> =
+export type CommitInfo = {
+  ref: string;
+  baseRef?: string;
+  mergeRef?: string;
+};
+
+export type Commit<EditMetadata = unknown, Delta = unknown> =
   | MergeCommit<EditMetadata, Delta>
   | EditCommit<EditMetadata, Delta>;
 
@@ -109,16 +113,9 @@ export type InitEvent =
 
 export type CommitAck = {
   ref: string;
-
-  // If the remote acking this commit is authoritative, main will indicate if this
-  // commit is on the mainline or not, otherwise it will be undefined.
-  main?: boolean;
 };
 
-export type ServerCommitAck = Required<CommitAck>;
-
-export type ServerCommit<EditMetadata, Delta> = Commit<EditMetadata, Delta> &
-  ServerCommitAck;
+export type ServerCommit<EditMetadata, Delta> = Commit<EditMetadata, Delta>;
 
 export type CommitsEvent<EditMetadata, Delta, Presence> = {
   type: 'commits';
@@ -232,5 +229,3 @@ export interface Remote<EditMetadata, Delta, Presence> {
   send(event: SyncEvent<EditMetadata, Delta, Presence>): void;
   shutdown(): void | Promise<void>;
 }
-
-export type UnsubscribeFn = () => void;

--- a/packages/trimerge-sync/src/validateCommits.ts
+++ b/packages/trimerge-sync/src/validateCommits.ts
@@ -1,17 +1,17 @@
 import { asCommitRefs } from './lib/Commits';
 import type { AckCommitsEvent, Commit } from './types';
 
-export type CommitValidation<EditMetadata, Delta> = {
-  newCommits: readonly Commit<EditMetadata, Delta>[];
+export type CommitValidation<CommitMetadata, Delta> = {
+  newCommits: readonly Commit<CommitMetadata, Delta>[];
   invalidRefs: Set<string>;
   referencedCommits: Set<string>;
 };
 
-export function validateCommitOrder<EditMetadata, Delta>(
-  commits: readonly Commit<EditMetadata, Delta>[],
-): CommitValidation<EditMetadata, Delta> {
+export function validateCommitOrder<CommitMetadata, Delta>(
+  commits: readonly Commit<CommitMetadata, Delta>[],
+): CommitValidation<CommitMetadata, Delta> {
   const newCommitRefs = new Set<string>();
-  const newCommits: Commit<EditMetadata, Delta>[] = [];
+  const newCommits: Commit<CommitMetadata, Delta>[] = [];
   const referencedCommits = new Set<string>();
   const invalidRefs = new Set<string>();
   function addReferencedCommit(ref?: string) {

--- a/packages/trimerge-sync/src/validateCommits.ts
+++ b/packages/trimerge-sync/src/validateCommits.ts
@@ -25,10 +25,9 @@ export function validateCommitOrder<EditMetadata, Delta>(
     } else {
       newCommits.push(commit);
       newCommitRefs.add(commit.ref);
-      const { baseRef, mergeRef, mergeBaseRef } = asCommitRefs(commit);
+      const { baseRef, mergeRef } = asCommitRefs(commit);
       addReferencedCommit(baseRef);
       addReferencedCommit(mergeRef);
-      addReferencedCommit(mergeBaseRef);
     }
   }
   return { newCommits, invalidRefs, referencedCommits };

--- a/packages/trimerge-sync/src/validateCommits.ts
+++ b/packages/trimerge-sync/src/validateCommits.ts
@@ -1,17 +1,17 @@
 import { asCommitRefs } from './lib/Commits';
 import type { AckCommitsEvent, Commit } from './types';
 
-export type CommitValidation<CommitMetadata, Delta> = {
-  newCommits: readonly Commit<CommitMetadata, Delta>[];
+export type CommitValidation<EditMetadata, Delta> = {
+  newCommits: readonly Commit<EditMetadata, Delta>[];
   invalidRefs: Set<string>;
   referencedCommits: Set<string>;
 };
 
-export function validateCommitOrder<CommitMetadata, Delta>(
-  commits: readonly Commit<CommitMetadata, Delta>[],
-): CommitValidation<CommitMetadata, Delta> {
+export function validateCommitOrder<EditMetadata, Delta>(
+  commits: readonly Commit<EditMetadata, Delta>[],
+): CommitValidation<EditMetadata, Delta> {
   const newCommitRefs = new Set<string>();
-  const newCommits: Commit<CommitMetadata, Delta>[] = [];
+  const newCommits: Commit<EditMetadata, Delta>[] = [];
   const referencedCommits = new Set<string>();
   const invalidRefs = new Set<string>();
   function addReferencedCommit(ref?: string) {

--- a/packages/trimerge-sync/src/validateNodes.test.ts
+++ b/packages/trimerge-sync/src/validateNodes.test.ts
@@ -8,7 +8,6 @@ import { CommitRefs } from './lib/Commits';
 function simpleCommit(args: CommitRefs): Commit<unknown, unknown> {
   return {
     ...args,
-    userId: 'x',
     metadata: undefined,
   };
 }
@@ -33,7 +32,6 @@ describe('validateCommitOrder', () => {
           Object {
             "metadata": undefined,
             "ref": "1",
-            "userId": "x",
           },
         ],
         "referencedCommits": Set {},
@@ -55,19 +53,16 @@ describe('validateCommitOrder', () => {
           Object {
             "metadata": undefined,
             "ref": "1",
-            "userId": "x",
           },
           Object {
             "baseRef": "1",
             "metadata": undefined,
             "ref": "2",
-            "userId": "x",
           },
           Object {
             "baseRef": "2",
             "metadata": undefined,
             "ref": "3",
-            "userId": "x",
           },
         ],
         "referencedCommits": Set {},
@@ -89,13 +84,11 @@ describe('validateCommitOrder', () => {
             "baseRef": "1",
             "metadata": undefined,
             "ref": "2",
-            "userId": "x",
           },
           Object {
             "baseRef": "2",
             "metadata": undefined,
             "ref": "3",
-            "userId": "x",
           },
         ],
         "referencedCommits": Set {
@@ -115,7 +108,6 @@ describe('validateCommitOrder', () => {
           ref: '4',
           baseRef: '2',
           mergeRef: '3',
-          mergeBaseRef: '1',
         }),
       ]),
     ).toMatchInlineSnapshot(`
@@ -125,27 +117,22 @@ describe('validateCommitOrder', () => {
           Object {
             "metadata": undefined,
             "ref": "1",
-            "userId": "x",
           },
           Object {
             "baseRef": "1",
             "metadata": undefined,
             "ref": "2",
-            "userId": "x",
           },
           Object {
             "baseRef": "1",
             "metadata": undefined,
             "ref": "3",
-            "userId": "x",
           },
           Object {
             "baseRef": "2",
-            "mergeBaseRef": "1",
             "mergeRef": "3",
             "metadata": undefined,
             "ref": "4",
-            "userId": "x",
           },
         ],
         "referencedCommits": Set {},
@@ -161,7 +148,6 @@ describe('validateCommitOrder', () => {
           ref: '4',
           baseRef: '2',
           mergeRef: '3',
-          mergeBaseRef: '1',
         }),
       ]),
     ).toMatchInlineSnapshot(`
@@ -172,15 +158,12 @@ describe('validateCommitOrder', () => {
             "baseRef": "1",
             "metadata": undefined,
             "ref": "3",
-            "userId": "x",
           },
           Object {
             "baseRef": "2",
-            "mergeBaseRef": "1",
             "mergeRef": "3",
             "metadata": undefined,
             "ref": "4",
-            "userId": "x",
           },
         ],
         "referencedCommits": Set {


### PR DESCRIPTION
this PR does two main things:
1. Change differ.merge to manage merging all head branches
2. Combine all commit metadata into one field, and change where it’s set 

It has a number of breaking changes:
1. need to implement `differ.mergeAllBranches` (see below)
2. `differ.computeRef` no longer takes metadata (this means the ref computation will be different!)
3. `differ.migrate` now is expected to return a `{ doc, metadata }` structure (instead of `{ doc, editMetadata }`

## Differ.mergeAllBranches

Instead of `mergeHeads` being internal to `TrimergeClient`, `Differ` now provides a `mergeAllBranches` function. It is expected to try to merge all head refs on the graph.

This function (see differ.ts) is handed a `branchHeadRefs: string[]` and set of helper functions for getting commit graph info, docs, and adding individual merge commits.

To mimic the existing `mergeHeads` behavior, a `makeAutoBranchMerger` is provided. It takes a `SortRefsFn`, and `MergeDocFn` (almost identical to the existing `differ.merge` type, except that it renames `editMetadata` to `metadata`). (To fully reproduce the existing behavior, sortRefs can be defined as a string sort `(refA: string, refB: string) => refA < refB ? -1 : 1` — but something that introspects the metadata is possibly more appropriate)

## New commit metadata and behavior

The main change here is that `metadata` can contain data from various sources (app, client, local store, remote) and grouped together. The metadata is now all accessible when doing merges.

- `CommitAck` (in `AckCommitsEvent`) now can specify new metadata that is used to overwrite the existing metadata
- `editMetadata` renamed to `metadata` in various places
- commits no longer have `userId`, `clientId` embedded in them
- notion of `main` is removed (can be added in user-land)
- TrimergeClient now takes an optional `adddNewCommitMetadata(metadata, ref, userId, clientId)` that is called to add metadata (like a timestamp, clientId) to new commits (via migrate, edit, and merge)
- `trimerge-indexed-db`:
  - now takes an optional `addStoreMetadata(commit, localStoreId, commitIndex)` which can be used to add metadata before a commit is stored locally (and is sent back in the ack)
  - if the remote adds a commit we already have, replace local metadata
  - if the remote acks a commit with new metadata, replace local metadata