### PR TITLE
Metadata Merging

### DIFF
--- a/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.test.ts
@@ -985,30 +985,32 @@ describe('createIndexedDbBackendFactory', () => {
     await client.shutdown();
 
     await expect(dumpDatabase(docId)).resolves.toMatchInlineSnapshot(`
-            Object {
-              "commits": Array [
-                Object {
-                  "metadata": Object {
-                    "qux": "quux",
-                  },
-                  "ref": "blah",
-                  "remoteSyncId": "blah2",
-                  "syncId": 1,
-                },
-              ],
-              "heads": Array [
-                Object {
-                  "ref": "blah",
-                },
-              ],
-              "remotes": Array [
-                Object {
-                  "lastSyncCursor": "blah2",
-                  "localStoreId": "test-doc-store",
-                },
-              ],
-            }
-          `);
+Object {
+  "commits": Array [
+    Object {
+      "metadata": Object {
+        "bar": "baz",
+        "foo": "bar",
+        "qux": "quux",
+      },
+      "ref": "blah",
+      "remoteSyncId": "blah2",
+      "syncId": 1,
+    },
+  ],
+  "heads": Array [
+    Object {
+      "ref": "blah",
+    },
+  ],
+  "remotes": Array [
+    Object {
+      "lastSyncCursor": "blah2",
+      "localStoreId": "test-doc-store",
+    },
+  ],
+}
+`);
   });
 
   it('updates metadata from remote with two users', async () => {

--- a/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
+++ b/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
@@ -8,6 +8,7 @@ import {
   isMergeCommit,
   RemoteSyncInfo,
   CommitRepository,
+  mergeMetadata,
 } from 'trimerge-sync';
 import type { DBSchema, IDBPDatabase, StoreValue } from 'idb';
 import { deleteDB, openDB } from 'idb';
@@ -178,7 +179,10 @@ export class IndexedDbCommitRepository<CommitMetadata, Delta, Presence>
       // But currently, we're just using this as a synced bit so it's probably fine either way.
       commit.remoteSyncId = remoteSyncId;
       if (metadata !== undefined) {
-        commit.metadata = metadata;
+        commit.metadata = mergeMetadata(
+          commit.metadata,
+          metadata,
+        ) as CommitMetadata;
       }
       return true;
     }

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -373,7 +373,7 @@ export class TrimergeClient<
     if (this.commits.has(ref)) {
       if (type === 'external') {
         // Promote temp commit
-        this.promoteTempCommit(ref);
+        this.updateCommitFromRemote(commit);
         // TODO: upsert commit metadata
       } else {
         console.warn(
@@ -439,6 +439,16 @@ export class TrimergeClient<
     }
     if (this.lastSavedDoc?.ref === ref) {
       this.lastNonTempDoc = this.lastSavedDoc;
+    }
+  }
+
+  private updateCommitFromRemote(commit: Commit<CommitMetadata, Delta>) {
+    if (!this.commits.has(commit.ref)) {
+      return;
+    }
+
+    if (this.tempCommits.has(commit.ref)) {
+      this.promoteTempCommit(commit.ref);
     }
   }
 

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -373,9 +373,7 @@ export class TrimergeClient<
     const { ref, baseRef, mergeRef } = asCommitRefs(commit);
     if (this.commits.has(ref)) {
       if (type === 'external') {
-        // Promote temp commit
         this.updateCommitFromRemote(commit);
-        // TODO: upsert commit metadata
       } else {
         console.warn(
           `[TRIMERGE-SYNC] skipping add commit ${ref}, base ${baseRef}, merge ${mergeRef} (type=${type})`,

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -12,6 +12,7 @@ import { CommitDoc, Differ, MergeHelpers } from './differ';
 import { getFullId } from './util';
 import { OnChangeFn, SubscriberList } from './lib/SubscriberList';
 import { asCommitRefs, CommitRefs } from './lib/Commits';
+import { mergeMetadata } from './lib/mergeMetadata';
 
 type AddCommitType =
   // Added from this client
@@ -443,9 +444,18 @@ export class TrimergeClient<
   }
 
   private updateCommitFromRemote(commit: Commit<CommitMetadata, Delta>) {
-    if (!this.commits.has(commit.ref)) {
+    const existingCommit = this.commits.get(commit.ref);
+    if (!existingCommit) {
       return;
     }
+
+    this.commits.set(commit.ref, {
+      ...commit,
+      metadata: mergeMetadata(
+        existingCommit.metadata,
+        commit.metadata,
+      ) as CommitMetadata,
+    });
 
     if (this.tempCommits.has(commit.ref)) {
       this.promoteTempCommit(commit.ref);

--- a/packages/trimerge-sync/src/index.ts
+++ b/packages/trimerge-sync/src/index.ts
@@ -5,4 +5,5 @@ export * from './CoordinatingLocalStore';
 export * from './validateCommits';
 export * from './lib/PromiseQueue';
 export * from './lib/EventChannel';
+export * from './lib/mergeMetadata';
 export * from './merge-all-helper';

--- a/packages/trimerge-sync/src/lib/mergeMetadata.test.ts
+++ b/packages/trimerge-sync/src/lib/mergeMetadata.test.ts
@@ -58,7 +58,7 @@ describe('mergeMetadata', () => {
     const existingMetadata = new Set([1, 2]);
     const newMetadata = new Set([3, 4]);
     expect(mergeMetadata(existingMetadata, newMetadata)).toEqual(
-      new Set([1, 2, 3, 4]),
+      new Set([3, 4]),
     );
   });
 
@@ -100,26 +100,25 @@ describe('mergeMetadata', () => {
       ]),
     };
     expect(mergeMetadata(existingMetadata, newMetadata)).toMatchInlineSnapshot(`
-      Object {
-        "a": 3,
-        "b": Object {
-          "c": 4,
-          "d": 5,
-        },
-        "x": Array [
-          1,
-          2,
-        ],
-        "y": Map {
-          "a" => 1,
-          "b" => 2,
-          "c" => Set {
-            1,
-            2,
-            3,
-          },
-        },
-      }
-    `);
+Object {
+  "a": 3,
+  "b": Object {
+    "c": 4,
+    "d": 5,
+  },
+  "x": Array [
+    1,
+    2,
+  ],
+  "y": Map {
+    "a" => 1,
+    "b" => 2,
+    "c" => Set {
+      2,
+      3,
+    },
+  },
+}
+`);
   });
 });

