### PR TITLE
[live collab] don't attach store info if the commit is remote

### DIFF
--- a/packages/example-broadcast-channel/package.json
+++ b/packages/example-broadcast-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-example-broadcast-channel",
-  "version": "0.14.0",
+  "version": "v0.15.0-test.4",
   "private": true,
   "dependencies": {
     "classnames": "2.3.1",
@@ -12,10 +12,10 @@
     "react-scripts": "4.0.3",
     "textarea-caret": "^3.1.0",
     "trimerge": "1.3.0-alpha.15",
-    "trimerge-sync": "0.14.0",
-    "trimerge-sync-basic-client": "0.14.0",
-    "trimerge-sync-hash": "0.14.0",
-    "trimerge-sync-indexed-db": "0.14.0"
+    "trimerge-sync": "v0.15.0-test.4",
+    "trimerge-sync-basic-client": "v0.15.0-test.4",
+    "trimerge-sync-hash": "v0.15.0-test.4",
+    "trimerge-sync-indexed-db": "v0.15.0-test.4"
   },
   "scripts": {
     "start": "cross-env SKIP_PREFLIGHT_CHECK=true FAST_REFRESH=false react-scripts start",
@@ -25,9 +25,15 @@
     "test:update-snapshots": "cross-env SKIP_PREFLIGHT_CHECK=true react-scripts test --updateSnapshot --passWithNoTests",
     "eject": "react-scripts eject"
   },
-  "eslintConfig": { "extends": "react-app" },
+  "eslintConfig": {
+    "extends": "react-app"
+  },
   "browserslist": {
-    "production": [">0.2%", "not dead", "not op_mini all"],
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",

--- a/packages/example-broadcast-channel/package.json
+++ b/packages/example-broadcast-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-example-broadcast-channel",
-  "version": "v0.15.0-test.4",
+  "version": "0.15.0-test.4",
   "private": true,
   "dependencies": {
     "classnames": "2.3.1",
@@ -12,10 +12,10 @@
     "react-scripts": "4.0.3",
     "textarea-caret": "^3.1.0",
     "trimerge": "1.3.0-alpha.15",
-    "trimerge-sync": "v0.15.0-test.4",
-    "trimerge-sync-basic-client": "v0.15.0-test.4",
-    "trimerge-sync-hash": "v0.15.0-test.4",
-    "trimerge-sync-indexed-db": "v0.15.0-test.4"
+    "trimerge-sync": "0.15.0-test.4",
+    "trimerge-sync-basic-client": "0.15.0-test.4",
+    "trimerge-sync-hash": "0.15.0-test.4",
+    "trimerge-sync-indexed-db": "0.15.0-test.4"
   },
   "scripts": {
     "start": "cross-env SKIP_PREFLIGHT_CHECK=true FAST_REFRESH=false react-scripts start",

--- a/packages/trimerge-sync-basic-client/package.json
+++ b/packages/trimerge-sync-basic-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-client",
-  "version": "0.14.0",
+  "version": "v0.15.0-test.4",
   "description": "basic websocket client for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -19,23 +19,34 @@
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {},
-  "files": ["dist/**/*", "src/**/*"],
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.0",
     "@rollup/plugin-node-resolve": "13.0.6",
     "jest": "27.0.6",
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.14.0",
+    "trimerge-sync": "v0.15.0-test.4",
     "ts-node": "^10.3.0",
     "ts-node-dev": "^1.1.8",
     "typescript": "4.4.4"
@@ -43,6 +54,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }

--- a/packages/trimerge-sync-basic-client/package.json
+++ b/packages/trimerge-sync-basic-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-client",
-  "version": "v0.15.0-test.4",
+  "version": "0.15.0-test.4",
   "description": "basic websocket client for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -46,7 +46,7 @@
     "jest": "27.0.6",
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "v0.15.0-test.4",
+    "trimerge-sync": "0.15.0-test.4",
     "ts-node": "^10.3.0",
     "ts-node-dev": "^1.1.8",
     "typescript": "4.4.4"

--- a/packages/trimerge-sync-basic-server/package.json
+++ b/packages/trimerge-sync-basic-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-server",
-  "version": "v0.15.0-test.4",
+  "version": "0.15.0-test.4",
   "description": "basic websocket server for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -37,7 +37,7 @@
   "dependencies": {
     "@types/ws": "^8.2.0",
     "fs-extra": "^10.0.0",
-    "trimerge-sync": "v0.15.0-test.4",
+    "trimerge-sync": "0.15.0-test.4",
     "ws": "^8.2.3"
   },
   "files": [
@@ -56,7 +56,7 @@
     "jest": "27.0.6",
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "v0.15.0-test.4",
+    "trimerge-sync": "0.15.0-test.4",
     "ts-node": "^10.3.0",
     "ts-node-dev": "^1.1.8",
     "typescript": "4.4.4"

--- a/packages/trimerge-sync-basic-server/package.json
+++ b/packages/trimerge-sync-basic-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-server",
-  "version": "0.14.0",
+  "version": "v0.15.0-test.4",
   "description": "basic websocket server for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -18,22 +18,35 @@
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {
     "@types/ws": "^8.2.0",
     "fs-extra": "^10.0.0",
-    "trimerge-sync": "0.14.0",
+    "trimerge-sync": "v0.15.0-test.4",
     "ws": "^8.2.3"
   },
-  "files": ["dist/**/*", "src/**/*"],
-  "peerDependencies": { "better-sqlite3": "^7.4.1" },
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
+  "peerDependencies": {
+    "better-sqlite3": "^7.4.1"
+  },
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.0",
     "@rollup/plugin-node-resolve": "13.0.6",
@@ -43,7 +56,7 @@
     "jest": "27.0.6",
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.14.0",
+    "trimerge-sync": "v0.15.0-test.4",
     "ts-node": "^10.3.0",
     "ts-node-dev": "^1.1.8",
     "typescript": "4.4.4"
@@ -51,6 +64,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }

--- a/packages/trimerge-sync-hash/package.json
+++ b/packages/trimerge-sync-hash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-hash",
-  "version": "0.14.0",
+  "version": "v0.15.0-test.4",
   "description": "SHA-256 based hash generator for use with trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -19,16 +19,29 @@
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
-  "dependencies": { "jssha": "^3.2.0" },
-  "files": ["dist/**/*", "src/**/*"],
+  "dependencies": {
+    "jssha": "^3.2.0"
+  },
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.0",
     "@rollup/plugin-node-resolve": "13.0.6",
@@ -40,6 +53,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }

--- a/packages/trimerge-sync-hash/package.json
+++ b/packages/trimerge-sync-hash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-hash",
-  "version": "v0.15.0-test.4",
+  "version": "0.15.0-test.4",
   "description": "SHA-256 based hash generator for use with trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",

--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-indexed-db",
-  "version": "0.14.0",
+  "version": "v0.15.0-test.4",
   "description": "indexed-db backend for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -19,17 +19,33 @@
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
-  "dependencies": { "broadcast-channel": "^4.2.0", "idb": "6.1.5" },
-  "peerDependencies": { "trimerge-sync": "0.14.0" },
-  "files": ["dist/**/*", "src/**/*"],
+  "dependencies": {
+    "broadcast-channel": "^4.2.0",
+    "idb": "6.1.5"
+  },
+  "peerDependencies": {
+    "trimerge-sync": "v0.15.0-test.4"
+  },
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.0",
     "@rollup/plugin-node-resolve": "13.0.6",
@@ -40,13 +56,19 @@
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
-    "trimerge-sync": "0.14.0",
-    "trimerge-sync-hash": "0.14.0",
+    "trimerge-sync": "v0.15.0-test.4",
+    "trimerge-sync-hash": "v0.15.0-test.4",
     "typescript": "4.4.4"
   },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }

--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-indexed-db",
-  "version": "v0.15.0-test.4",
+  "version": "0.15.0-test.4",
   "description": "indexed-db backend for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -40,7 +40,7 @@
     "idb": "6.1.5"
   },
   "peerDependencies": {
-    "trimerge-sync": "v0.15.0-test.4"
+    "trimerge-sync": "0.15.0-test.4"
   },
   "files": [
     "dist/**/*",
@@ -56,8 +56,8 @@
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
-    "trimerge-sync": "v0.15.0-test.4",
-    "trimerge-sync-hash": "v0.15.0-test.4",
+    "trimerge-sync": "0.15.0-test.4",
+    "trimerge-sync-hash": "0.15.0-test.4",
     "typescript": "4.4.4"
   },
   "jest": {

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
@@ -318,7 +318,8 @@ class IndexedDbBackend<
               return;
             }
 
-            if (this.addStoreMetadata) {
+            // we should only be attaching store metadata to local commits.
+            if (this.addStoreMetadata && !remoteSyncId) {
               const localStoreId = await this.localStoreId;
               commit.metadata = this.addStoreMetadata(
                 commit,

--- a/packages/trimerge-sync/package.json
+++ b/packages/trimerge-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync",
-  "version": "v0.15.0-test.4",
+  "version": "0.15.0-test.4",
   "description": "distributed data sync using trimerge",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -55,7 +55,7 @@
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
-    "trimerge-sync-hash": "v0.15.0-test.4",
+    "trimerge-sync-hash": "0.15.0-test.4",
     "typescript": "4.4.4"
   },
   "jest": {

--- a/packages/trimerge-sync/package.json
+++ b/packages/trimerge-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync",
-  "version": "0.14.0",
+  "version": "v0.15.0-test.4",
   "description": "distributed data sync using trimerge",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -15,22 +15,35 @@
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "rm -rf dist/ && npm run build"
   },
-  "engines": { "node": ">=6" },
+  "engines": {
+    "node": ">=6"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {},
   "peerDependencies": {},
-  "files": ["dist/**/*", "src/**/*"],
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.0",
     "@rollup/plugin-node-resolve": "13.0.6",
@@ -42,12 +55,18 @@
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
-    "trimerge-sync-hash": "0.14.0",
+    "trimerge-sync-hash": "v0.15.0-test.4",
     "typescript": "4.4.4"
   },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
`addStoreSetadata()` is a hook to add metadata for locally generated commits about the original store that stored them before they are sent to the server. It would be confusing, then, for us to attach client info to a commit that had already been acked by the server. This pr only calls add store metadata in the case that the commit doesn't have a remoteSyncId.