### PR TITLE
[Live Collab] promise based update doc

### DIFF
--- a/packages/example-broadcast-channel/package.json
+++ b/packages/example-broadcast-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-example-broadcast-channel",
-  "version": "0.16.0-alpha.3",
+  "version": "0.17.0-test.1",
   "private": true,
   "dependencies": {
     "classnames": "2.3.1",
@@ -12,10 +12,10 @@
     "react-scripts": "4.0.3",
     "textarea-caret": "^3.1.0",
     "trimerge": "1.3.0-alpha.15",
-    "trimerge-sync": "0.16.0-alpha.3",
-    "trimerge-sync-basic-client": "0.16.0-alpha.3",
-    "trimerge-sync-hash": "0.16.0-alpha.3",
-    "trimerge-sync-indexed-db": "0.16.0-alpha.3"
+    "trimerge-sync": "0.17.0-test.1",
+    "trimerge-sync-basic-client": "0.17.0-test.1",
+    "trimerge-sync-hash": "0.17.0-test.1",
+    "trimerge-sync-indexed-db": "0.17.0-test.1"
   },
   "scripts": {
     "start": "cross-env SKIP_PREFLIGHT_CHECK=true FAST_REFRESH=false react-scripts start",
@@ -25,9 +25,15 @@
     "test:update-snapshots": "cross-env SKIP_PREFLIGHT_CHECK=true react-scripts test --updateSnapshot --passWithNoTests",
     "eject": "react-scripts eject"
   },
-  "eslintConfig": { "extends": "react-app" },
+  "eslintConfig": {
+    "extends": "react-app"
+  },
   "browserslist": {
-    "production": [">0.2%", "not dead", "not op_mini all"],
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",

--- a/packages/trimerge-sync-basic-client/package.json
+++ b/packages/trimerge-sync-basic-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-client",
-  "version": "0.16.0-alpha.3",
+  "version": "0.17.0-test.1",
   "description": "basic websocket client for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -19,23 +19,34 @@
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {},
-  "files": ["dist/**/*", "src/**/*"],
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.0",
     "@rollup/plugin-node-resolve": "13.0.6",
     "jest": "27.0.6",
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.16.0-alpha.3",
+    "trimerge-sync": "0.17.0-test.1",
     "ts-node": "^10.3.0",
     "ts-node-dev": "^1.1.8",
     "typescript": "4.4.4"
@@ -43,6 +54,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }

--- a/packages/trimerge-sync-basic-server/package.json
+++ b/packages/trimerge-sync-basic-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-basic-server",
-  "version": "0.16.0-alpha.3",
+  "version": "0.17.0-test.1",
   "description": "basic websocket server for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -18,22 +18,35 @@
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {
     "@types/ws": "^8.2.0",
     "fs-extra": "^10.0.0",
-    "trimerge-sync": "0.16.0-alpha.3",
+    "trimerge-sync": "0.17.0-test.1",
     "ws": "^8.2.3"
   },
-  "files": ["dist/**/*", "src/**/*"],
-  "peerDependencies": { "better-sqlite3": "^7.4.1" },
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
+  "peerDependencies": {
+    "better-sqlite3": "^7.4.1"
+  },
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.0",
     "@rollup/plugin-node-resolve": "13.0.6",
@@ -43,7 +56,7 @@
     "jest": "27.0.6",
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
-    "trimerge-sync": "0.16.0-alpha.3",
+    "trimerge-sync": "0.17.0-test.1",
     "ts-node": "^10.3.0",
     "ts-node-dev": "^1.1.8",
     "typescript": "4.4.4"
@@ -51,6 +64,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }

--- a/packages/trimerge-sync-hash/package.json
+++ b/packages/trimerge-sync-hash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-hash",
-  "version": "0.16.0-alpha.3",
+  "version": "0.17.0-test.1",
   "description": "SHA-256 based hash generator for use with trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -19,16 +19,29 @@
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
-  "dependencies": { "jssha": "^3.2.0" },
-  "files": ["dist/**/*", "src/**/*"],
+  "dependencies": {
+    "jssha": "^3.2.0"
+  },
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.0",
     "@rollup/plugin-node-resolve": "13.0.6",
@@ -40,6 +53,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }

