### PR TITLE
add a remote read invalid status

### DIFF
--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -70,7 +70,7 @@ export type RemoteReadStatus =
   | 'offline'
   | 'loading'
   | 'ready'
-  | 'invalid' /** the remote is in a bad state */;
+  | 'error' /** the remote is in a persistent state */;
 
 export type RemoteSaveStatus =
   | 'ready' /**  all local state has been synced to remote (though maybe local changes in memory) */

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -66,7 +66,11 @@ export type LocalSaveStatus =
 
 export type RemoteConnectStatus = 'offline' | 'connecting' | 'online';
 
-export type RemoteReadStatus = 'offline' | 'loading' | 'ready';
+export type RemoteReadStatus =
+  | 'offline'
+  | 'loading'
+  | 'ready'
+  | 'invalid' /** the remote is in a bad state */;
 
 export type RemoteSaveStatus =
   | 'ready' /**  all local state has been synced to remote (though maybe local changes in memory) */

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -70,7 +70,7 @@ export type RemoteReadStatus =
   | 'offline'
   | 'loading'
   | 'ready'
-  | 'error' /** the remote is in a persistent state */;
+  | 'error' /** the remote is in a persistent bad state */;
 
 export type RemoteSaveStatus =
   | 'ready' /**  all local state has been synced to remote (though maybe local changes in memory) */


### PR DESCRIPTION
This status would be used to indicate that we've successfully read from the remote and we've determined it to be in an invalid state.