### PR TITLE
[Indexed DB] inject the local channel dependency 

### DIFF
--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -36,8 +36,7 @@
   },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {
-    "idb": "6.1.5",
-    "p-queue": "7.2.0"
+    "idb": "6.1.5"
   },
   "peerDependencies": {
     "trimerge-sync": "0.17.0"

--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -36,7 +36,6 @@
   },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {
-    "broadcast-channel": "^4.2.0",
     "idb": "6.1.5"
   },
   "peerDependencies": {
@@ -50,6 +49,7 @@
     "@rollup/plugin-commonjs": "21.0.0",
     "@rollup/plugin-node-resolve": "13.0.6",
     "fake-indexeddb": "^3.1.4",
+    "broadcast-channel": "^4.2.0",
     "immer": "^9.0.6",
     "jest": "27.0.6",
     "jsondiffpatch": "^0.4.1",

--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -36,7 +36,8 @@
   },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {
-    "idb": "6.1.5"
+    "idb": "6.1.5",
+    "p-queue": "7.2.0"
   },
   "peerDependencies": {
     "trimerge-sync": "0.17.0"

--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -8,7 +8,7 @@
   "sideEffects": false,
   "scripts": {
     "test": "jest --watch",
-    "test-ci": "jest --coverage --reporters=@descript/jest-github-reporter --detectOpenHandles",
+    "test-ci": "jest --coverage --reporters=@descript/jest-github-reporter --forceExit",
     "test:update-snapshots": "jest --updateSnapshot",
     "build": "rollup -c",
     "watch": "rollup -c -w",

--- a/packages/trimerge-sync-indexed-db/package.json
+++ b/packages/trimerge-sync-indexed-db/package.json
@@ -8,7 +8,7 @@
   "sideEffects": false,
   "scripts": {
     "test": "jest --watch",
-    "test-ci": "jest --coverage --reporters=@descript/jest-github-reporter",
+    "test-ci": "jest --coverage --reporters=@descript/jest-github-reporter --detectOpenHandles",
     "test:update-snapshots": "jest --updateSnapshot",
     "build": "rollup -c",
     "watch": "rollup -c -w",

--- a/packages/trimerge-sync-indexed-db/rollup.config.js
+++ b/packages/trimerge-sync-indexed-db/rollup.config.js
@@ -1,9 +1,8 @@
 // rollup.config.js
-import pkg from './package.json';
+import { dependencies, main, module } from './package.json';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';
-import { dependencies } from './package.json';
 
 export default {
   input: 'src/index.ts',
@@ -15,11 +14,11 @@ export default {
   ],
   output: [
     {
-      file: pkg.main,
+      file: main,
       format: 'cjs',
     },
     {
-      file: pkg.module,
+      file: module,
       format: 'esm',
     },
   ],

--- a/packages/trimerge-sync-indexed-db/src/BroadcastChannelEventChannel.ts
+++ b/packages/trimerge-sync-indexed-db/src/BroadcastChannelEventChannel.ts
@@ -1,0 +1,40 @@
+import { BroadcastEvent, EventChannel } from 'trimerge-sync';
+
+/** This creates a native browser BroadcastChannel implementation of EventChannel */
+function getBroadcastChannelEventChannel<CommitMetadata, Delta, Presence>(
+  docId: string,
+): EventChannel<CommitMetadata, Delta, Presence> {
+  let channel: BroadcastChannel | undefined = new BroadcastChannel(docId);
+  const eventListenerCallbacks: ((e: MessageEvent) => void)[] = [];
+
+  return {
+    onEvent: (
+      cb: (ev: BroadcastEvent<CommitMetadata, Delta, Presence>) => void,
+    ) => {
+      if (!channel) {
+        throw new Error(
+          'attempting to register an event callback after channel has been shutdown',
+        );
+      }
+
+      const newCb = (e: MessageEvent) => cb(e.data);
+      eventListenerCallbacks.push(newCb);
+      return channel?.addEventListener('message', newCb);
+    },
+    sendEvent: (ev: BroadcastEvent<CommitMetadata, Delta, Presence>) => {
+      if (!channel) {
+        throw new Error(
+          `attempting to send an event after channel has been shutdown ${ev}`,
+        );
+      }
+      return channel?.postMessage(ev);
+    },
+    shutdown: () => {
+      for (const cb of eventListenerCallbacks) {
+        channel?.removeEventListener('message', cb);
+      }
+      channel?.close();
+      channel = undefined;
+    },
+  };
+}

--- a/packages/trimerge-sync-indexed-db/src/BroadcastChannelEventChannel.ts
+++ b/packages/trimerge-sync-indexed-db/src/BroadcastChannelEventChannel.ts
@@ -1,9 +1,11 @@
 import { BroadcastEvent, EventChannel } from 'trimerge-sync';
 
 /** This creates a native browser BroadcastChannel implementation of EventChannel */
-function getBroadcastChannelEventChannel<CommitMetadata, Delta, Presence>(
-  docId: string,
-): EventChannel<CommitMetadata, Delta, Presence> {
+export function getBroadcastChannelEventChannel<
+  CommitMetadata,
+  Delta,
+  Presence,
+>(docId: string): EventChannel<CommitMetadata, Delta, Presence> {
   let channel: BroadcastChannel | undefined = new BroadcastChannel(docId);
   const eventListenerCallbacks: ((e: MessageEvent) => void)[] = [];
 

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.test.ts
@@ -39,7 +39,9 @@ function makeTestBroadcastChannel(docId: string): EventChannel<any, any, any> {
     sendEvent: (ev: BroadcastEvent<any, any, any>) => {
       if (!channel) {
         throw new Error(
-          'attempting to send an event after channel has been shutdown',
+          `attempting to send an event after channel has been shutdown ${JSON.stringify(
+            ev,
+          )}`,
         );
       }
 
@@ -118,6 +120,7 @@ async function makeTestClientWithRemoteOnEventHandle(
             heartbeatTimeoutMs: 50,
           },
           addStoreMetadata,
+          localChannel: makeTestBroadcastChannel(docId),
         });
         return store;
       },
@@ -528,6 +531,9 @@ describe('createIndexedDbBackendFactory', () => {
     );
     await client1.updateDoc('hello remote', '');
 
+    // wait for all writes to settle.
+    await timeout(100);
+
     expect(dumpDatabase(docId)).resolves.toMatchInlineSnapshot(`
 Object {
   "commits": Array [
@@ -538,7 +544,7 @@ Object {
       ],
       "metadata": "",
       "ref": "F2C9k7m0",
-      "remoteSyncId": "",
+      "remoteSyncId": "foo",
       "syncId": 1,
     },
   ],
@@ -549,6 +555,7 @@ Object {
   ],
   "remotes": Array [
     Object {
+      "lastSyncCursor": "foo",
       "localStoreId": "test-doc-store",
     },
   ],

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
@@ -38,45 +38,6 @@ function toSyncNumber(syncId: string | undefined): number {
   return syncId === undefined ? 0 : parseInt(syncId, 36);
 }
 
-/** This creates a native browser BroadcastChannel implementation of EventChannel */
-function getBroadcastChannelEventChannel<CommitMetadata, Delta, Presence>(
-  docId: string,
-): EventChannel<CommitMetadata, Delta, Presence> {
-  let channel: BroadcastChannel | undefined = new BroadcastChannel(docId);
-  const eventListenerCallbacks: ((e: MessageEvent) => void)[] = [];
-
-  return {
-    onEvent: (
-      cb: (ev: BroadcastEvent<CommitMetadata, Delta, Presence>) => void,
-    ) => {
-      if (!channel) {
-        throw new Error(
-          'attempting to register an event callback after channel has been shutdown',
-        );
-      }
-
-      const newCb = (e: MessageEvent) => cb(e.data);
-      eventListenerCallbacks.push(newCb);
-      return channel?.addEventListener('message', newCb);
-    },
-    sendEvent: (ev: BroadcastEvent<CommitMetadata, Delta, Presence>) => {
-      if (!channel) {
-        throw new Error(
-          `attempting to send an event after channel has been shutdown ${ev}`,
-        );
-      }
-      return channel?.postMessage(ev);
-    },
-    shutdown: () => {
-      for (const cb of eventListenerCallbacks) {
-        channel?.removeEventListener('message', cb);
-      }
-      channel?.close();
-      channel = undefined;
-    },
-  };
-}
-
 type LocalIdGeneratorFn = () => Promise<string> | string;
 export type IndexedDbBackendOptions<CommitMetadata, Delta, Presence> = {
   getRemote?: GetRemoteFn<CommitMetadata, Delta, Presence>;

--- a/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
+++ b/packages/trimerge-sync-indexed-db/src/trimerge-indexed-db.ts
@@ -16,6 +16,7 @@ import {
 import type { DBSchema, IDBPDatabase, StoreValue } from 'idb';
 import { deleteDB, openDB } from 'idb';
 import { timeout } from './lib/timeout';
+import { getBroadcastChannelEventChannel } from './BroadcastChannelEventChannel';
 
 const COMMIT_PAGE_SIZE = 100;
 

--- a/packages/trimerge-sync/rollup.config.js
+++ b/packages/trimerge-sync/rollup.config.js
@@ -6,7 +6,6 @@ import typescript from 'rollup-plugin-typescript2';
 
 export default {
   input: 'src/index.ts',
-  external: Object.keys(dependencies),
   plugins: [commonjs(), resolve(), typescript({ exclude: '**/*.test.ts' })],
   output: [
     {

--- a/packages/trimerge-sync/rollup.config.js
+++ b/packages/trimerge-sync/rollup.config.js
@@ -1,5 +1,5 @@
 // rollup.config.js
-import { dependencies, main, module } from './package.json';
+import { main, module } from './package.json';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';

--- a/packages/trimerge-sync/rollup.config.js
+++ b/packages/trimerge-sync/rollup.config.js
@@ -1,19 +1,20 @@
 // rollup.config.js
-import pkg from './package.json';
+import { dependencies, main, module } from './package.json';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';
 
 export default {
   input: 'src/index.ts',
+  external: Object.keys(dependencies),
   plugins: [commonjs(), resolve(), typescript({ exclude: '**/*.test.ts' })],
   output: [
     {
-      file: pkg.main,
+      file: main,
       format: 'cjs',
     },
     {
-      file: pkg.module,
+      file: module,
       format: 'esm',
     },
   ],

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -257,7 +257,6 @@ export abstract class AbstractLocalStore<CommitMetadata, Delta, Presence>
       return;
     }
 
-    // stop processing events / reporting errors.
     this.closed = true;
 
     const { userId, clientId } = this;
@@ -274,19 +273,13 @@ export abstract class AbstractLocalStore<CommitMetadata, Delta, Presence>
       console.warn('ignoring error while shutting down', error);
     }
 
-    // disconnect from the remote
     await this.closeRemote();
-    await this.remoteQueue.shutdown();
 
     try {
       this.leaderManager?.shutdown();
     } catch (error) {
       console.warn('ignoring error while shutting down', error);
     }
-
-    await this.localQueue.shutdown();
-
-    await this.localChannel?.shutdown();
   }
 
   private closeRemote(reconnect: boolean = false): Promise<void> {

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -293,11 +293,7 @@ export abstract class AbstractLocalStore<CommitMetadata, Delta, Presence>
     await this.localChannel?.shutdown();
   }
 
-  private async closeRemote(reconnect: boolean = false): Promise<void> {
-    if (!this.remote) {
-      return;
-    }
-
+  private closeRemote(reconnect: boolean = false): Promise<void> {
     const p = this.remoteQueue
       .add(async () => {
         const remote = this.remote;
@@ -331,8 +327,8 @@ export abstract class AbstractLocalStore<CommitMetadata, Delta, Presence>
         console.log(`[TRIMERGE-SYNC] reconnecting now...`);
         this.connectRemote();
       }, reconnectDelayMs);
-      return await p;
     }
+    return p;
   }
 
   private connectRemote(): void {

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -245,10 +245,6 @@ export abstract class AbstractLocalStore<CommitMetadata, Delta, Presence>
     event,
     remoteOrigin,
   }: BroadcastEvent<CommitMetadata, Delta, Presence>): void {
-    if (this.closed) {
-      return;
-    }
-
     this.localQueue
       .add(() =>
         this.processEvent(event, remoteOrigin ? 'remote-via-local' : 'local'),

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -20,6 +20,7 @@ import {
   LeaderSettings,
 } from './lib/LeaderManager';
 import { PromiseQueue } from './lib/PromiseQueue';
+import { BroadcastEvent, EventChannel } from './lib/EventChannel';
 
 export type NetworkSettings = Readonly<
   {
@@ -28,21 +29,6 @@ export type NetworkSettings = Readonly<
     maxReconnectDelayMs: number;
   } & LeaderSettings
 >;
-
-export type BroadcastEvent<CommitMetadata, Delta, Presence> = {
-  event: SyncEvent<CommitMetadata, Delta, Presence>;
-  remoteOrigin: boolean;
-};
-
-export type EventChannel<CommitMetadata, Delta, Presence> = {
-  onEvent(
-    cb: (ev: BroadcastEvent<CommitMetadata, Delta, Presence>) => void,
-  ): void;
-  sendEvent(
-    ev: BroadcastEvent<CommitMetadata, Delta, Presence>,
-  ): void | Promise<void>;
-  shutdown(): void | Promise<void>;
-};
 
 const DEFAULT_SETTINGS: NetworkSettings = {
   initialDelayMs: 1_000,

--- a/packages/trimerge-sync/src/AbstractLocalStore.ts
+++ b/packages/trimerge-sync/src/AbstractLocalStore.ts
@@ -34,6 +34,16 @@ export type BroadcastEvent<CommitMetadata, Delta, Presence> = {
   remoteOrigin: boolean;
 };
 
+export type EventChannel<CommitMetadata, Delta, Presence> = {
+  onEvent(
+    cb: (ev: BroadcastEvent<CommitMetadata, Delta, Presence>) => void,
+  ): void;
+  sendEvent(
+    ev: BroadcastEvent<CommitMetadata, Delta, Presence>,
+  ): void | Promise<void>;
+  shutdown(): void | Promise<void>;
+};
+
 const DEFAULT_SETTINGS: NetworkSettings = {
   initialDelayMs: 1_000,
   reconnectBackoffMultiplier: 2,

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -1153,6 +1153,13 @@ Array [
     "remoteRead": "offline",
     "remoteSave": "ready",
   },
+  Object {
+    "localRead": "error",
+    "localSave": "ready",
+    "remoteConnect": "offline",
+    "remoteRead": "offline",
+    "remoteSave": "ready",
+  },
 ]
 `);
     expect(syncUpdates2).toMatchInlineSnapshot(`
@@ -1411,20 +1418,6 @@ Array [
         "presence": undefined,
         "ref": "ZLVXz73q",
         "userId": "b",
-      },
-    ],
-    Object {
-      "origin": "remote",
-    },
-  ],
-  Array [
-    Array [
-      Object {
-        "clientId": "a",
-        "presence": undefined,
-        "ref": "x_n2sT7P",
-        "self": true,
-        "userId": "a",
       },
     ],
     Object {

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -96,7 +96,6 @@ function newRemoteStore(online?: boolean) {
 }
 
 describe('Remote sync', () => {
-  jest.setTimeout(1000000000);
   it('syncs one client to a remote', async () => {
     const remoteStore = newStore();
     const localStore = newStore(remoteStore);

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -96,6 +96,7 @@ function newRemoteStore(online?: boolean) {
 }
 
 describe('Remote sync', () => {
+  jest.setTimeout(1000000000);
   it('syncs one client to a remote', async () => {
     const remoteStore = newStore();
     const localStore = newStore(remoteStore);

--- a/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Remote.test.ts
@@ -114,109 +114,109 @@ describe('Remote sync', () => {
     const remoteGraph1 = basicGraph(remoteStore, client);
     expect(remoteGraph1).toEqual(localGraph1);
     expect(localGraph1).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "graph": "undefined -> Zob0dMmD",
-    "step": "initialize",
-    "value": Object {},
-  },
-  Object {
-    "graph": "Zob0dMmD -> leySPlIR",
-    "step": "add hello",
-    "value": Object {
-      "hello": "world",
-    },
-  },
-]
-`);
+      Array [
+        Object {
+          "graph": "undefined -> Zob0dMmD",
+          "step": "initialize",
+          "value": Object {},
+        },
+        Object {
+          "graph": "Zob0dMmD -> leySPlIR",
+          "step": "add hello",
+          "value": Object {
+            "hello": "world",
+          },
+        },
+      ]
+    `);
     expect(syncUpdates).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "loading",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "connecting",
-    "remoteRead": "loading",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "loading",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-]
-`);
+      Array [
+        Object {
+          "localRead": "loading",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "loading",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "connecting",
+          "remoteRead": "loading",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "loading",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "ready",
+        },
+      ]
+    `);
   });
   it('handles shutdown while connecting', async () => {
     const remoteStore = newRemoteStore(false);
@@ -251,70 +251,70 @@ Array [
     const remoteGraph1 = basicGraph(remoteStore, client);
     expect(remoteGraph1).toEqual(localGraph1);
     expect(localGraph1).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "graph": "undefined -> Zob0dMmD",
-    "step": "initialize",
-    "value": Object {},
-  },
-  Object {
-    "graph": "Zob0dMmD -> leySPlIR",
-    "step": "add hello",
-    "value": Object {
-      "hello": "world",
-    },
-  },
-  Object {
-    "graph": "leySPlIR -> DWZJPKBc",
-    "step": "edit hello",
-    "value": Object {
-      "hello": "world 2",
-    },
-  },
-  Object {
-    "graph": "DWZJPKBc -> EM9w-Vme",
-    "step": "edit hello",
-    "value": Object {
-      "hello": "world 3",
-    },
-  },
-  Object {
-    "graph": "EM9w-Vme -> bPTFg9aG",
-    "step": "edit hello",
-    "value": Object {
-      "hello": "world 4",
-    },
-  },
-  Object {
-    "graph": "bPTFg9aG -> SZgOrzaG",
-    "step": "edit hello",
-    "value": Object {
-      "hello": "world 5",
-    },
-  },
-  Object {
-    "graph": "SZgOrzaG -> s9y6mchq",
-    "step": "edit hello",
-    "value": Object {
-      "hello": "world 6",
-    },
-  },
-  Object {
-    "graph": "s9y6mchq -> DnqoAp6m",
-    "step": "edit hello",
-    "value": Object {
-      "hello": "world 7",
-    },
-  },
-  Object {
-    "graph": "DnqoAp6m -> _fOHZjAT",
-    "step": "edit hello",
-    "value": Object {
-      "hello": "world 8",
-    },
-  },
-]
-`);
+      Array [
+        Object {
+          "graph": "undefined -> Zob0dMmD",
+          "step": "initialize",
+          "value": Object {},
+        },
+        Object {
+          "graph": "Zob0dMmD -> leySPlIR",
+          "step": "add hello",
+          "value": Object {
+            "hello": "world",
+          },
+        },
+        Object {
+          "graph": "leySPlIR -> DWZJPKBc",
+          "step": "edit hello",
+          "value": Object {
+            "hello": "world 2",
+          },
+        },
+        Object {
+          "graph": "DWZJPKBc -> EM9w-Vme",
+          "step": "edit hello",
+          "value": Object {
+            "hello": "world 3",
+          },
+        },
+        Object {
+          "graph": "EM9w-Vme -> bPTFg9aG",
+          "step": "edit hello",
+          "value": Object {
+            "hello": "world 4",
+          },
+        },
+        Object {
+          "graph": "bPTFg9aG -> SZgOrzaG",
+          "step": "edit hello",
+          "value": Object {
+            "hello": "world 5",
+          },
+        },
+        Object {
+          "graph": "SZgOrzaG -> s9y6mchq",
+          "step": "edit hello",
+          "value": Object {
+            "hello": "world 6",
+          },
+        },
+        Object {
+          "graph": "s9y6mchq -> DnqoAp6m",
+          "step": "edit hello",
+          "value": Object {
+            "hello": "world 7",
+          },
+        },
+        Object {
+          "graph": "DnqoAp6m -> _fOHZjAT",
+          "step": "edit hello",
+          "value": Object {
+            "hello": "world 8",
+          },
+        },
+      ]
+    `);
   });
 
   it('syncs two clients to a remote', async () => {
@@ -342,250 +342,250 @@ Array [
     await timeout();
 
     expect(syncUpdates1).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "loading",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "connecting",
-    "remoteRead": "loading",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "loading",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-]
-`);
+      Array [
+        Object {
+          "localRead": "loading",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "loading",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "connecting",
+          "remoteRead": "loading",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "loading",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "ready",
+        },
+      ]
+    `);
     expect(syncUpdates2).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-]
-`);
+      Array [
+        Object {
+          "localRead": "loading",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "ready",
+        },
+      ]
+    `);
     expect(client1Sub.mock.calls).toMatchInlineSnapshot(`
-Array [
-  Array [
-    Array [
-      Object {
-        "clientId": "a",
-        "presence": undefined,
-        "ref": undefined,
-        "self": true,
-        "userId": "test",
-      },
-    ],
-    Object {
-      "origin": "subscribe",
-    },
-  ],
-  Array [
-    Array [
-      Object {
-        "clientId": "a",
-        "presence": undefined,
-        "ref": "Zob0dMmD",
-        "self": true,
-        "userId": "test",
-      },
-    ],
-    Object {
-      "origin": "self",
-    },
-  ],
-  Array [
-    Array [
-      Object {
-        "clientId": "a",
-        "presence": undefined,
-        "ref": "Zob0dMmD",
-        "self": true,
-        "userId": "test",
-      },
-    ],
-    Object {
-      "origin": "self",
-    },
-  ],
-  Array [
-    Array [
-      Object {
-        "clientId": "a",
-        "presence": undefined,
-        "ref": "leySPlIR",
-        "self": true,
-        "userId": "test",
-      },
-    ],
-    Object {
-      "origin": "self",
-    },
-  ],
-  Array [
-    Array [
-      Object {
-        "clientId": "a",
-        "presence": undefined,
-        "ref": "leySPlIR",
-        "self": true,
-        "userId": "test",
-      },
-    ],
-    Object {
-      "origin": "self",
-    },
-  ],
-  Array [
-    Array [
-      Object {
-        "clientId": "a",
-        "presence": undefined,
-        "ref": "leySPlIR",
-        "self": true,
-        "userId": "test",
-      },
-      Object {
-        "clientId": "b",
-        "presence": undefined,
-        "ref": undefined,
-        "userId": "test",
-      },
-    ],
-    Object {
-      "origin": "local",
-    },
-  ],
-]
-`);
+      Array [
+        Array [
+          Array [
+            Object {
+              "clientId": "a",
+              "presence": undefined,
+              "ref": undefined,
+              "self": true,
+              "userId": "test",
+            },
+          ],
+          Object {
+            "origin": "subscribe",
+          },
+        ],
+        Array [
+          Array [
+            Object {
+              "clientId": "a",
+              "presence": undefined,
+              "ref": "Zob0dMmD",
+              "self": true,
+              "userId": "test",
+            },
+          ],
+          Object {
+            "origin": "self",
+          },
+        ],
+        Array [
+          Array [
+            Object {
+              "clientId": "a",
+              "presence": undefined,
+              "ref": "Zob0dMmD",
+              "self": true,
+              "userId": "test",
+            },
+          ],
+          Object {
+            "origin": "self",
+          },
+        ],
+        Array [
+          Array [
+            Object {
+              "clientId": "a",
+              "presence": undefined,
+              "ref": "leySPlIR",
+              "self": true,
+              "userId": "test",
+            },
+          ],
+          Object {
+            "origin": "self",
+          },
+        ],
+        Array [
+          Array [
+            Object {
+              "clientId": "a",
+              "presence": undefined,
+              "ref": "leySPlIR",
+              "self": true,
+              "userId": "test",
+            },
+          ],
+          Object {
+            "origin": "self",
+          },
+        ],
+        Array [
+          Array [
+            Object {
+              "clientId": "a",
+              "presence": undefined,
+              "ref": "leySPlIR",
+              "self": true,
+              "userId": "test",
+            },
+            Object {
+              "clientId": "b",
+              "presence": undefined,
+              "ref": undefined,
+              "userId": "test",
+            },
+          ],
+          Object {
+            "origin": "local",
+          },
+        ],
+      ]
+    `);
     expect(client2Sub.mock.calls).toMatchInlineSnapshot(`
-Array [
-  Array [
-    Array [
-      Object {
-        "clientId": "b",
-        "presence": undefined,
-        "ref": undefined,
-        "self": true,
-        "userId": "test",
-      },
-    ],
-    Object {
-      "origin": "subscribe",
-    },
-  ],
-  Array [
-    Array [
-      Object {
-        "clientId": "b",
-        "presence": undefined,
-        "ref": undefined,
-        "self": true,
-        "userId": "test",
-      },
-      Object {
-        "clientId": "a",
-        "presence": undefined,
-        "ref": "leySPlIR",
-        "userId": "test",
-      },
-    ],
-    Object {
-      "origin": "local",
-    },
-  ],
-]
-`);
+      Array [
+        Array [
+          Array [
+            Object {
+              "clientId": "b",
+              "presence": undefined,
+              "ref": undefined,
+              "self": true,
+              "userId": "test",
+            },
+          ],
+          Object {
+            "origin": "subscribe",
+          },
+        ],
+        Array [
+          Array [
+            Object {
+              "clientId": "b",
+              "presence": undefined,
+              "ref": undefined,
+              "self": true,
+              "userId": "test",
+            },
+            Object {
+              "clientId": "a",
+              "presence": undefined,
+              "ref": "leySPlIR",
+              "userId": "test",
+            },
+          ],
+          Object {
+            "origin": "local",
+          },
+        ],
+      ]
+    `);
   });
 
   it('syncs two clients to remote with a local split', async () => {
@@ -614,14 +614,14 @@ Array [
       ]
     `);
     expect(states2).toMatchInlineSnapshot(`
-Array [
-  undefined,
-  Object {},
-  Object {
-    "hello": "world",
-  },
-]
-`);
+      Array [
+        undefined,
+        Object {},
+        Object {
+          "hello": "world",
+        },
+      ]
+    `);
 
     localStore.localNetworkPaused = true;
 
@@ -641,49 +641,49 @@ Array [
       ]
     `);
     expect(states2).toMatchInlineSnapshot(`
-Array [
-  undefined,
-  Object {},
-  Object {
-    "hello": "world",
-  },
-  Object {
-    "hello": "world",
-    "world": "hello",
-  },
-]
-`);
+      Array [
+        undefined,
+        Object {},
+        Object {
+          "hello": "world",
+        },
+        Object {
+          "hello": "world",
+          "world": "hello",
+        },
+      ]
+    `);
 
     localStore.localNetworkPaused = false;
 
     await timeout(100);
 
     expect(states1).toMatchInlineSnapshot(`
