### PR TITLE
Expose an Externally configurable DocCache option for TrimergeClient

### DIFF
--- a/packages/trimerge-sync/src/InMemoryDocCache.ts
+++ b/packages/trimerge-sync/src/InMemoryDocCache.ts
@@ -1,0 +1,21 @@
+import { CommitDoc, DocCache } from './TrimergeClientOptions';
+
+/** Simple implementation that just wraps a Map. */
+export class InMemoryDocCache<SavedDoc, CommitMetadata>
+  implements DocCache<SavedDoc, CommitMetadata>
+{
+  private readonly docs: Map<string, CommitDoc<SavedDoc, CommitMetadata>> =
+    new Map();
+  get(ref: string) {
+    return this.docs.get(ref);
+  }
+  set(ref: string, doc: CommitDoc<SavedDoc, CommitMetadata>) {
+    this.docs.set(ref, doc);
+  }
+  has(ref: string) {
+    return this.docs.has(ref);
+  }
+  delete(ref: string) {
+    this.docs.delete(ref);
+  }
+}

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -1,4 +1,4 @@
-import { InMemoryDocCache, TrimergeClient } from './TrimergeClient';
+import { TrimergeClient } from './TrimergeClient';
 import { timeout } from './lib/Timeout';
 import { OnStoreEventFn, SyncEvent, SyncStatus } from './types';
 import {
@@ -9,6 +9,7 @@ import {
 
 import { create } from 'jsondiffpatch';
 import { computeRef } from 'trimerge-sync-hash';
+import { InMemoryDocCache } from './InMemoryDocCache';
 
 const jsonDiffPatch = create({ textDiff: { minLength: 20 } });
 

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -418,9 +418,6 @@ export class TrimergeClient<
       headRefs.delete(baseRef);
     }
     if (mergeRef !== undefined) {
-      if (!this.commits.has(mergeRef)) {
-        throw new Error(`unknown mergeRef for commit ${ref}: ${mergeRef}`);
-      }
       headRefs.delete(mergeRef);
     }
     headRefs.add(ref);
@@ -461,7 +458,7 @@ export class TrimergeClient<
     this.commits.set(ref, commit);
     this.addHead(this.allHeadRefs, commit);
     const currentRef = this.lastSavedDoc?.ref;
-    if (currentRef === baseRef || currentRef === mergeRef) {
+    if (!currentRef || currentRef === baseRef || currentRef === mergeRef) {
       this.lastSavedDoc = this.getCommitDoc(commit.ref);
       if (type !== 'temp') {
         this.lastNonTempDoc = this.lastSavedDoc;

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -39,7 +39,7 @@ export type SubscribeEvent = {
     | 'remote'; // A remote client updated the value
 };
 
-class InMemoryDocCache<SavedDoc, CommitMetadata>
+export class InMemoryDocCache<SavedDoc, CommitMetadata>
   implements DocCache<SavedDoc, CommitMetadata>
 {
   private readonly docs: Map<string, CommitDoc<SavedDoc, CommitMetadata>> =
@@ -49,6 +49,9 @@ class InMemoryDocCache<SavedDoc, CommitMetadata>
   }
   set(ref: string, doc: CommitDoc<SavedDoc, CommitMetadata>) {
     this.docs.set(ref, doc);
+  }
+  has(ref: string) {
+    return this.docs.has(ref);
   }
   delete(ref: string) {
     this.docs.delete(ref);
@@ -409,7 +412,7 @@ export class TrimergeClient<
     { ref, baseRef, mergeRef }: CommitRefs,
   ): void {
     if (baseRef !== undefined) {
-      if (!this.commits.has(baseRef)) {
+      if (!this.commits.has(baseRef) && !this.docCache.has(baseRef)) {
         throw new Error(`unknown baseRef for commit ${ref}: ${baseRef}`);
       }
       headRefs.delete(baseRef);

--- a/packages/trimerge-sync/src/TrimergeClientOptions.ts
+++ b/packages/trimerge-sync/src/TrimergeClientOptions.ts
@@ -31,6 +31,12 @@ export type AddNewCommitMetadataFn<CommitMetadata> = (
   clientId: string,
 ) => CommitMetadata;
 
+export interface DocCache<SavedDoc, CommitMetadata> {
+  get: (ref: string) => CommitDoc<SavedDoc, CommitMetadata> | undefined;
+  set: (ref: string, doc: CommitDoc<SavedDoc, CommitMetadata>) => void;
+  delete: (ref: string) => void;
+}
+
 export type MergeHelpers<LatestDoc, CommitMetadata> = {
   getCommitInfo(ref: string): CommitInfo;
   computeLatestDoc(ref: string): CommitDoc<LatestDoc, CommitMetadata>;
@@ -88,4 +94,10 @@ export type TrimergeClientOptions<
   readonly migrate?: MigrateDocFn<SavedDoc, LatestDoc, CommitMetadata>;
 
   readonly addNewCommitMetadata?: AddNewCommitMetadataFn<CommitMetadata>;
+
+  /** This is an optional entry point to an alternative storage system for documents. This allows
+   *  consumers of TrimergeClient to create snapshots of the document and cut off the recursive
+   *  building up of the Document.
+   */
+  readonly docCache?: DocCache<SavedDoc, CommitMetadata>;
 };

--- a/packages/trimerge-sync/src/TrimergeClientOptions.ts
+++ b/packages/trimerge-sync/src/TrimergeClientOptions.ts
@@ -34,6 +34,7 @@ export type AddNewCommitMetadataFn<CommitMetadata> = (
 export interface DocCache<SavedDoc, CommitMetadata> {
   get: (ref: string) => CommitDoc<SavedDoc, CommitMetadata> | undefined;
   set: (ref: string, doc: CommitDoc<SavedDoc, CommitMetadata>) => void;
+  has: (ref: string) => boolean;
   delete: (ref: string) => void;
 }
 

--- a/packages/trimerge-sync/src/index.ts
+++ b/packages/trimerge-sync/src/index.ts
@@ -1,5 +1,6 @@
 export * from './TrimergeClientOptions';
 export * from './TrimergeClient';
+export * from './InMemoryDocCache';
 export * from './types';
 export * from './CoordinatingLocalStore';
 export * from './validateCommits';


### PR DESCRIPTION
This PR lays the foundation for supporting Snapshots in LiveCollab.

Essentially, PullPokeRemote will be able to supply snapshots to TrimergeClient via the shared cache.

This includes a couple of other subtle behavior changes:
 - We only throw an error if neither the doc cache nor the set of commits has a particular ref
 - We no longer throw an error if a merge ref is missing
 - If currentRef is undefined, we always set the lastSavedDoc to the doc that corresponds to the current commitRef