--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync-indexed-db",
-  "version": "0.16.0-alpha.3",
+  "version": "0.17.0-test.1",
   "description": "indexed-db backend for trimerge-sync",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -19,17 +19,33 @@
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
-  "dependencies": { "broadcast-channel": "^4.2.0", "idb": "6.1.5" },
-  "peerDependencies": { "trimerge-sync": "0.16.0-alpha.3" },
-  "files": ["dist/**/*", "src/**/*"],
+  "dependencies": {
+    "broadcast-channel": "^4.2.0",
+    "idb": "6.1.5"
+  },
+  "peerDependencies": {
+    "trimerge-sync": "0.17.0-test.1"
+  },
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.0",
     "@rollup/plugin-node-resolve": "13.0.6",
@@ -40,13 +56,19 @@
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
-    "trimerge-sync": "0.16.0-alpha.3",
-    "trimerge-sync-hash": "0.16.0-alpha.3",
+    "trimerge-sync": "0.17.0-test.1",
+    "trimerge-sync-hash": "0.17.0-test.1",
     "typescript": "4.4.4"
   },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }

--- a/packages/trimerge-sync/package.json
+++ b/packages/trimerge-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimerge-sync",
-  "version": "0.16.0-alpha.3",
+  "version": "0.17.0-test.1",
   "description": "distributed data sync using trimerge",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -15,22 +15,35 @@
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "rm -rf dist/ && npm run build"
   },
-  "engines": { "node": ">=6" },
+  "engines": {
+    "node": ">=6"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/marcello3d/trimerge.git"
   },
-  "keywords": ["json", "three-way-merge", "diff", "diff3", "merge"],
+  "keywords": [
+    "json",
+    "three-way-merge",
+    "diff",
+    "diff3",
+    "merge"
+  ],
   "author": {
     "name": "Marcello Bastéa-Forte",
     "email": "marcello@cellosoft.com"
   },
   "license": "Zlib",
-  "bugs": { "url": "https://github.com/marcello3d/trimerge-sync/issues" },
+  "bugs": {
+    "url": "https://github.com/marcello3d/trimerge-sync/issues"
+  },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {},
   "peerDependencies": {},
-  "files": ["dist/**/*", "src/**/*"],
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.0",
     "@rollup/plugin-node-resolve": "13.0.6",
@@ -42,12 +55,18 @@
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge": "^1.3.0-alpha.15",
-    "trimerge-sync-hash": "0.16.0-alpha.3",
+    "trimerge-sync-hash": "0.17.0-test.1",
     "typescript": "4.4.4"
   },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": { "ts-jest": { "diagnostics": { "warnOnly": true } } }
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "warnOnly": true
+        }
+      }
+    }
   }
 }

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -445,14 +445,14 @@ export abstract class AbstractLocalStore<CommitMetadata, Delta, Presence>
       await this.sendEvent({ type: 'ready' }, { self: true });
     });
   }
-  update(
+  async update(
     commits: Commit<CommitMetadata, Delta>[],
     presence: ClientPresenceRef<Presence> | undefined,
-  ): void {
-    if (this.closed) {
+  ): Promise<void> {
+    if (this.closed || (commits.length === 0 && !presence)) {
       return;
     }
-    this.localQueue
+    return await this.localQueue
       .add(() => this.doUpdate(commits, presence))
       .catch(this.handleAsError('invalid-commits'));
   }

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -222,4 +222,13 @@ Object {
       /Not a real error/,
     );
   });