-Array [
-  undefined,
-  Object {},
-  Object {
-    "hello": "world",
-  },
-  Object {
-    "hello": "world",
-    "world": "hello",
-  },
-]
-`);
+      Array [
+        undefined,
+        Object {},
+        Object {
+          "hello": "world",
+        },
+        Object {
+          "hello": "world",
+          "world": "hello",
+        },
+      ]
+    `);
     expect(states2).toMatchInlineSnapshot(`
-Array [
-  undefined,
-  Object {},
-  Object {
-    "hello": "world",
-  },
-  Object {
-    "hello": "world",
-    "world": "hello",
-  },
-]
-`);
+      Array [
+        undefined,
+        Object {},
+        Object {
+          "hello": "world",
+        },
+        Object {
+          "hello": "world",
+          "world": "hello",
+        },
+      ]
+    `);
   });
 
   it('syncs one clients to a store multiple times', async () => {
@@ -717,177 +717,177 @@ Array [
     expect(remoteGraph3).toEqual(localGraph3);
 
     expect(syncUpdates).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "loading",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "connecting",
-    "remoteRead": "loading",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "loading",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "connecting",
-    "remoteRead": "loading",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "loading",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-]
-`);
+      Array [
+        Object {
+          "localRead": "loading",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "loading",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "connecting",
+          "remoteRead": "loading",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "loading",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "connecting",
+          "remoteRead": "loading",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "loading",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "ready",
+        },
+      ]
+    `);
   });
 
   it('handles leader network split', async () => {
@@ -1003,267 +1003,260 @@ Array [
     const graph1 = basicGraph(store1, client1);
     const graph2 = basicGraph(store2, client1);
     expect(graph1).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "graph": "undefined -> Zob0dMmD",
-    "step": "initialize",
-    "value": Object {},
-  },
-  Object {
-    "graph": "Zob0dMmD -> leySPlIR",
-    "step": "add hello",
-    "value": Object {
-      "hello": "world",
-    },
-  },
-  Object {
-    "graph": "leySPlIR -> x_n2sT7P",
-    "step": "change hello",
-    "value": Object {
-      "hello": "vorld",
-    },
-  },
-  Object {
-    "graph": "x_n2sT7P -> iOywLlrW",
-    "step": "add world",
-    "value": Object {
-      "hello": "vorld",
-      "world": "world",
-    },
-  },
-  Object {
-    "graph": "iOywLlrW -> ZLVXz73q",
-    "step": "change world",
-    "value": Object {
-      "hello": "vorld",
-      "world": "vorld",
-    },
-  },
-]
-`);
+      Array [
+        Object {
+          "graph": "undefined -> Zob0dMmD",
+          "step": "initialize",
+          "value": Object {},
+        },
+        Object {
+          "graph": "Zob0dMmD -> leySPlIR",
+          "step": "add hello",
+          "value": Object {
+            "hello": "world",
+          },
+        },
+        Object {
+          "graph": "leySPlIR -> x_n2sT7P",
+          "step": "change hello",
+          "value": Object {
+            "hello": "vorld",
+          },
+        },
+        Object {
+          "graph": "x_n2sT7P -> iOywLlrW",
+          "step": "add world",
+          "value": Object {
+            "hello": "vorld",
+            "world": "world",
+          },
+        },
+        Object {
+          "graph": "iOywLlrW -> ZLVXz73q",
+          "step": "change world",
+          "value": Object {
+            "hello": "vorld",
+            "world": "vorld",
+          },
+        },
+      ]
+    `);
     expect(graph2).toEqual(graph1);
 
     await client1.shutdown();
     await client2.shutdown();
 
     expect(syncUpdates1).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "loading",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "connecting",
-    "remoteRead": "loading",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "loading",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "error",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-]
-`);
+      Array [
+        Object {
+          "localRead": "loading",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "loading",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "connecting",
+          "remoteRead": "loading",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "loading",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+      ]
+    `);
     expect(syncUpdates2).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "localRead": "loading",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "connecting",
-    "remoteRead": "loading",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "loading",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "pending",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "saving",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "saving",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "online",
-    "remoteRead": "ready",
-    "remoteSave": "ready",
-  },
-  Object {
-    "localRead": "ready",
-    "localSave": "ready",
-    "remoteConnect": "offline",
-    "remoteRead": "offline",
-    "remoteSave": "ready",
-  },
-]
-`);
+      Array [
+        Object {
+          "localRead": "loading",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "connecting",
+          "remoteRead": "loading",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "loading",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "pending",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "saving",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "saving",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "online",
+          "remoteRead": "ready",
+          "remoteSave": "ready",
+        },
+        Object {
+          "localRead": "ready",
+          "localSave": "ready",
+          "remoteConnect": "offline",
+          "remoteRead": "offline",
+          "remoteSave": "ready",
+        },
+      ]
+    `);
     expect(client1ListSub.mock.calls).toMatchInlineSnapshot(`
 Array [
   Array [
@@ -1418,6 +1411,20 @@ Array [
         "presence": undefined,
         "ref": "ZLVXz73q",
         "userId": "b",
+      },
+    ],
+    Object {
+      "origin": "remote",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "clientId": "a",
+        "presence": undefined,
+        "ref": "x_n2sT7P",
+        "self": true,
+        "userId": "a",
       },
     ],
     Object {
@@ -1615,25 +1622,25 @@ Array [
     await timeout();
 
     expect(basicClients(client1)).toMatchInlineSnapshot(`
-Object {
-  "a:client1": "presence 1",
-  "b:client2": "presence 2",
-  "b:client3": "presence 3",
-}
-`);
+      Object {
+        "a:client1": "presence 1",
+        "b:client2": "presence 2",
+        "b:client3": "presence 3",
+      }
+    `);
     expect(basicClients(client2)).toMatchInlineSnapshot(`
-Object {
-  "a:client1": "presence 1",
-  "b:client2": "presence 2",
-  "b:client3": "presence 3",
-}
-`);
+      Object {
+        "a:client1": "presence 1",
+        "b:client2": "presence 2",
+        "b:client3": "presence 3",
+      }
+    `);
     expect(basicClients(client3)).toMatchInlineSnapshot(`
-Object {
-  "a:client1": "presence 1",
-  "b:client2": "presence 2",
-  "b:client3": "presence 3",
-}
-`);
+      Object {
+        "a:client1": "presence 1",
+        "b:client2": "presence 2",
+        "b:client3": "presence 3",
+      }
+    `);
   });
 });

--- a/packages/trimerge-sync/src/index.ts
+++ b/packages/trimerge-sync/src/index.ts
@@ -4,4 +4,5 @@ export * from './types';
 export * from './AbstractLocalStore';
 export * from './validateCommits';
 export * from './lib/PromiseQueue';
+export * from './lib/EventChannel';
 export * from './merge-all-helper';

--- a/packages/trimerge-sync/src/lib/EventChannel.ts
+++ b/packages/trimerge-sync/src/lib/EventChannel.ts
@@ -1,0 +1,16 @@
+import { SyncEvent } from '../types';
+
+export type BroadcastEvent<CommitMetadata, Delta, Presence> = {
+  event: SyncEvent<CommitMetadata, Delta, Presence>;
+  remoteOrigin: boolean;
+};
+
+export type EventChannel<CommitMetadata, Delta, Presence> = {
+  onEvent(
+    cb: (ev: BroadcastEvent<CommitMetadata, Delta, Presence>) => void,
+  ): void;
+  sendEvent(
+    ev: BroadcastEvent<CommitMetadata, Delta, Presence>,
+  ): void | Promise<void>;
+  shutdown(): void | Promise<void>;
+};

--- a/packages/trimerge-sync/src/lib/LeaderManager.test.ts
+++ b/packages/trimerge-sync/src/lib/LeaderManager.test.ts
@@ -40,7 +40,7 @@ function makeLeaderManager(
   );
   channel.onMessage = (event) => leaderManagement.receiveEvent(event);
   async function close(cleanShutdown: boolean | undefined) {
-    leaderManagement.close(cleanShutdown);
+    leaderManagement.shutdown(cleanShutdown);
     channel.close();
 
     // need to wait for messages to send
@@ -85,7 +85,7 @@ describe('LeaderManagement', () => {
         events.push(e);
       },
     );
-    lm.close();
+    lm.shutdown();
     await timeout();
     lm.receiveEvent({ type: 'leader', action: 'request', clientId: 'foo' });
     expect(events).toMatchInlineSnapshot(`

--- a/packages/trimerge-sync/src/lib/LeaderManager.ts
+++ b/packages/trimerge-sync/src/lib/LeaderManager.ts
@@ -186,7 +186,7 @@ export class LeaderManager {
     }
   }
 
