### PR TITLE
export `getDocDatabase` utility

### DIFF
--- a/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
+++ b/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
@@ -86,7 +86,7 @@ export async function resetDocRemoteSyncData(docId: string): Promise<void> {
 export function getIDBPDatabase<CommitMetadata, Delta>(
   docId: string,
 ): Promise<IDBPDatabase<TrimergeSyncDbSchema<CommitMetadata, Delta>>> {
-  return getDocDatabase(getDatabaseName(docId));
+  return createIndexedDb(getDatabaseName(docId));
 }
 export type AddStoreMetadataFn<CommitMetadata> = (
   commit: Commit<CommitMetadata>,
@@ -235,7 +235,7 @@ export class IndexedDbCommitRepository<CommitMetadata, Delta, Presence>
       );
       await timeout(3_000);
     }
-    const db = await getDocDatabase<CommitMetadata, Delta>(this.dbName);
+    const db = await createIndexedDb<CommitMetadata, Delta>(this.dbName);
     db.onclose = () => {
       this.db = this.connect(true);
     };
@@ -422,12 +422,6 @@ interface TrimergeSyncDbSchema<CommitMetadata, Delta> extends DBSchema {
       lastSyncCursor?: string;
     };
   };
-}
-
-export function getDocDatabase<CommitMetadata, Delta>(
-  docId: string,
-): Promise<IDBPDatabase<TrimergeSyncDbSchema<CommitMetadata, Delta>>> {
-  return createIndexedDb(getDatabaseName(docId));
 }
 
 function createIndexedDb<CommitMetadata, Delta>(

--- a/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
+++ b/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
@@ -56,8 +56,8 @@ export function deleteDocDatabase(
   {
     blocked,
   }: {
-    /** callback to execute if the db has active connections. */
-    blocked: () => void;
+    /** callback to execute if the DB deletion was blocked due to the DB having active connections. */
+    blocked?: () => void;
   },
 ): Promise<void> {
   return deleteDB(getDatabaseName(docId), { blocked });

--- a/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
+++ b/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
@@ -69,7 +69,7 @@ export function deleteDocDatabase(
  * Should not cause data loss.
  */
 export async function resetDocRemoteSyncData(docId: string): Promise<void> {
-  const db = await getIDBPDatabase(docId);
+  const db = await getIdbpDatabase(docId);
   const tx = await db.transaction(['remotes', 'commits'], 'readwrite');
   const remotes = tx.objectStore('remotes');
   const commits = tx.objectStore('commits');
@@ -83,7 +83,7 @@ export async function resetDocRemoteSyncData(docId: string): Promise<void> {
   await tx.done;
 }
 
-export function getIDBPDatabase<CommitMetadata, Delta>(
+export function getIdbpDatabase<CommitMetadata, Delta>(
   docId: string,
 ): Promise<IDBPDatabase<TrimergeSyncDbSchema<CommitMetadata, Delta>>> {
   return createIndexedDb(getDatabaseName(docId));

--- a/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
+++ b/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
@@ -416,7 +416,7 @@ interface TrimergeSyncDbSchema<CommitMetadata, Delta> extends DBSchema {
   };
 }
 
-function createIndexedDb<CommitMetadata, Delta>(
+export function createIndexedDb<CommitMetadata, Delta>(
   dbName: string,
 ): Promise<IDBPDatabase<TrimergeSyncDbSchema<CommitMetadata, Delta>>> {
   return openDB(dbName, 2, {

--- a/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
+++ b/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
@@ -58,7 +58,7 @@ export function deleteDocDatabase(
   }: {
     /** callback to execute if the DB deletion was blocked due to the DB having active connections. */
     blocked?: () => void;
-  },
+  } = {},
 ): Promise<void> {
   return deleteDB(getDatabaseName(docId), { blocked });
 }

--- a/packages/trimerge-sync-indexed-db/src/index.ts
+++ b/packages/trimerge-sync-indexed-db/src/index.ts
@@ -2,7 +2,7 @@ export {
   IndexedDbCommitRepository,
   deleteDocDatabase,
   resetDocRemoteSyncData,
-  getIDBPDatabase,
+  getIdbpDatabase,
 } from './IndexedDbCommitRepository';
 export type {
   IndexedDbBackendOptions,

--- a/packages/trimerge-sync-indexed-db/src/index.ts
+++ b/packages/trimerge-sync-indexed-db/src/index.ts
@@ -2,6 +2,7 @@ export {
   IndexedDbCommitRepository,
   deleteDocDatabase,
   resetDocRemoteSyncData,
+  createIndexedDb,
 } from './IndexedDbCommitRepository';
 export type {
   IndexedDbBackendOptions,

--- a/packages/trimerge-sync-indexed-db/src/index.ts
+++ b/packages/trimerge-sync-indexed-db/src/index.ts
@@ -2,7 +2,7 @@ export {
   IndexedDbCommitRepository,
   deleteDocDatabase,
   resetDocRemoteSyncData,
-  getDocDatabase,
+  getIDBPDatabase,
 } from './IndexedDbCommitRepository';
 export type {
   IndexedDbBackendOptions,

--- a/packages/trimerge-sync-indexed-db/src/index.ts
+++ b/packages/trimerge-sync-indexed-db/src/index.ts
@@ -2,7 +2,7 @@ export {
   IndexedDbCommitRepository,
   deleteDocDatabase,
   resetDocRemoteSyncData,
-  createIndexedDb,
+  getDocDatabase,
 } from './IndexedDbCommitRepository';
 export type {
   IndexedDbBackendOptions,

--- a/packages/trimerge-sync-indexed-db/src/testLib/IndexedDB.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/IndexedDB.ts
@@ -1,4 +1,4 @@
-import { getIDBPDatabase } from '../IndexedDbCommitRepository';
+import { getIdbpDatabase } from '../IndexedDbCommitRepository';
 
 export function getIdbDatabases(): Promise<
   { name: string; version: number }[]
@@ -9,7 +9,7 @@ export function getIdbDatabases(): Promise<
 }
 
 export async function dumpDatabase(docId: string): Promise<any> {
-  const idb = await getIDBPDatabase(docId);
+  const idb = await getIdbpDatabase(docId);
   const dump: any = {};
   for (const name of idb.objectStoreNames) {
     dump[name] = await idb.getAll(name);


### PR DESCRIPTION
To implement version history, we're reading commits directly from the indexed db. This generally works okay but if the IndexedDb hasn't already been created (i.e. when the project has been newly created), we wind up creating a new invalid indexed db. This change would use the createIndexedDb utility to open the indexed db when reading the commits so that we don't create an invalid instance.