+
+  it('throws if there is an invalid number of commits', async () => {
+    const { client } = makeTrimergeClient(undefined);
+    (client as any).numUnsavedCommits = -1;
+
+    expect(client.updateDoc({ foo: 'bar' }, 'message')).rejects.toThrowError(
+      /Assertion Error: numUnsavedCommits <= 0/,
+    );
+  });
 });

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -27,6 +27,7 @@ const NOOP_DIFFER: Differ<any, any, any, any> = {
 function makeTrimergeClient(
   addNewCommitMetadata?: AddNewCommitMetadataFn<any>,
   differ?: Differ<any, any, any, any>,
+  updateStore?: (commits: any[], presence: any) => Promise<void>,
 ): {
   client: TrimergeClient<any, any, any, any, any>;
   onEvent: OnStoreEventFn<any, any, any>;
@@ -38,7 +39,7 @@ function makeTrimergeClient(
     (userId, clientId, _onEvent) => {
       onEvent = _onEvent;
       return {
-        update: () => Promise.resolve(),
+        update: updateStore ?? (() => Promise.resolve()),
         shutdown: () => undefined,
         isRemoteLeader: false,
       };
@@ -208,5 +209,17 @@ Object {
 
     expect(client.doc.array).toBe(array);
     expect(client.doc.nested).toBe(nestedObject);
+  });
+
+  it('rejects if commits failed to store', async () => {
+    const { client } = makeTrimergeClient(undefined, NOOP_DIFFER, () =>
+      Promise.reject(
+        new Error("Not a real error. Don't worry. It's only a test."),
+      ),
+    );
+
+    expect(client.updateDoc({ foo: 'bar' }, 'message')).rejects.toThrowError(
+      /Not a real error/,
+    );
   });
 });

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -38,7 +38,7 @@ function makeTrimergeClient(
     (userId, clientId, _onEvent) => {
       onEvent = _onEvent;
       return {
-        update: () => undefined,
+        update: () => Promise.resolve(),
         shutdown: () => undefined,
         isRemoteLeader: false,
       };

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -337,22 +337,17 @@ export class TrimergeClient<
       try {
         await this.store.update(commits, this.newPresence);
 
-        if (this.numUnsavedCommits <= 0) {
-          throw new Error('Assertion Error: numUnsavedCommits <= 0');
-        }
-
-        this.numUnsavedCommits--;
-        if (this.numUnsavedCommits === 0) {
+        if (this.numUnsavedCommits === 1) {
           this.updateSyncState({ localSave: 'ready' });
         }
       } catch (err) {
+        this.updateSyncState({ localSave: 'error' });
+        throw err;
+      } finally {
         if (this.numUnsavedCommits <= 0) {
           throw new Error('Assertion Error: numUnsavedCommits <= 0');
         }
-
-        this.updateSyncState({ localSave: 'error' });
         this.numUnsavedCommits--;
-        throw err;
       }
 
       this.newPresence = undefined;

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -36,6 +36,11 @@ export type AddNewCommitMetadataFn<CommitMetadata> = (
   clientId: string,
 ) => CommitMetadata;
 
+type UnsyncedCommit<CommitMetadata, Delta> = {
+  commit: Commit<CommitMetadata, Delta>;
+  resolve?: () => void;
+};
+
 export class TrimergeClient<
   SavedDoc,
   LatestDoc extends SavedDoc,
@@ -82,7 +87,7 @@ export class TrimergeClient<
 
   private store: LocalStore<CommitMetadata, Delta, Presence>;
   private tempCommits = new Map<string, Commit<CommitMetadata, Delta>>();
-  private unsyncedCommits: Commit<CommitMetadata, Delta>[] = [];
+  private unsyncedCommits: UnsyncedCommit<CommitMetadata, Delta>[] = [];
 
   private newPresence: ClientInfo<Presence> | undefined;
 
@@ -228,12 +233,26 @@ export class TrimergeClient<
     return this.clientListSubs.subscribe(onChange, { origin: 'subscribe' });
   }
 
-  updateDoc(doc: LatestDoc, metadata: CommitMetadata, presence?: Presence) {
-    const ref = this.addNewCommit(doc, metadata, false);
-    this.setPresence(presence, ref);
-    this.mergeHeads();
-    this.docSubs.emitChange({ origin: 'self' });
-    this.sync();
+  updateDoc(
+    doc: LatestDoc,
+    metadata: CommitMetadata,
+    presence?: Presence,
+  ): Promise<void> {
+    const result = new Promise<void>((resolve) => {
+      const ref = this.addNewCommit(
+        doc,
+        metadata,
+        false,
+        undefined,
+        undefined,
+        resolve,
+      );
+      this.setPresence(presence, ref);
+      this.mergeHeads();
+      this.docSubs.emitChange({ origin: 'self' });
+      this.sync();
+    });
+    return result;
   }
 
   updatePresence(state: Presence) {
@@ -318,13 +337,21 @@ export class TrimergeClient<
     this.clientList = Array.from(this.clientMap.values());
     this.clientListSubs.emitChange(event);
   }
-  private sync(): void {
+  private async sync() {
     const commits = this.unsyncedCommits;
     if (commits.length > 0 || this.newPresence !== undefined) {
       this.unsyncedCommits = [];
       this.updateSyncState({ localSave: 'saving' });
-      this.store.update(commits, this.newPresence);
+      await this.store.update(
+        commits.map((c) => c.commit),
+        this.newPresence,
+      );
       this.newPresence = undefined;
+      for (const commit of commits) {
+        if (commit.resolve) {
+          commit.resolve();
+        }
+      }
     }
     this.updateSyncState({ localSave: 'ready' });
   }
@@ -355,6 +382,7 @@ export class TrimergeClient<
   private addCommit(
     commit: Commit<CommitMetadata, Delta>,
     type: AddCommitType,
+    resolve?: () => void,
   ): void {
     const { ref, baseRef, mergeRef } = asCommitRefs(commit);
     if (this.commits.has(ref)) {
@@ -403,7 +431,7 @@ export class TrimergeClient<
       case 'local':
         this.promoteTempCommit(baseRef);
         this.promoteTempCommit(mergeRef);
-        this.unsyncedCommits.push(commit);
+        this.unsyncedCommits.push({ commit, resolve });
         break;
     }
     if (type !== 'temp') {
@@ -422,7 +450,7 @@ export class TrimergeClient<
       this.promoteTempCommit(mergeRef);
       this.addHead(this.nonTempHeadRefs, commit);
       this.tempCommits.delete(ref);
-      this.unsyncedCommits.push(commit);
+      this.unsyncedCommits.push({ commit });
     }
     if (this.lastSavedDoc?.ref === ref) {
       this.lastNonTempDoc = this.lastSavedDoc;
@@ -435,6 +463,7 @@ export class TrimergeClient<
     temp: boolean,
     base: CommitDoc<SavedDoc, CommitMetadata> | undefined = this.lastSavedDoc,
     mergeRef?: string,
+    resolve?: () => void,
   ): string {
     const delta = this.differ.diff(base?.doc, newDoc);
     const baseRef = base?.ref;
@@ -455,7 +484,7 @@ export class TrimergeClient<
       mergeRef !== undefined
         ? { ref, baseRef, mergeRef, delta, metadata }
         : { ref, baseRef, delta, metadata };
-    this.addCommit(commit, temp ? 'temp' : 'local');
+    this.addCommit(commit, temp ? 'temp' : 'local', resolve);
     return ref;
   }
 

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -336,20 +336,22 @@ export class TrimergeClient<
       this.numUnsavedCommits++;
       try {
         await this.store.update(commits, this.newPresence);
-        if (this.numUnsavedCommits > 0) {
-          this.numUnsavedCommits--;
-          if (this.numUnsavedCommits === 0) {
-            this.updateSyncState({ localSave: 'ready' });
-          }
-        } else {
-          // potentially unneccessary
-          this.numUnsavedCommits = 0;
+
+        if (this.numUnsavedCommits <= 0) {
+          throw new Error('Assertion Error: numUnsavedCommits <= 0');
+        }
+
+        this.numUnsavedCommits--;
+        if (this.numUnsavedCommits === 0) {
+          this.updateSyncState({ localSave: 'ready' });
         }
       } catch (err) {
-        this.updateSyncState({ localSave: 'error' });
-        if (this.numUnsavedCommits > 0) {
-          this.numUnsavedCommits--;
+        if (this.numUnsavedCommits <= 0) {
+          throw new Error('Assertion Error: numUnsavedCommits <= 0');
         }
+
+        this.updateSyncState({ localSave: 'error' });
+        this.numUnsavedCommits--;
         throw err;
       }
 

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -338,7 +338,7 @@ export class TrimergeClient<
     this.clientList = Array.from(this.clientMap.values());
     this.clientListSubs.emitChange(event);
   }
-  private async sync() {
+  private async sync(): Promise<void> {
     const commits = this.unsyncedCommits;
     if (commits.length > 0 || this.newPresence !== undefined) {
       this.unsyncedCommits = [];

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -238,7 +238,7 @@ export class TrimergeClient<
     metadata: CommitMetadata,
     presence?: Presence,
   ): Promise<void> {
-    const result = new Promise<void>((resolve) => {
+    return new Promise<void>((resolve) => {
       const ref = this.addNewCommit(
         doc,
         metadata,
@@ -252,7 +252,6 @@ export class TrimergeClient<
       this.docSubs.emitChange({ origin: 'self' });
       this.sync();
     });
-    return result;
   }
 
   updatePresence(state: Presence) {

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -145,46 +145,32 @@ Array [
     "remoteSave": "ready",
   },
   Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "loading",
+    "localRead": "ready",
     "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "ready",
   },
   Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
     "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "saving",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
@@ -371,46 +357,32 @@ Array [
     "remoteSave": "ready",
   },
   Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "loading",
+    "localRead": "ready",
     "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "ready",
   },
   Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
     "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "saving",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
@@ -760,46 +732,32 @@ Array [
     "remoteSave": "ready",
   },
   Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "loading",
+    "localRead": "ready",
     "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "ready",
   },
   Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
     "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "saving",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
@@ -852,52 +810,38 @@ Array [
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "online",
     "remoteRead": "ready",
-    "remoteSave": "ready",
+    "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "saving",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
     "localSave": "saving",
     "remoteConnect": "online",
     "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
     "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "saving",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
@@ -1118,60 +1062,32 @@ Array [
     "remoteSave": "ready",
   },
   Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "loading",
+    "localRead": "ready",
     "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "ready",
   },
   Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "loading",
+    "localRead": "ready",
     "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "saving",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
@@ -1284,38 +1200,24 @@ Array [
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
     "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
     "remoteConnect": "online",
     "remoteRead": "ready",
     "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "online",
     "remoteRead": "ready",
     "remoteSave": "saving",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "saving",
+    "remoteConnect": "online",
+    "remoteRead": "ready",
+    "remoteSave": "pending",
   },
   Object {
     "localRead": "ready",
@@ -1719,25 +1621,25 @@ Array [
     await timeout();
 
     expect(basicClients(client1)).toMatchInlineSnapshot(`
-      Object {
-        "a:client1": "presence 1",
-        "b:client2": "presence 2",
-        "b:client3": "presence 3",
-      }
-    `);
+Object {
+  "a:client1": "presence 1",
+  "b:client2": "presence 2",
+  "b:client3": "presence 3",
+}
+`);
     expect(basicClients(client2)).toMatchInlineSnapshot(`
-      Object {
-        "a:client1": "presence 1",
-        "b:client2": "presence 2",
-        "b:client3": "presence 3",
-      }
-    `);
+Object {
+  "a:client1": "presence 1",
+  "b:client2": "presence 2",
+  "b:client3": "presence 3",
+}
+`);
     expect(basicClients(client3)).toMatchInlineSnapshot(`
-      Object {
-        "a:client1": "presence 1",
-        "b:client2": "presence 2",
-        "b:client3": "presence 3",
-      }
-    `);
+Object {
+  "a:client1": "presence 1",
+  "b:client2": "presence 2",
+  "b:client3": "presence 3",
+}
+`);
   });
 });

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -174,10 +174,10 @@ Array [
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
-    "remoteSave": "pending",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
@@ -386,10 +386,10 @@ Array [
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
-    "remoteSave": "pending",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
@@ -761,10 +761,10 @@ Array [
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
-    "remoteSave": "pending",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
@@ -845,10 +845,10 @@ Array [
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
-    "remoteSave": "pending",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
@@ -1091,24 +1091,24 @@ Array [
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "offline",
     "remoteRead": "offline",
     "remoteSave": "pending",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "saving",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",
@@ -1221,17 +1221,17 @@ Array [
   },
   Object {
     "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
+    "localSave": "saving",
     "remoteConnect": "online",
     "remoteRead": "ready",
     "remoteSave": "ready",
+  },
+  Object {
+    "localRead": "ready",
+    "localSave": "saving",
+    "remoteConnect": "online",
+    "remoteRead": "ready",
+    "remoteSave": "saving",
   },
   Object {
     "localRead": "ready",

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
@@ -10,7 +10,6 @@ import {
   patch,
 } from './MergeUtils';
 import { getBasicGraph, getDotGraph } from './GraphVisualizers';
-import { timeout } from '../lib/Timeout';
 
 type TestMetadata = string;
 type TestSavedDoc = any;

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
@@ -75,10 +75,11 @@ describe('GraphVisualizers', () => {
     const store = newStore();
     const client1 = makeClient('a', store);
     const client2 = makeClient('b', store);
-    client1.updateDoc({ hello: '1' }, 'initialize');
-    client2.updateDoc({ world: '2' }, 'initialize');
-    client2.updateDoc({ world: '3' }, 'initialize');
-    await timeout();
+    await Promise.all([
+      client1.updateDoc({ hello: '1' }, 'initialize'),
+      client2.updateDoc({ world: '2' }, 'initialize'),
+      client2.updateDoc({ world: '3' }, 'initialize'),
+    ]);
     expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
 Array [
   Object {

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
@@ -10,6 +10,7 @@ import {
   patch,
 } from './MergeUtils';
 import { getBasicGraph, getDotGraph } from './GraphVisualizers';
+import { timeout } from '../lib/Timeout';
 
 type TestMetadata = string;
 type TestSavedDoc = any;
@@ -74,11 +75,12 @@ describe('GraphVisualizers', () => {
     const store = newStore();
     const client1 = makeClient('a', store);
     const client2 = makeClient('b', store);
-    await Promise.all([
-      client1.updateDoc({ hello: '1' }, 'initialize'),
-      client2.updateDoc({ world: '2' }, 'initialize'),
-      client2.updateDoc({ world: '3' }, 'initialize'),
-    ]);
+    client1.updateDoc({ hello: '1' }, 'initialize');
+    client2.updateDoc({ world: '2' }, 'initialize');
+    client2.updateDoc({ world: '3' }, 'initialize');
+
+    await timeout(100);
+
     expect(basicGraph(store, client1)).toMatchInlineSnapshot(`
 Array [
   Object {

--- a/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/testLib/GraphVisualizers.test.ts
@@ -75,9 +75,10 @@ describe('GraphVisualizers', () => {
     const store = newStore();
     const client1 = makeClient('a', store);
     const client2 = makeClient('b', store);
-    client1.updateDoc({ hello: '1' }, 'initialize');
-    client2.updateDoc({ world: '2' }, 'initialize');
-    client2.updateDoc({ world: '3' }, 'initialize');
+
+    void client1.updateDoc({ hello: '1' }, 'initialize');
+    void client2.updateDoc({ world: '2' }, 'initialize');
+    void client2.updateDoc({ world: '3' }, 'initialize');
 
     await timeout(100);
 

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
@@ -1,5 +1,4 @@
 import { MemoryStore } from './MemoryStore';
-import { timeout } from '../lib/Timeout';
 
 describe('MemoryLocalStore', () => {
   it('can be shutdown twice', async () => {

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
@@ -12,7 +12,7 @@ describe('MemoryLocalStore', () => {
     const store = new MemoryStore('test');
     const fn = jest.fn();
     const local = store.getLocalStore('test', 'test', fn);
-    local.update(
+    await local.update(
       [
         {
           ref: 'test1',
@@ -21,9 +21,6 @@ describe('MemoryLocalStore', () => {
       ],
       undefined,
     );
-
-    // Let everything flush out first
-    await timeout();
 
     expect(fn.mock.calls).toMatchInlineSnapshot(`
 Array [
@@ -80,7 +77,7 @@ Array [
 `);
 
     await local.shutdown();
-    local.update(
+    await local.update(
       [
         {
           ref: 'test2',

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -222,7 +222,7 @@ export interface LocalStore<CommitMetadata, Delta, Presence> {
   update(
     commits: Commit<CommitMetadata, Delta>[],
     presence: ClientPresenceRef<Presence> | undefined,
-  ): void;
+  ): Promise<void>;
   isRemoteLeader: boolean;
   shutdown(): void | Promise<void>;
 }


### PR DESCRIPTION
Updates the APIs to return Promises when calling updateDoc() on TrimergeClient and update() on LocalStore which both resolve when the commit has been persisted locally. This gives clients a way to avoid losing work by closing their application before commits have been persisted.

This PR:
 - Updates LocalStore and AbstractLocalStore to return a Promise when calling `update`.
 - Returns promises from updateDoc and holds references to the resolves which we call on the next call to sync()
 - synchronizes many tests with the new Promise based methods
 - adds a simple new unit test which confirms that the document is immediately available from the indexed DB, once the promise resolves.