--- a/packages/trimerge-sync/src/lib/mergeMetadata.test.ts
+++ b/packages/trimerge-sync/src/lib/mergeMetadata.test.ts
@@ -1,0 +1,125 @@
+import { mergeMetadata } from './mergeMetadata';
+
+describe('mergeMetadata', () => {
+  it('merges simple objects', () => {
+    const existingMetadata = { a: 1, b: 2 };
+    const newMetadata = { a: 3, c: 4 };
+    expect(mergeMetadata(existingMetadata, newMetadata)).toEqual({
+      a: 3,
+      b: 2,
+      c: 4,
+    });
+  });
+
+  it('should return newMetadata if existingMetadata is undefined', () => {
+    const existingMetadata = undefined;
+    const newMetadata = { a: 3, c: 4 };
+    expect(mergeMetadata(existingMetadata, newMetadata)).toEqual(newMetadata);
+  });
+
+  it('should return existingMetadata if newMetadata is undefined', () => {
+    const existingMetadata = { a: 1, b: 2 };
+    const newMetadata = undefined;
+    expect(mergeMetadata(existingMetadata, newMetadata)).toEqual(
+      existingMetadata,
+    );
+  });
+
+  it('shouldnt merge arrays', () => {
+    const existingMetadata = [1, 2];
+    const newMetadata = [3, 4];
+    expect(mergeMetadata(existingMetadata, newMetadata)).toEqual(newMetadata);
+  });
+
+  it('recurses correctly', () => {
+    const existingMetadata = { a: 1, b: { c: 2 } };
+    const newMetadata = { a: 3, b: { c: 4 } };
+    expect(mergeMetadata(existingMetadata, newMetadata)).toEqual({
+      a: 3,
+      b: { c: 4 },
+    });
+  });
+
+  it('returns newMetadata if they are different types', () => {
+    const existingMetadata = { a: 1, b: 2 };
+    const newMetadata = [3, 4];
+    expect(mergeMetadata(existingMetadata, newMetadata)).toEqual(newMetadata);
+    expect(mergeMetadata([2, 1], 8)).toEqual(8);
+    expect(mergeMetadata(8, [2, 1])).toEqual([2, 1]);
+    expect(mergeMetadata('blah', [2, 1])).toEqual([2, 1]);
+  });
+
+  it('returns new metadata for simple types', () => {
+    expect(mergeMetadata(2, 5)).toEqual(5);
+    expect(mergeMetadata('blah', 'bar')).toEqual('bar');
+  });
+
+  it('merges sets', () => {
+    const existingMetadata = new Set([1, 2]);
+    const newMetadata = new Set([3, 4]);
+    expect(mergeMetadata(existingMetadata, newMetadata)).toEqual(
+      new Set([1, 2, 3, 4]),
+    );
+  });
+
+  it('merges maps', () => {
+    const existingMetadata = new Map([
+      ['a', 1],
+      ['b', 2],
+    ]);
+    const newMetadata = new Map([
+      ['a', 3],
+      ['c', 4],
+    ]);
+    expect(mergeMetadata(existingMetadata, newMetadata)).toEqual(
+      new Map([
+        ['a', 3],
+        ['b', 2],
+        ['c', 4],
+      ]),
+    );
+  });
+
+  it('merges a complex example', () => {
+    const existingMetadata = {
+      a: 1,
+      b: { c: 2, d: [1, 3] },
+      x: [1, 2],
+      y: new Map<string, number | Set<number>>([
+        ['a', 1],
+        ['b', 2],
+        ['c', new Set([1, 2])],
+      ]),
+    };
+    const newMetadata = {
+      a: 3,
+      b: { c: 4, d: 5 },
+      y: new Map<string, number | Set<number>>([
+        ['a', 1],
+        ['c', new Set([2, 3])],
+      ]),
+    };
+    expect(mergeMetadata(existingMetadata, newMetadata)).toMatchInlineSnapshot(`
+      Object {
+        "a": 3,
+        "b": Object {
+          "c": 4,
+          "d": 5,
+        },
+        "x": Array [
+          1,
+          2,
+        ],
+        "y": Map {
+          "a" => 1,
+          "b" => 2,
+          "c" => Set {
+            1,
+            2,
+            3,
+          },
+        },
+      }
+    `);
+  });
+});

