### PR TITLE
Set lastSyncCursor on the commit if it has been supplied

### DIFF
--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
@@ -269,7 +269,11 @@ class IndexedDbBackend<
             if (await commitExistsAlready(commit)) {
               return;
             }
-            await commitsDb.add({ syncId, remoteSyncId: '', ...commit });
+            await commitsDb.add({
+              syncId,
+              remoteSyncId: lastSyncCursor ?? '',
+              ...commit,
+            });
             const ackedCommit = await commitsDb.get(commit.ref);
             if (ackedCommit) {
               refs.set(ref, ackedCommit.main);


### PR DESCRIPTION
We weren't correctly recording remote Sync Id on commits that were coming from the server. This PR just uses lastSyncId when writing the commits to the local store if it's available.

## Tests

 - [x] ci
 - [x] confirmed that commits from remote have a correctly labelled remoteSyncId now 