### PR TITLE
Sortrefs used throughout mergeHeads to always prefer lowest ref

### DIFF
--- a/packages/trimerge-sync/src/merge-heads.test.ts
+++ b/packages/trimerge-sync/src/merge-heads.test.ts
@@ -4,7 +4,7 @@ import { CommitInfo } from './types';
 
 const commitMap: Map<string, CommitInfo> = new Map();
 const sortMap: Map<string, number> = new Map();
-const basicSort: SortRefsFn = (a, b) => {
+const insertSequenceSort: SortRefsFn = (a, b) => {
   const aIdx = sortMap.get(a);
   if (aIdx === undefined) {
     throw new Error('unknown ref ' + a);
@@ -15,7 +15,7 @@ const basicSort: SortRefsFn = (a, b) => {
   }
   return aIdx - bIdx;
 };
-const reverseSort: SortRefsFn = (a, b) => (-1 * basicSort(a, b));
+const reverseSort: SortRefsFn = (a, b) => (-1 * insertSequenceSort(a, b));
 const basicMerge: MergeCommitsFn = (baseRef, leftRef, rightRef) => {
   const ref = `(${baseRef ?? '-'}:${leftRef}+${rightRef})`
   sortMap.set(ref, sortMap.size);
@@ -52,7 +52,7 @@ describe('mergeHeads()', () => {
     ]);
     const mergeFn = jest.fn(basicMerge);
     const heads = ['foo3', 'bar3'];
-    expect(mergeHeads(heads, basicSort, getCommit, mergeFn)).toEqual(
+    expect(mergeHeads(heads, insertSequenceSort, getCommit, mergeFn)).toEqual(
       '(-:foo3+bar3)',
     );
     expect(mergeFn.mock.calls).toEqual([[undefined, 'foo3', 'bar3', 4]]);
@@ -69,7 +69,7 @@ describe('mergeHeads()', () => {
     ]);
     const mergeFn = jest.fn(basicMerge);
     const heads = ['foo', 'bar', 'baz'];
-    expect(mergeHeads(heads, basicSort, getCommit, mergeFn),).toEqual(
+    expect(mergeHeads(heads, insertSequenceSort, getCommit, mergeFn),).toEqual(
       '(-:baz+(-:foo+bar))',
     );
     expect(mergeFn.mock.calls).toEqual([
@@ -90,7 +90,7 @@ describe('mergeHeads()', () => {
     ]);
     const mergeFn = jest.fn(basicMerge);
     const heads = ['fooA', 'fooB', 'foo'];
-    expect(mergeHeads(heads, basicSort, getCommit, mergeFn)).toEqual(
+    expect(mergeHeads(heads, insertSequenceSort, getCommit, mergeFn)).toEqual(
       '(-:foo+(bar:fooA+fooB))',
     );
     expect(mergeFn.mock.calls).toEqual([
@@ -110,7 +110,7 @@ describe('mergeHeads()', () => {
     ]);
     const mergeFn = jest.fn(basicMerge);
     const heads = ['foo', 'bar'];
-    expect(mergeHeads(heads, basicSort, getCommit, mergeFn)).toEqual(
+    expect(mergeHeads(heads, insertSequenceSort, getCommit, mergeFn)).toEqual(
       '(root:foo+bar)',
     );
     expect(mergeFn.mock.calls).toEqual([['root', 'foo', 'bar', 1]]);
@@ -126,7 +126,7 @@ describe('mergeHeads()', () => {
     ]);
     const mergeFn = jest.fn(basicMerge);
     expect(() =>
-      mergeHeads(['root', 'foo'], basicSort, getCommit, mergeFn),
+      mergeHeads(['root', 'foo'], insertSequenceSort, getCommit, mergeFn),
     ).toThrowErrorMatchingInlineSnapshot(
       `"unexpected merge with base === left/right"`,
     );
@@ -138,7 +138,7 @@ describe('mergeHeads()', () => {
       { ref: 'foo', baseRef: 'root' },
     ]);
     const mergeFn = jest.fn(basicMerge);
-    expect(mergeHeads([], basicSort, getCommit, mergeFn)).toBeUndefined();
+    expect(mergeHeads([], insertSequenceSort, getCommit, mergeFn)).toBeUndefined();
   });
 
   it('find common parent on v split', () => {
@@ -153,7 +153,7 @@ describe('mergeHeads()', () => {
     ]);
     const mergeFn = jest.fn(basicMerge);
     const heads = ['foo2', 'bar2'];
-    expect(mergeHeads(heads, basicSort, getCommit, mergeFn)).toEqual(
+    expect(mergeHeads(heads, insertSequenceSort, getCommit, mergeFn)).toEqual(
       '(root:foo2+bar2)',
     );
     expect(mergeFn.mock.calls).toEqual([['root', 'foo2', 'bar2', 3]]);
@@ -169,7 +169,7 @@ describe('mergeHeads()', () => {
     const getCommit = makeGetCommitFn([root, foo, bar, baz]);
     const mergeFn = jest.fn(basicMerge);
     const heads = ['foo', 'bar', 'baz'];
-    expect(mergeHeads(heads, basicSort, getCommit, mergeFn)).toEqual(
+    expect(mergeHeads(heads, insertSequenceSort, getCommit, mergeFn)).toEqual(
       '(root:baz+(root:foo+bar))',
     );
     expect(mergeFn.mock.calls).toEqual([
@@ -190,7 +190,7 @@ describe('mergeHeads()', () => {
     ]);
     const mergeFn = jest.fn(basicMerge);
     const heads = ['foo', 'bar', 'baz1'];
-    expect(mergeHeads(heads, basicSort, getCommit, mergeFn)).toEqual(
+    expect(mergeHeads(heads, insertSequenceSort, getCommit, mergeFn)).toEqual(
       '(root:baz1+(root:foo+bar))',
     );
     expect(mergeFn.mock.calls).toEqual([
@@ -212,7 +212,7 @@ describe('mergeHeads()', () => {
     ]);
     const mergeFn = jest.fn(basicMerge);
     const heads = ['foo', 'bar1', 'baz'];
-    expect(mergeHeads(heads, basicSort, getCommit, mergeFn)).toEqual(
+    expect(mergeHeads(heads, insertSequenceSort, getCommit, mergeFn)).toEqual(
       '(root:foo+(bar:bar1+baz))',
     );
     expect(mergeFn.mock.calls).toEqual([

--- a/packages/trimerge-sync/src/merge-heads.test.ts
+++ b/packages/trimerge-sync/src/merge-heads.test.ts
@@ -223,4 +223,18 @@ describe('mergeHeads()', () => {
       '(root:(bar:baz+bar1)+foo)',
     );
   });
+
+  it('bad sort is still deterministic', () => {
+    const getCommit = makeGetCommitFn([
+      { ref: 'root' },
+      { ref: 'foo', baseRef: 'root' },
+      { ref: 'bar', baseRef: 'root' },
+    ]);
+    const mergeFn = jest.fn(basicMerge);
+    const heads = ['foo', 'bar'];
+    expect(mergeHeads(heads, () => 0, getCommit, mergeFn)).toEqual(
+      '(root:bar+foo)',
+    );
+    expect(mergeFn.mock.calls).toEqual([['root', 'bar', 'foo', 1]]);
+  });
 });

--- a/packages/trimerge-sync/src/merge-heads.ts
+++ b/packages/trimerge-sync/src/merge-heads.ts
@@ -60,7 +60,7 @@ export function mergeHeads<N extends CommitInfo>(
       current: new Set([...a.current, ...b.current]),
       seenRefs: new Set([...a.seenRefs, ...b.seenRefs]),
     };
-    visitors.splice(j, 1).sort(sortVisitors);
+    visitors.splice(j, 1);
   }
 
   // Use inner function because we want to be able to break out of 3 levels of for loop

--- a/packages/trimerge-sync/src/merge-heads.ts
+++ b/packages/trimerge-sync/src/merge-heads.ts
@@ -18,7 +18,8 @@ export type SortRefsFn = (refA: string, refB: string) => number;
 export type GetCommitFn<N extends CommitInfo> = (ref: string) => N;
 
 /**
- * This function walks up the tree starting at the commits in a breadth-first manner, merging commits as common ancestors are found.
+ * This function walks up the tree starting at the commits in a breadth-first manner, merging commits,
+ * prioritizing lowest refs first, as common ancestors are found.
  *
  * Those merged commits then continue to be merged together until there is just one head commit left.
  *
@@ -30,34 +31,36 @@ export function mergeHeads<N extends CommitInfo>(
   getCommit: GetCommitFn<N>,
   merge: MergeCommitsFn,
 ): string | undefined {
-  headRefs.sort(sortRefs);
-  const visitors = headRefs.map(
-    (ref): Visitor => ({
+  function sortFn(a: Visitor, b: Visitor): number {
+    const result = sortRefs(a.ref, b.ref);
+    if (!result) {
+      return a.ref > b.ref ? 1 : -1;
+    }
+    return result;
+  }
+
+  const visitors = headRefs
+    .map((ref): Visitor => ({
       ref,
       current: new Set([ref]),
       seenRefs: new Set([ref]),
-    }),
-  );
+    }))
+    .sort(sortFn);
   let depth = 0;
 
   function mergeVisitors(i: number, j: number, baseRef?: string) {
-    const a = visitors[i];
-    const b = visitors[j];
+    const [a, b] = [visitors[i], visitors[j]].sort(sortFn);
     const aRef = a.ref;
     const bRef = b.ref;
     if (baseRef === aRef || baseRef === bRef) {
       throw new Error('unexpected merge with base === left/right');
     }
-    const ref =
-      aRef < bRef
-        ? merge(baseRef, aRef, bRef, depth)
-        : merge(baseRef, bRef, aRef, depth);
     visitors[i] = {
-      ref,
+      ref: merge(baseRef, aRef, bRef, depth),
       current: new Set([...a.current, ...b.current]),
       seenRefs: new Set([...a.seenRefs, ...b.seenRefs]),
     };
-    visitors.splice(j, 1);
+    visitors.splice(j, 1).sort(sortFn);
   }
 
   // Use inner function because we want to be able to break out of 3 levels of for loop
@@ -70,7 +73,7 @@ export function mergeHeads<N extends CommitInfo>(
         for (let j = 0; j < visitors.length; j++) {
           if (j !== i && visitors[j].seenRefs.has(commitRef)) {
             mergeVisitors(i, j, commitRef);
-            return true;
+            return visitors.length > 1;
           }
         }
         const { baseRef, mergeRef } = getCommit(commitRef);
@@ -84,8 +87,8 @@ export function mergeHeads<N extends CommitInfo>(
           leaf.seenRefs.add(mergeRef);
           hasCommits = true;
         }
-        leaf.current = nextCommitRefs;
       }
+      leaf.current = nextCommitRefs;
     }
     depth++;
     return hasCommits;
@@ -95,8 +98,7 @@ export function mergeHeads<N extends CommitInfo>(
 
   if (visitors.length > 1) {
     // If we still have multiple visitors, we have unconnected root commits (undefined baseRef)
-    // Sort them deterministically and merge from left to right: e.g. merge(merge(merge(0,1),2),3)
-    visitors.sort((a, b) => sortRefs(a.ref, b.ref));
+    // Merge from left to right: e.g. merge(merge(merge(0,1),2),3)
     while (visitors.length > 1) {
       mergeVisitors(0, 1);
     }

--- a/packages/trimerge-sync/src/merge-heads.ts
+++ b/packages/trimerge-sync/src/merge-heads.ts
@@ -31,7 +31,7 @@ export function mergeHeads<N extends CommitInfo>(
   getCommit: GetCommitFn<N>,
   merge: MergeCommitsFn,
 ): string | undefined {
-  function sortFn(a: Visitor, b: Visitor): number {
+  function sortVisitors(a: Visitor, b: Visitor): number {
     const result = sortRefs(a.ref, b.ref);
     if (!result) {
       return a.ref > b.ref ? 1 : -1;
@@ -45,11 +45,11 @@ export function mergeHeads<N extends CommitInfo>(
       current: new Set([ref]),
       seenRefs: new Set([ref]),
     }))
-    .sort(sortFn);
+    .sort(sortVisitors);
   let depth = 0;
 
   function mergeVisitors(i: number, j: number, baseRef?: string) {
-    const [a, b] = [visitors[i], visitors[j]].sort(sortFn);
+    const [a, b] = [visitors[i], visitors[j]].sort(sortVisitors);
     const aRef = a.ref;
     const bRef = b.ref;
     if (baseRef === aRef || baseRef === bRef) {
@@ -60,7 +60,7 @@ export function mergeHeads<N extends CommitInfo>(
       current: new Set([...a.current, ...b.current]),
       seenRefs: new Set([...a.seenRefs, ...b.seenRefs]),
     };
-    visitors.splice(j, 1).sort(sortFn);
+    visitors.splice(j, 1).sort(sortVisitors);
   }
 
   // Use inner function because we want to be able to break out of 3 levels of for loop


### PR DESCRIPTION
If there are multiple merges with a shared head, the sort of heads is corrupted by merging the visitors without a fresh sort.  Further, left and right was still being determined by alphanumeric sort of refs instead of using sortRefs.

Tests updated to use a more meaningful sort (that can handle sorting merges) and tested in two directions to ensure lowest sortRefs are preferred for merging and for left.