### PR TITLE
[Live Collab] allow metadata overriding

### DIFF
--- a/packages/example-broadcast-channel/package.json
+++ b/packages/example-broadcast-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-example-broadcast-channel",
-  "version": "0.15.0-test.4",
+  "version": "0.15.0-test.5",
   "private": true,
   "dependencies": {
     "classnames": "2.3.1",
@@ -12,10 +12,10 @@
     "react-scripts": "4.0.3",
     "textarea-caret": "^3.1.0",
     "trimerge": "1.3.0-alpha.15",
-    "trimerge-sync": "0.15.0-test.4",
-    "trimerge-sync-basic-client": "0.15.0-test.4",
-    "trimerge-sync-hash": "0.15.0-test.4",
-    "trimerge-sync-indexed-db": "0.15.0-test.4"
+    "trimerge-sync": "0.15.0-test.5",
+    "trimerge-sync-basic-client": "0.15.0-test.5",
+    "trimerge-sync-hash": "0.15.0-test.5",
+    "trimerge-sync-indexed-db": "0.15.0-test.5"
   },
   "scripts": {
     "start": "cross-env SKIP_PREFLIGHT_CHECK=true FAST_REFRESH=false react-scripts start",

--- a/packages/trimerge-sync-basic-client/package.json
+++ b/packages/trimerge-sync-basic-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-client",
-  "version": "0.15.0-test.4",
+  "version": "0.15.0-test.5",
   "description": "basic websocket client for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -46,7 +46,7 @@
     "jest": "27.0.6",
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.15.0-test.4",
+    "trimerge-sync": "0.15.0-test.5",
     "ts-node": "^10.3.0",
     "ts-node-dev": "^1.1.8",
     "typescript": "4.4.4"

--- a/packages/trimerge-sync-basic-server/package.json
+++ b/packages/trimerge-sync-basic-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-server",
-  "version": "0.15.0-test.4",
+  "version": "0.15.0-test.5",
   "description": "basic websocket server for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -37,7 +37,7 @@
   "dependencies": {
     "@types/ws": "^8.2.0",
     "fs-extra": "^10.0.0",
-    "trimerge-sync": "0.15.0-test.4",
+    "trimerge-sync": "0.15.0-test.5",
     "ws": "^8.2.3"
   },
   "files": [
@@ -56,7 +56,7 @@
     "jest": "27.0.6",
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.15.0-test.4",
+    "trimerge-sync": "0.15.0-test.5",
     "ts-node": "^10.3.0",
     "ts-node-dev": "^1.1.8",
     "typescript": "4.4.4"

--- a/packages/trimerge-sync-hash/package.json
+++ b/packages/trimerge-sync-hash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-hash",
-  "version": "0.15.0-test.4",
+  "version": "0.15.0-test.5",
   "description": "SHA-256 based hash generator for use with trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",

--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-indexed-db",
-  "version": "0.15.0-test.4",
+  "version": "0.15.0-test.5",
   "description": "indexed-db backend for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -40,7 +40,7 @@
     "idb": "6.1.5"
   },
   "peerDependencies": {
-    "trimerge-sync": "0.15.0-test.4"
+    "trimerge-sync": "0.15.0-test.5"
   },
   "files": [
     "dist/**/*",
@@ -56,8 +56,8 @@
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
-    "trimerge-sync": "0.15.0-test.4",
-    "trimerge-sync-hash": "0.15.0-test.4",
+    "trimerge-sync": "0.15.0-test.5",
+    "trimerge-sync-hash": "0.15.0-test.5",
     "typescript": "4.4.4"
   },
   "jest": {

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
@@ -101,7 +101,7 @@ export type AddStoreMetadataFn<CommitMetadata> = (
   commitIndex: number,
 ) => CommitMetadata;
 
-class IndexedDbBackend<
+export class IndexedDbBackend<
   CommitMetadata,
   Delta,
   Presence,
@@ -186,7 +186,12 @@ class IndexedDbBackend<
     metadata: CommitMetadata | undefined,
     remoteSyncId: string | undefined,
   ): commit is TrimergeSyncDbCommit<CommitMetadata, Delta> {
-    if (commit && !commit.remoteSyncId && remoteSyncId) {
+    // In the world where servers decide when to send merges,
+    // it's conceivable that a commit could be "acked" twice
+    // and we want to allow the metadata to be updated in that case.
+    if (commit && remoteSyncId) {
+      // Unclear if this is the right thing to do here.
+      // This could probably be replaced with a remote acked bit.
       commit.remoteSyncId = remoteSyncId;
       if (metadata !== undefined) {
         commit.metadata = metadata;

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
@@ -190,8 +190,8 @@ export class IndexedDbBackend<
     // it's conceivable that a commit could be "acked" twice
     // and we want to allow the metadata to be updated in that case.
     if (commit && remoteSyncId) {
-      // Unclear if this is the right thing to do here.
-      // This could probably be replaced with a remote acked bit.
+      // Unclear if overwriting the remoteSyncId is the right thing to do here.
+      // But currently, we're just using this as a synced bit so it's probably fine either way.
       commit.remoteSyncId = remoteSyncId;
       if (metadata !== undefined) {
         commit.metadata = metadata;

--- a/packages/trimerge-sync/package.json
+++ b/packages/trimerge-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync",
-  "version": "0.15.0-test.4",
+  "version": "0.15.0-test.5",
   "description": "distributed data sync using trimerge",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -55,7 +55,7 @@
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
-    "trimerge-sync-hash": "0.15.0-test.4",
+    "trimerge-sync-hash": "0.15.0-test.5",
     "typescript": "4.4.4"
   },
   "jest": {


### PR DESCRIPTION
This PR removes a previous restriction in Trimerge Sync Indexed DB implementation that asserted that remoteSyncId was falsy before overwriting the metadata. This removes that assertion since now it will be possible for a commit to be "acked" without a remote index.