-  close(cleanShutdown: boolean = true) {
+  shutdown(cleanShutdown: boolean = true) {
     if (this.closed) {
       return;
     }

--- a/packages/trimerge-sync/src/lib/PromiseQueue.ts
+++ b/packages/trimerge-sync/src/lib/PromiseQueue.ts
@@ -1,13 +1,20 @@
 /**
- * Ensures only one promise is being called at a time.
- *
- * Used for testing
+ * Ensures that provided promises are called in the order they were received, one at a time.
  */
 export class PromiseQueue {
   private promise: Promise<unknown> = Promise.resolve();
+  private running = true;
   add<T>(exec: () => Promise<T>): Promise<T> {
+    if (!this.running) {
+      return Promise.reject(new Error('PromiseQueue is closed'));
+    }
     const typedPromise = this.promise.then(exec);
     this.promise = typedPromise.catch(() => undefined);
     return typedPromise;
+  }
+
+  async shutdown(): Promise<void> {
+    this.running = false;
+    return await this.promise.then();
   }
 }

--- a/packages/trimerge-sync/src/testLib/MemoryBroadcastChannel.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryBroadcastChannel.ts
@@ -1,4 +1,4 @@
-import { BroadcastEvent, EventChannel } from '../AbstractLocalStore';
+import { BroadcastEvent, EventChannel } from '../lib/EventChannel';
 import { removeItem } from './Arrays';
 
 const ALL_CHANNELS = new Map<string, MemoryBroadcastChannel<any>[]>();

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
@@ -21,7 +21,7 @@ describe('MemoryLocalStore', () => {
       undefined,
     );
 
-    const callsBeforeShutdown = fn.mock.calls;
+    const callsBeforeShutdown = [...fn.mock.calls];
 
     expect(fn.mock.calls).toMatchInlineSnapshot(`
       Array [

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.test.ts
@@ -21,59 +21,73 @@ describe('MemoryLocalStore', () => {
       undefined,
     );
 
+    const callsBeforeShutdown = fn.mock.calls;
+
     expect(fn.mock.calls).toMatchInlineSnapshot(`
-Array [
-  Array [
-    Object {
-      "commits": Array [
-        Object {
-          "metadata": undefined,
-          "ref": "test1",
-        },
-      ],
-      "syncId": "0",
-      "type": "commits",
-    },
-    false,
-  ],
-  Array [
-    Object {
-      "type": "ready",
-    },
-    false,
-  ],
-  Array [
-    Object {
-      "connect": "offline",
-      "read": "offline",
-      "save": "pending",
-      "type": "remote-state",
-    },
-    false,
-  ],
-  Array [
-    Object {
-      "acks": Array [
-        Object {
-          "ref": "test1",
-        },
-      ],
-      "syncId": "1",
-      "type": "ack",
-    },
-    false,
-  ],
-  Array [
-    Object {
-      "connect": "offline",
-      "read": "offline",
-      "save": "saving",
-      "type": "remote-state",
-    },
-    false,
-  ],
-]
-`);
+      Array [
+        Array [
+          Object {
+            "commits": Array [
+              Object {
+                "metadata": undefined,
+                "ref": "test1",
+              },
+            ],
+            "syncId": "0",
+            "type": "commits",
+          },
+          false,
+        ],
+        Array [
+          Object {
+            "type": "ready",
+          },
+          false,
+        ],
+        Array [
+          Object {
+            "connect": "offline",
+            "read": "offline",
+            "save": "pending",
+            "type": "remote-state",
+          },
+          false,
+        ],
+        Array [
+          Object {
+            "acks": Array [
+              Object {
+                "ref": "test1",
+              },
+            ],
+            "syncId": "1",
+            "type": "ack",
+          },
+          false,
+        ],
+        Array [
+          Object {
+            "connect": "offline",
+            "read": "offline",
+            "save": "saving",
+            "type": "remote-state",
+          },
+          false,
+        ],
+        Array [
+          Object {
+            "info": Object {
+              "clientId": "test",
+              "presence": undefined,
+              "ref": undefined,
+              "userId": "test",
+            },
+            "type": "client-presence",
+          },
+          false,
+        ],
+      ]
+    `);
 
     await local.shutdown();
     await local.update(
@@ -85,58 +99,6 @@ Array [
       ],
       undefined,
     );
-    expect(fn.mock.calls).toMatchInlineSnapshot(`
-Array [
-  Array [
-    Object {
-      "commits": Array [
-        Object {
-          "metadata": undefined,
-          "ref": "test1",
-        },
-      ],
-      "syncId": "0",
-      "type": "commits",
-    },
-    false,
-  ],
-  Array [
-    Object {
-      "type": "ready",
-    },
-    false,
-  ],
-  Array [
-    Object {
-      "connect": "offline",
-      "read": "offline",
-      "save": "pending",
-      "type": "remote-state",
-    },
-    false,
-  ],
-  Array [
-    Object {
-      "acks": Array [
-        Object {
-          "ref": "test1",
-        },
-      ],
-      "syncId": "1",
-      "type": "ack",
-    },
-    false,
-  ],
-  Array [
-    Object {
-      "connect": "offline",
-      "read": "offline",
-      "save": "saving",
-      "type": "remote-state",
-    },
-    false,
-  ],
-]
-`);
+    expect(fn.mock.calls).toEqual(callsBeforeShutdown);
   });
 });

