### PR TITLE
Add subscriber event origin

### DIFF
--- a/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
+++ b/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
@@ -1,10 +1,10 @@
 import type {
   ErrorCode,
-  OnEventFn,
   Remote,
   RemoteSyncInfo,
   SyncEvent,
 } from 'trimerge-sync';
+import { OnRemoteEventFn } from 'trimerge-sync';
 
 export class WebsocketRemote<EditMetadata, Delta, Presence>
   implements Remote<EditMetadata, Delta, Presence>
@@ -14,7 +14,7 @@ export class WebsocketRemote<EditMetadata, Delta, Presence>
   constructor(
     auth: unknown,
     { localStoreId, lastSyncCursor }: RemoteSyncInfo,
-    private readonly onEvent: OnEventFn<EditMetadata, Delta, Presence>,
+    private readonly onEvent: OnRemoteEventFn<EditMetadata, Delta, Presence>,
     websocketUrl: string,
   ) {
     console.log(`[TRIMERGE-SYNC] Connecting to ${websocketUrl}...`);

--- a/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
+++ b/packages/trimerge-sync-basic-client/src/WebsocketRemote.ts
@@ -1,10 +1,10 @@
 import type {
   ErrorCode,
+  OnRemoteEventFn,
   Remote,
   RemoteSyncInfo,
   SyncEvent,
 } from 'trimerge-sync';
-import { OnRemoteEventFn } from 'trimerge-sync';
 
 export class WebsocketRemote<EditMetadata, Delta, Presence>
   implements Remote<EditMetadata, Delta, Presence>

--- a/packages/trimerge-sync-indexed-db/src/testLib/MockRemote.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/MockRemote.ts
@@ -1,7 +1,7 @@
 import type {
   Commit,
   GetRemoteFn,
-  OnEventFn,
+  OnRemoteEventFn,
   Remote,
   RemoteSyncInfo,
   SyncEvent,
@@ -12,7 +12,7 @@ class MockRemote implements Remote<any, any, any> {
   constructor(
     private readonly userId: string,
     private readonly remoteSyncInfo: RemoteSyncInfo,
-    private readonly onEvent: OnEventFn<any, any, any>,
+    private readonly onEvent: OnRemoteEventFn<any, any, any>,
     private readonly commits?: Commit<any, any>[],
   ) {
     this.onEvent({ type: 'remote-state', connect: 'online' });

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
@@ -1,19 +1,19 @@
 import {
+  AbstractLocalStore,
   AckCommitsEvent,
   AckRefErrors,
   BroadcastEvent,
   Commit,
+  CommitAck,
+  CommitsEvent,
   GetLocalStoreFn,
   GetRemoteFn,
+  isMergeCommit,
   NetworkSettings,
-  CommitsEvent,
-  OnEventFn,
+  OnStoreEventFn,
   RemoteSyncInfo,
   ServerCommit,
-  isMergeCommit,
-  CommitAck,
 } from 'trimerge-sync';
-import { AbstractLocalStore } from 'trimerge-sync';
 import type { DBSchema, IDBPDatabase, StoreValue } from 'idb';
 import { deleteDB, openDB } from 'idb';
 import { BroadcastChannel } from 'broadcast-channel';
@@ -112,7 +112,7 @@ class IndexedDbBackend<
     private readonly docId: string,
     userId: string,
     clientId: string,
-    onEvent: OnEventFn<EditMetadata, Delta, Presence>,
+    onStoreEvent: OnStoreEventFn<EditMetadata, Delta, Presence>,
     {
       getRemote,
       networkSettings,
@@ -120,7 +120,7 @@ class IndexedDbBackend<
       localIdGenerator,
     }: IndexedDbBackendOptions<EditMetadata, Delta, Presence>,
   ) {
-    super(userId, clientId, onEvent, getRemote, networkSettings);
+    super(userId, clientId, onStoreEvent, getRemote, networkSettings);
     this.remoteId = remoteId;
     this.localIdGenerator = localIdGenerator;
     const dbName = getDatabaseName(docId);
@@ -258,7 +258,7 @@ class IndexedDbBackend<
 
     for (const commit of commits) {
       const syncId = ++syncCounter;
-      const { ref, baseRef, } = commit;
+      const { ref, baseRef } = commit;
       let mergeRef: string | undefined;
       if (isMergeCommit(commit)) {
         mergeRef = commit.mergeRef;

--- a/packages/trimerge-sync/src/AbstractLocalStore.test.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.test.ts
@@ -4,7 +4,7 @@ import {
   AckCommitsEvent,
   CommitsEvent,
   GetRemoteFn,
-  OnEventFn,
+  OnStoreEventFn,
   Remote,
   RemoteSyncInfo,
   SyncEvent,
@@ -12,7 +12,7 @@ import {
 
 class MockLocalStore extends AbstractLocalStore<unknown, unknown, unknown> {
   constructor(
-    onEvent: OnEventFn<unknown, unknown, unknown> = () => undefined,
+    onEvent: OnStoreEventFn<unknown, unknown, unknown> = () => undefined,
     getRemote?: GetRemoteFn<unknown, unknown, unknown>,
   ) {
     super('', '', onEvent, getRemote);
@@ -50,7 +50,7 @@ class MockLocalStore extends AbstractLocalStore<unknown, unknown, unknown> {
 }
 
 class MockRemote implements Remote<unknown, unknown, unknown> {
-  constructor(readonly onEvent: OnEventFn<unknown, unknown, unknown>) {}
+  constructor(readonly onEvent: OnStoreEventFn<unknown, unknown, unknown>) {}
 
   send(event: SyncEvent<unknown, unknown, unknown>): void {
     //

--- a/packages/trimerge-sync/src/AbstractLocalStore.test.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.test.ts
@@ -4,6 +4,7 @@ import {
   AckCommitsEvent,
   CommitsEvent,
   GetRemoteFn,
+  OnRemoteEventFn,
   OnStoreEventFn,
   Remote,
   RemoteSyncInfo,
@@ -50,7 +51,7 @@ class MockLocalStore extends AbstractLocalStore<unknown, unknown, unknown> {
 }
 
 class MockRemote implements Remote<unknown, unknown, unknown> {
-  constructor(readonly onEvent: OnStoreEventFn<unknown, unknown, unknown>) {}
+  constructor(readonly onEvent: OnRemoteEventFn<unknown, unknown, unknown>) {}
 
   send(event: SyncEvent<unknown, unknown, unknown>): void {
     //

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -8,7 +8,7 @@ import {
   ErrorCode,
   GetRemoteFn,
   LocalStore,
-  OnEventFn,
+  OnStoreEventFn,
   Remote,
   RemoteStateEvent,
   RemoteSyncInfo,
@@ -68,7 +68,11 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, Presence>
   protected constructor(
     protected readonly userId: string,
     protected readonly clientId: string,
-    private readonly onEvent: OnEventFn<EditMetadata, Delta, Presence>,
+    private readonly onStoreEvent: OnStoreEventFn<
+      EditMetadata,
+      Delta,
+      Presence
+    >,
     private readonly getRemote?: GetRemoteFn<EditMetadata, Delta, Presence>,
     networkSettings: Partial<NetworkSettings> = {},
   ) {
@@ -385,7 +389,7 @@ export abstract class AbstractLocalStore<EditMetadata, Delta, Presence>
   ): Promise<void> {
     if (self) {
       try {
-        this.onEvent(event);
+        this.onStoreEvent(event, remoteOrigin);
       } catch (e) {
         console.error(`[TRIMERGE-SYNC] local error handling event`, e);
         void this.shutdown();

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -49,58 +49,70 @@ describe('TrimergeClient', () => {
   it('handles event with invalid baseRef', async () => {
     const { onEvent } = makeTrimergeClient();
     expect(() =>
-      onEvent({
-        type: 'commits',
-        commits: [
-          {
-            userId: '',
-            ref: 'a',
-            baseRef: 'unknown',
-            metadata: '',
-          },
-        ],
-      }),
+      onEvent(
+        {
+          type: 'commits',
+          commits: [
+            {
+              userId: '',
+              ref: 'a',
+              baseRef: 'unknown',
+              metadata: '',
+            },
+          ],
+        },
+        false,
+      ),
     ).toThrowErrorMatchingInlineSnapshot(`"unknown baseRef unknown"`);
   });
   it('handles event with invalid mergeRef', async () => {
     const { onEvent } = makeTrimergeClient();
     expect(() =>
-      onEvent({
-        type: 'commits',
-        commits: [
-          {
-            userId: '',
-            ref: 'a',
-            mergeRef: 'unknown',
-            metadata: '',
-          },
-        ],
-      }),
+      onEvent(
+        {
+          type: 'commits',
+          commits: [
+            {
+              userId: '',
+              ref: 'a',
+              mergeRef: 'unknown',
+              metadata: '',
+            },
+          ],
+        },
+        false,
+      ),
     ).toThrowErrorMatchingInlineSnapshot(`"unknown mergeRef unknown"`);
   });
 
   it('handles internal error', async () => {
     const { onEvent, client } = makeTrimergeClient();
-    onEvent({
-      type: 'error',
-      code: 'internal',
-      reconnect: false,
-      message: 'testing fake error',
-      fatal: true,
-    });
+    onEvent(
+      {
+        type: 'error',
+        code: 'internal',
+        reconnect: false,
+        message: 'testing fake error',
+        fatal: true,
+      },
+      false,
+    );
     await timeout();
     expect(client.syncStatus.localRead).toEqual('error');
   });
 
   it('ignores other error', async () => {
     const { onEvent, client } = makeTrimergeClient();
-    onEvent({
-      type: 'error',
-      code: 'internal',
-      reconnect: false,
-      message: 'testing fake error',
-      fatal: false,
-    });
+    onEvent(
+      {
+        type: 'error',
+        code: 'internal',
+        reconnect: false,
+        message: 'testing fake error',
+        fatal: false,
+      },
+      false,
+    );
     await timeout();
     expect(client.syncStatus.localRead).toEqual('error');
   });
@@ -108,13 +120,16 @@ describe('TrimergeClient', () => {
   it('handles unknown event type', async () => {
     const { onEvent } = makeTrimergeClient();
     // This just logs a warning, added for code coverage
-    onEvent({ type: 'fake-event' } as unknown as SyncEvent<any, any, any>);
+    onEvent(
+      { type: 'fake-event' } as unknown as SyncEvent<any, any, any>,
+      false,
+    );
     await timeout();
   });
   it('fails on leader event with no leader', async () => {
     const { onEvent } = makeTrimergeClient();
     // This just logs a warning, added for code coverage
-    onEvent({ type: 'leader', clientId: '', action: 'accept' });
+    onEvent({ type: 'leader', clientId: '', action: 'accept' }, false);
     await timeout();
   });
 });

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -1,6 +1,6 @@
 import { TrimergeClient } from './TrimergeClient';
 import { timeout } from './lib/Timeout';
-import { OnEventFn, SyncEvent } from './types';
+import { OnStoreEventFn, SyncEvent } from './types';
 import { Differ } from './differ';
 import { migrate } from './testLib/MergeUtils';
 
@@ -14,9 +14,9 @@ const differ: Differ<any, any, any, any> = {
 
 function makeTrimergeClient(): {
   client: TrimergeClient<any, any, any, any, any>;
-  onEvent: OnEventFn<any, any, any>;
+  onEvent: OnStoreEventFn<any, any, any>;
 } {
-  let onEvent: OnEventFn<any, any, any> | undefined;
+  let onEvent: OnStoreEventFn<any, any, any> | undefined;
   const client = new TrimergeClient(
     '',
     '',

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -154,9 +154,7 @@ export class TrimergeClient<
 
       case 'client-leave':
         this.clientMap.delete(getFullId(event.userId, event.clientId));
-        this.emitClientListChange({
-          origin,
-        });
+        this.emitClientListChange({ origin });
         break;
 
       case 'client-join':
@@ -166,7 +164,6 @@ export class TrimergeClient<
 
       case 'remote-state':
         // TODO: remove remote clients as applicable?
-        this.emitClientListChange({ origin: 'remote' });
         const changes: Partial<SyncStatus> = {};
         if (event.connect) {
           changes.remoteConnect = event.connect;

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -220,10 +220,12 @@ Array [
   it('sends presence information correctly', async () => {
     const store = newStore();
     const client1 = makeClient('a', store);
-    const client2 = makeClient('b', store);
     const client1Sub = jest.fn();
-
     const client1Unsub = client1.subscribeClientList(client1Sub);
+
+    const client2 = makeClient('b', store);
+    const client2Sub = jest.fn();
+    const client2Unsub = client2.subscribeClientList(client2Sub);
 
     // Initial values
     expect(client1.clients).toEqual([
@@ -246,6 +248,19 @@ Array [
         [
           {
             userId: 'a',
+            self: true,
+            clientId: 'test',
+          },
+        ],
+        { origin: 'subscribe' },
+      ],
+    ]);
+
+    expect(client2Sub.mock.calls).toEqual([
+      [
+        [
+          {
+            userId: 'b',
             self: true,
             clientId: 'test',
           },
@@ -325,7 +340,7 @@ Array [
       },
     ],
     Object {
-      "origin": "self",
+      "origin": "local",
     },
   ],
   Array [
@@ -345,12 +360,71 @@ Array [
       },
     ],
     Object {
-      "origin": "self",
+      "origin": "local",
+    },
+  ],
+]
+`);
+    expect(client2Sub.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    Array [
+      Object {
+        "clientId": "test",
+        "presence": undefined,
+        "ref": undefined,
+        "self": true,
+        "userId": "b",
+      },
+    ],
+    Object {
+      "origin": "subscribe",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "test",
+        "presence": undefined,
+        "ref": undefined,
+        "self": true,
+        "userId": "b",
+      },
+      Object {
+        "clientId": "test",
+        "presence": undefined,
+        "ref": undefined,
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "local",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "test",
+        "presence": undefined,
+        "ref": undefined,
+        "self": true,
+        "userId": "b",
+      },
+      Object {
+        "clientId": "test",
+        "presence": undefined,
+        "ref": undefined,
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "local",
     },
   ],
 ]
 `);
     client1Unsub();
+    client2Unsub();
   });
 
   it('handles client-leave', async () => {

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -128,12 +128,15 @@ Array [
     await timeout();
 
     expect(onStateChange.mock.calls).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          undefined,
-        ],
-      ]
-    `);
+Array [
+  Array [
+    undefined,
+    Object {
+      "origin": "subscribe",
+    },
+  ],
+]
+`);
     unsub();
   });
   it('tracks presence', async () => {
@@ -157,6 +160,9 @@ Array [
         "userId": "a",
       },
     ],
+    Object {
+      "origin": "self",
+    },
   ],
 ]
 `);
@@ -244,6 +250,7 @@ Array [
             clientId: 'test',
           },
         ],
+        { origin: 'subscribe' },
       ],
     ]);
 
@@ -297,6 +304,9 @@ Array [
         "userId": "a",
       },
     ],
+    Object {
+      "origin": "subscribe",
+    },
   ],
   Array [
     Array [
@@ -314,6 +324,9 @@ Array [
         "userId": "b",
       },
     ],
+    Object {
+      "origin": "self",
+    },
   ],
   Array [
     Array [
@@ -331,6 +344,9 @@ Array [
         "userId": "b",
       },
     ],
+    Object {
+      "origin": "self",
+    },
   ],
 ]
 `);
@@ -652,11 +668,11 @@ Array [
 `);
 
     expect(subscribeFn.mock.calls).toEqual([
-      [undefined],
-      [{}],
-      [{ hello: 'world' }],
-      [{ hello: 'vorld' }],
-      [{ hello: 'there' }],
+      [undefined, { origin: 'subscribe' }],
+      [{}, { origin: 'self' }],
+      [{ hello: 'world' }, { origin: 'self' }],
+      [{ hello: 'vorld' }, { origin: 'self' }],
+      [{ hello: 'there' }, { origin: 'self' }],
     ]);
   });
 

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -1025,6 +1025,12 @@ Array [
     client1.subscribeSyncStatus((state) => syncUpdates1.push(state));
     client2.subscribeSyncStatus((state) => syncUpdates2.push(state));
 
+    const client1ListSub = jest.fn();
+    const client2ListSub = jest.fn();
+
+    client1.subscribeClientList(client1ListSub);
+    client2.subscribeClientList(client2ListSub);
+
     client1.updateDoc({}, 'initialize');
     client1.updateDoc({ hello: 'world' }, 'add hello');
     client1.updateDoc({ hello: 'vorld' }, 'change hello');
@@ -1346,6 +1352,314 @@ Array [
     "remoteRead": "offline",
     "remoteSave": "ready",
   },
+]
+`);
+    expect(client1ListSub.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": undefined,
+        "self": true,
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "subscribe",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "DuQe--Vh",
+        "self": true,
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "self",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "DuQe--Vh",
+        "self": true,
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "self",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "u0wBto6f",
+        "self": true,
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "self",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "u0wBto6f",
+        "self": true,
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "self",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "YYUSBDXS",
+        "self": true,
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "self",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "YYUSBDXS",
+        "self": true,
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "self",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "YYUSBDXS",
+        "self": true,
+        "userId": "a",
+      },
+      Object {
+        "clientId": "b",
+        "presence": undefined,
+        "ref": undefined,
+        "userId": "b",
+      },
+    ],
+    Object {
+      "origin": "remote",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "YYUSBDXS",
+        "self": true,
+        "userId": "a",
+      },
+      Object {
+        "clientId": "b",
+        "presence": undefined,
+        "ref": "YFIigfVr",
+        "userId": "b",
+      },
+    ],
+    Object {
+      "origin": "remote",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "YYUSBDXS",
+        "self": true,
+        "userId": "a",
+      },
+      Object {
+        "clientId": "b",
+        "presence": undefined,
+        "ref": "3duBmH5E",
+        "userId": "b",
+      },
+    ],
+    Object {
+      "origin": "remote",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "YYUSBDXS",
+        "self": true,
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "remote",
+    },
+  ],
+]
+`);
+    expect(client2ListSub.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    Array [
+      Object {
+        "clientId": "b",
+        "presence": undefined,
+        "ref": undefined,
+        "self": true,
+        "userId": "b",
+      },
+    ],
+    Object {
+      "origin": "subscribe",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "b",
+        "presence": undefined,
+        "ref": undefined,
+        "self": true,
+        "userId": "b",
+      },
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "YYUSBDXS",
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "remote",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "b",
+        "presence": undefined,
+        "ref": "YFIigfVr",
+        "self": true,
+        "userId": "b",
+      },
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "YYUSBDXS",
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "self",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "b",
+        "presence": undefined,
+        "ref": "YFIigfVr",
+        "self": true,
+        "userId": "b",
+      },
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "YYUSBDXS",
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "self",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "b",
+        "presence": undefined,
+        "ref": "3duBmH5E",
+        "self": true,
+        "userId": "b",
+      },
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "YYUSBDXS",
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "self",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "b",
+        "presence": undefined,
+        "ref": "3duBmH5E",
+        "self": true,
+        "userId": "b",
+      },
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "YYUSBDXS",
+        "userId": "a",
+      },
+    ],
+    Object {
+      "origin": "self",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "b",
+        "presence": undefined,
+        "ref": "3duBmH5E",
+        "self": true,
+        "userId": "b",
+      },
+    ],
+    Object {
+      "origin": "remote",
+    },
+  ],
 ]
 `);
   });

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -337,6 +337,8 @@ Array [
 
     const syncUpdates1: SyncStatus[] = [];
     client1.subscribeSyncStatus((state) => syncUpdates1.push(state));
+    const client1Sub = jest.fn();
+    client1.subscribeClientList(client1Sub);
 
     client1.updateDoc({}, 'initialize');
     client1.updateDoc({ hello: 'world' }, 'add hello');
@@ -347,6 +349,8 @@ Array [
 
     const syncUpdates2: SyncStatus[] = [];
     client2.subscribeSyncStatus((state) => syncUpdates2.push(state));
+    const client2Sub = jest.fn();
+    client2.subscribeClientList(client2Sub);
 
     await timeout();
 
@@ -475,6 +479,138 @@ Array [
     "remoteRead": "ready",
     "remoteSave": "ready",
   },
+]
+`);
+    expect(client1Sub.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": undefined,
+        "self": true,
+        "userId": "test",
+      },
+    ],
+    Object {
+      "origin": "subscribe",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "DuQe--Vh",
+        "self": true,
+        "userId": "test",
+      },
+    ],
+    Object {
+      "origin": "self",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "DuQe--Vh",
+        "self": true,
+        "userId": "test",
+      },
+    ],
+    Object {
+      "origin": "self",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "u0wBto6f",
+        "self": true,
+        "userId": "test",
+      },
+    ],
+    Object {
+      "origin": "self",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "u0wBto6f",
+        "self": true,
+        "userId": "test",
+      },
+    ],
+    Object {
+      "origin": "self",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "u0wBto6f",
+        "self": true,
+        "userId": "test",
+      },
+      Object {
+        "clientId": "b",
+        "presence": undefined,
+        "ref": undefined,
+        "userId": "test",
+      },
+    ],
+    Object {
+      "origin": "local",
+    },
+  ],
+]
+`);
+    expect(client2Sub.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    Array [
+      Object {
+        "clientId": "b",
+        "presence": undefined,
+        "ref": undefined,
+        "self": true,
+        "userId": "test",
+      },
+    ],
+    Object {
+      "origin": "subscribe",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "b",
+        "presence": undefined,
+        "ref": undefined,
+        "self": true,
+        "userId": "test",
+      },
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "u0wBto6f",
+        "userId": "test",
+      },
+    ],
+    Object {
+      "origin": "local",
+    },
+  ],
 ]
 `);
   });

--- a/packages/trimerge-sync/src/lib/SubscriberList.test.ts
+++ b/packages/trimerge-sync/src/lib/SubscriberList.test.ts
@@ -5,32 +5,38 @@ describe('SubscriberList', () => {
     let value = 0;
     const s = new SubscriberList(() => value);
     const onChange = jest.fn();
-    const unsub = s.subscribe(onChange);
-    expect(onChange.mock.calls).toEqual([[0]]);
-    s.emitChange(); // no change
+    const unsub = s.subscribe(onChange, '0');
+    expect(onChange.mock.calls).toEqual([[0, '0']]);
+    s.emitChange('1'); // no change
     value = 1;
-    s.emitChange(); // change
-    s.emitChange(); // no change
+    s.emitChange('2'); // change
+    s.emitChange('3'); // no change
     unsub();
     value = 2;
-    s.emitChange(); // change, but no listeners
-    expect(onChange.mock.calls).toEqual([[0], [1]]);
+    s.emitChange('4'); // change, but no listeners
+    expect(onChange.mock.calls).toEqual([
+      [0, '0'],
+      [1, '2'],
+    ]);
   });
   it('two listeners subscribes', () => {
     let value = 0;
     const s = new SubscriberList(() => value);
     const onChange1 = jest.fn();
-    const unsub1 = s.subscribe(onChange1);
-    s.emitChange(); // no change
+    const unsub1 = s.subscribe(onChange1, '0');
+    s.emitChange('1'); // no change
     value = 1;
     const onChange2 = jest.fn();
-    const unsub2 = s.subscribe(onChange2);
-    expect(onChange1.mock.calls).toEqual([[0]]);
-    expect(onChange2.mock.calls).toEqual([[1]]);
-    s.emitChange(); // change
+    const unsub2 = s.subscribe(onChange2, '2');
+    expect(onChange1.mock.calls).toEqual([[0, '0']]);
+    expect(onChange2.mock.calls).toEqual([[1, '2']]);
+    s.emitChange('3'); // change
     unsub1();
     unsub2();
-    expect(onChange1.mock.calls).toEqual([[0], [1]]);
-    expect(onChange2.mock.calls).toEqual([[1]]);
+    expect(onChange1.mock.calls).toEqual([
+      [0, '0'],
+      [1, '3'],
+    ]);
+    expect(onChange2.mock.calls).toEqual([[1, '2']]);
   });
 });

--- a/packages/trimerge-sync/src/lib/SubscriberList.ts
+++ b/packages/trimerge-sync/src/lib/SubscriberList.ts
@@ -1,28 +1,28 @@
-export type OnChangeFn<T> = (state: T) => void;
+export type OnChangeFn<T, E> = (state: T, event: E) => void;
 
-export class SubscriberList<T> {
-  private readonly map = new Map<OnChangeFn<T>, T>();
+export class SubscriberList<T, E> {
+  private readonly map = new Map<OnChangeFn<T, E>, T>();
 
   constructor(
     private readonly get: () => T,
     private readonly equalFn: (a: T, b: T) => boolean = (a, b) => a === b,
   ) {}
 
-  subscribe(onChange: OnChangeFn<T>) {
+  subscribe(onChange: OnChangeFn<T, E>, event: E) {
     const state = this.get();
     this.map.set(onChange, state);
-    onChange(state);
+    onChange(state, event);
     return () => {
       this.map.delete(onChange);
     };
   }
 
-  emitChange() {
+  emitChange(event: E) {
     const state = this.get();
     const { equalFn: eq, map } = this;
     for (const [subscriber, lastState] of map.entries()) {
       if (!eq(state, lastState)) {
-        subscriber(state);
+        subscriber(state, event);
         map.set(subscriber, state);
       }
     }

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
@@ -40,11 +40,13 @@ Array [
       "syncId": "0",
       "type": "commits",
     },
+    false,
   ],
   Array [
     Object {
       "type": "ready",
     },
+    false,
   ],
   Array [
     Object {
@@ -53,6 +55,7 @@ Array [
       "save": "pending",
       "type": "remote-state",
     },
+    false,
   ],
   Array [
     Object {
@@ -64,6 +67,7 @@ Array [
       "syncId": "1",
       "type": "ack",
     },
+    false,
   ],
   Array [
     Object {
@@ -72,6 +76,7 @@ Array [
       "save": "saving",
       "type": "remote-state",
     },
+    false,
   ],
 ]
 `);
@@ -101,11 +106,13 @@ Array [
       "syncId": "0",
       "type": "commits",
     },
+    false,
   ],
   Array [
     Object {
       "type": "ready",
     },
+    false,
   ],
   Array [
     Object {
@@ -114,6 +121,7 @@ Array [
       "save": "pending",
       "type": "remote-state",
     },
+    false,
   ],
   Array [
     Object {
@@ -125,6 +133,7 @@ Array [
       "syncId": "1",
       "type": "ack",
     },
+    false,
   ],
   Array [
     Object {
@@ -133,6 +142,7 @@ Array [
       "save": "saving",
       "type": "remote-state",
     },
+    false,
   ],
 ]
 `);

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
@@ -5,7 +5,7 @@ import {
   Commit,
   GetRemoteFn,
   CommitsEvent,
-  OnEventFn,
+  OnStoreEventFn,
   RemoteSyncInfo,
   CommitAck,
 } from '../types';
@@ -25,7 +25,7 @@ export class MemoryLocalStore<
     private readonly store: MemoryStore<EditMetadata, Delta, Presence>,
     userId: string,
     clientId: string,
-    onEvent: OnEventFn<EditMetadata, Delta, Presence>,
+    onEvent: OnStoreEventFn<EditMetadata, Delta, Presence>,
     getRemote?: GetRemoteFn<EditMetadata, Delta, Presence>,
   ) {
     super(userId, clientId, onEvent, getRemote, {

--- a/packages/trimerge-sync/src/testLib/MemoryRemote.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryRemote.ts
@@ -3,7 +3,7 @@ import {
   Commit,
   ErrorCode,
   CommitsEvent,
-  OnEventFn,
+  OnStoreEventFn,
   Remote,
   RemoteSyncInfo,
   SyncEvent,
@@ -22,7 +22,7 @@ export class MemoryRemote<EditMetadata, Delta, Presence>
     private readonly store: MemoryStore<EditMetadata, Delta, Presence>,
     private readonly userId: string,
     { lastSyncCursor, localStoreId }: RemoteSyncInfo,
-    private readonly onEvent: OnEventFn<EditMetadata, Delta, Presence>,
+    private readonly onEvent: OnStoreEventFn<EditMetadata, Delta, Presence>,
   ) {
     this.clientStoreId = localStoreId;
     this.sendInitialEvents(lastSyncCursor).catch(

--- a/packages/trimerge-sync/src/testLib/MemoryRemote.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryRemote.ts
@@ -1,9 +1,9 @@
 import {
   AckCommitsEvent,
   Commit,
-  ErrorCode,
   CommitsEvent,
-  OnStoreEventFn,
+  ErrorCode,
+  OnRemoteEventFn,
   Remote,
   RemoteSyncInfo,
   SyncEvent,
@@ -22,7 +22,7 @@ export class MemoryRemote<EditMetadata, Delta, Presence>
     private readonly store: MemoryStore<EditMetadata, Delta, Presence>,
     private readonly userId: string,
     { lastSyncCursor, localStoreId }: RemoteSyncInfo,
-    private readonly onEvent: OnStoreEventFn<EditMetadata, Delta, Presence>,
+    private readonly onEvent: OnRemoteEventFn<EditMetadata, Delta, Presence>,
   ) {
     this.clientStoreId = localStoreId;
     this.sendInitialEvents(lastSyncCursor).catch(

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -196,14 +196,19 @@ export type SyncEvent<EditMetadata, Delta, Presence> = Readonly<
   | ErrorEvent
 >;
 
-export type OnEventFn<EditMetadata, Delta, Presence> = (
+export type OnStoreEventFn<EditMetadata, Delta, Presence> = (
+  event: SyncEvent<EditMetadata, Delta, Presence>,
+  remoteOrigin: boolean,
+) => void;
+
+export type OnRemoteEventFn<EditMetadata, Delta, Presence> = (
   event: SyncEvent<EditMetadata, Delta, Presence>,
 ) => void;
 
 export type GetLocalStoreFn<EditMetadata, Delta, Presence> = (
   userId: string,
   clientId: string,
-  onEvent: OnEventFn<EditMetadata, Delta, Presence>,
+  onEvent: OnStoreEventFn<EditMetadata, Delta, Presence>,
 ) => LocalStore<EditMetadata, Delta, Presence>;
 
 export type RemoteSyncInfo = {
@@ -214,7 +219,7 @@ export type RemoteSyncInfo = {
 export type GetRemoteFn<EditMetadata, Delta, Presence> = (
   userId: string,
   remoteSyncInfo: RemoteSyncInfo,
-  onEvent: OnEventFn<EditMetadata, Delta, Presence>,
+  onRemoteEvent: OnRemoteEventFn<EditMetadata, Delta, Presence>,
 ) =>
   | Remote<EditMetadata, Delta, Presence>
   | Promise<Remote<EditMetadata, Delta, Presence>>;


### PR DESCRIPTION
- various subscribers (doc, syncStatus, clientList) now will receive a second param with the event origin
- split out OnEventFn into OnStoreEventFn and OnRemoteEventFn