### PR TITLE
a couple of type changes for descripts usage of trimerge sync

### DIFF
--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -111,7 +111,6 @@ export type InitEvent =
       lastSyncCursor: string | undefined;
       auth: unknown;
       docId?: string;
-      userId?: string;
     };
 
 export type CommitAck<CommitMetadata = unknown> = {

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -110,6 +110,8 @@ export type InitEvent =
       localStoreId: string;
       lastSyncCursor: string | undefined;
       auth: unknown;
+      docId?: string;
+      userId?: string;
     };
 
 export type CommitAck<CommitMetadata = unknown> = {
@@ -220,7 +222,7 @@ export type GetRemoteFn<CommitMetadata, Delta, Presence> = (
 
 export interface LocalStore<CommitMetadata, Delta, Presence> {
   update(
-    commits: Commit<CommitMetadata, Delta>[],
+    commits: readonly Commit<CommitMetadata, Delta>[],
     presence: ClientPresenceRef<Presence> | undefined,
   ): Promise<void>;
   isRemoteLeader: boolean;


### PR DESCRIPTION
As discussed, no reason not to support `docId` on `InitEvent` and `store.update()` doesn't need a mutable array of commits.