--- a/packages/trimerge-sync/src/lib/mergeMetadata.ts
+++ b/packages/trimerge-sync/src/lib/mergeMetadata.ts
@@ -5,18 +5,28 @@ export function mergeMetadata(
   existingMetadata: unknown,
   newMetadata: unknown,
 ): unknown {
+  // check for null
   if (existingMetadata === undefined || existingMetadata === null) {
     return newMetadata;
   }
   if (newMetadata === undefined || newMetadata === null) {
     return existingMetadata;
   }
+
+  // check for mismatched types
   if (
     typeof existingMetadata !== typeof newMetadata ||
     Array.isArray(existingMetadata) !== Array.isArray(newMetadata)
   ) {
     return newMetadata;
   }
+
+  // bail on arrays, just take newMetadata's value
+  if (Array.isArray(existingMetadata) && Array.isArray(newMetadata)) {
+    return newMetadata;
+  }
+
+  // combine sets
   if (existingMetadata instanceof Set && newMetadata instanceof Set) {
     const merged = new Set(existingMetadata);
     for (const item of newMetadata) {
@@ -24,6 +34,8 @@ export function mergeMetadata(
     }
     return merged;
   }
+
+  // recursively merge maps
   if (existingMetadata instanceof Map && newMetadata instanceof Map) {
     const merged = new Map(existingMetadata);
     for (const [key, value] of newMetadata) {
@@ -31,9 +43,8 @@ export function mergeMetadata(
     }
     return merged;
   }
-  if (Array.isArray(existingMetadata) && Array.isArray(newMetadata)) {
-    return newMetadata;
-  }
+
+  // recursively merge objects
   if (
     typeof existingMetadata === 'object' &&
     typeof newMetadata === 'object' &&
@@ -56,5 +67,7 @@ export function mergeMetadata(
     }
     return result;
   }
+
+  // when in doubt, just return newMetadata
   return newMetadata;
 }

--- a/packages/trimerge-sync/src/lib/mergeMetadata.ts
+++ b/packages/trimerge-sync/src/lib/mergeMetadata.ts
@@ -1,5 +1,5 @@
 /**  Attempts to recursively merge two values, preferring newMetadata if there's ambiguity.
- *   This does not merge arrays but it will combine sets and recursively merge objects and maps.
+ *   This does not merge arrays or sets but it will recursively merge objects and maps.
  */
 export function mergeMetadata(
   existingMetadata: unknown,
@@ -21,18 +21,12 @@ export function mergeMetadata(
     return newMetadata;
   }
 
-  // bail on arrays, just take newMetadata's value
-  if (Array.isArray(existingMetadata) && Array.isArray(newMetadata)) {
+  // bail on arrays and sets, just take newMetadata's value
+  if (
+    (Array.isArray(existingMetadata) && Array.isArray(newMetadata)) ||
+    (existingMetadata instanceof Set && newMetadata instanceof Set)
+  ) {
     return newMetadata;
-  }
-
-  // combine sets
-  if (existingMetadata instanceof Set && newMetadata instanceof Set) {
-    const merged = new Set(existingMetadata);
-    for (const item of newMetadata) {
-      merged.add(item);
-    }
-    return merged;
   }
 
   // recursively merge maps

--- a/packages/trimerge-sync/src/lib/mergeMetadata.ts
+++ b/packages/trimerge-sync/src/lib/mergeMetadata.ts
@@ -1,0 +1,60 @@
+/**  Attempts to recursively merge two values, preferring newMetadata if there's ambiguity.
+ *   This does not merge arrays but it will combine sets and recursively merge objects and maps.
+ */
+export function mergeMetadata(
+  existingMetadata: unknown,
+  newMetadata: unknown,
+): unknown {
+  if (existingMetadata === undefined || existingMetadata === null) {
+    return newMetadata;
+  }
+  if (newMetadata === undefined || newMetadata === null) {
+    return existingMetadata;
+  }
+  if (
+    typeof existingMetadata !== typeof newMetadata ||
+    Array.isArray(existingMetadata) !== Array.isArray(newMetadata)
+  ) {
+    return newMetadata;
+  }
+  if (existingMetadata instanceof Set && newMetadata instanceof Set) {
+    const merged = new Set(existingMetadata);
+    for (const item of newMetadata) {
+      merged.add(item);
+    }
+    return merged;
+  }
+  if (existingMetadata instanceof Map && newMetadata instanceof Map) {
+    const merged = new Map(existingMetadata);
+    for (const [key, value] of newMetadata) {
+      merged.set(key, mergeMetadata(merged.get(key), value));
+    }
+    return merged;
+  }
+  if (Array.isArray(existingMetadata) && Array.isArray(newMetadata)) {
+    return newMetadata;
+  }
+  if (
+    typeof existingMetadata === 'object' &&
+    typeof newMetadata === 'object' &&
+    existingMetadata !== null &&
+    newMetadata !== null
+  ) {
+    const indexableNewMetadata = newMetadata as { [key: string]: unknown };
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(existingMetadata)) {
+      if (key in indexableNewMetadata) {
+        result[key] = mergeMetadata(value, indexableNewMetadata[key]);
+      } else {
+        result[key] = value;
+      }
+    }
+    for (const [key, value] of Object.entries(newMetadata)) {
+      if (!(key in result)) {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+  return newMetadata;
+}


### PR DESCRIPTION
Previously, we'd just clobber existing metadata from the server in indexed db commit repository and ignore it in trimerge client. This PR:
 - adds a simple general-purpose metadata merger which attempts to preserve existing values in a metadata object and patch in values coming back from the server.
 - update IndexedDbCommitRepository to merge metadata when updating it from remote instead of just replacing it
 - update TrimergeClient to update its in memory instance of commit metadata with the metadata coming back from the server.