--- a/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryLocalStore.ts
@@ -1,5 +1,5 @@
-import { AbstractLocalStore, BroadcastEvent } from '../AbstractLocalStore';
-import { MemoryBroadcastChannel } from './MemoryBroadcastChannel';
+import { AbstractLocalStore } from '../AbstractLocalStore';
+import { MemoryEventChannel } from './MemoryBroadcastChannel';
 import {
   AckCommitsEvent,
   Commit,
@@ -17,9 +17,6 @@ export class MemoryLocalStore<
   Presence,
 > extends AbstractLocalStore<CommitMetadata, Delta, Presence> {
   private _closed = false;
-  public readonly channel: MemoryBroadcastChannel<
-    BroadcastEvent<CommitMetadata, Delta, Presence>
-  >;
 
   constructor(
     private readonly store: MemoryStore<CommitMetadata, Delta, Presence>,
@@ -27,18 +24,24 @@ export class MemoryLocalStore<
     clientId: string,
     onEvent: OnStoreEventFn<CommitMetadata, Delta, Presence>,
     getRemote?: GetRemoteFn<CommitMetadata, Delta, Presence>,
+    readonly channel = new MemoryEventChannel<CommitMetadata, Delta, Presence>(
+      'local:' + store.channelName,
+    ),
   ) {
-    super(userId, clientId, onEvent, getRemote, {
-      initialDelayMs: 0,
-      reconnectBackoffMultiplier: 1,
-      maxReconnectDelayMs: 0,
-      electionTimeoutMs: 0,
-      heartbeatIntervalMs: 10,
-      heartbeatTimeoutMs: 50,
-    });
-    this.channel = new MemoryBroadcastChannel(
-      'local:' + this.store.channelName,
-      this.onLocalBroadcastEvent,
+    super(
+      userId,
+      clientId,
+      onEvent,
+      getRemote,
+      {
+        initialDelayMs: 0,
+        reconnectBackoffMultiplier: 1,
+        maxReconnectDelayMs: 0,
+        electionTimeoutMs: 0,
+        heartbeatIntervalMs: 10,
+        heartbeatTimeoutMs: 50,
+      },
+      channel,
     );
     this.initialize().catch(this.handleAsError('internal'));
   }
@@ -55,15 +58,6 @@ export class MemoryLocalStore<
     remoteSyncId: string,
   ): Promise<void> {
     await this.store.acknowledgeCommits(refs, remoteSyncId);
-  }
-
-  protected async broadcastLocal(
-    event: BroadcastEvent<CommitMetadata, Delta, Presence>,
-  ): Promise<void> {
-    if (this._closed) {
-      return;
-    }
-    await this.channel.postMessage(event);
   }
 
   protected async *getLocalCommits(): AsyncIterableIterator<
@@ -89,6 +83,5 @@ export class MemoryLocalStore<
     await super.shutdown();
     // Must be after super.shutdown() because it needs to call broadcastLocal()
     this._closed = true;
-    this.channel.close();
   }
 }


### PR DESCRIPTION
We don't think we need to rely on the broadcast-channel npm package anymore so this PR, removes the explicit dependency on it.

One nice thing the broadcast-channel npm package does is support node so we actually still depend on broadcast channel for tests but this allows clients to make that decision for themselves.

One thing that occurred to me was that given that AbstractLocal store relies on subclasses to implement `broadcastLocal()` potentially this can be a dependency that AbstractLocalStore can accept directly?