### PR TITLE
Restructure RemoteSyncInfo

### DIFF
--- a/examples/example-broadcast-channel/src/lib/trimergeOptions.ts
+++ b/examples/example-broadcast-channel/src/lib/trimergeOptions.ts
@@ -58,10 +58,11 @@ export function createLocalStoreFactory(
         localIdGenerator: randomId,
         remoteId: 'localhost',
       }),
-      (userId, lastSyncId, onEvent) =>
+      (userId, lastSyncInfo, onEvent) =>
         new WebsocketRemote(
           { userId, readonly: false },
-          lastSyncId,
+
+          lastSyncInfo,
           onEvent,
           `ws://localhost:4444/${encodeURIComponent(docId)}`,
         ),

--- a/examples/example-broadcast-channel/src/lib/trimergeOptions.ts
+++ b/examples/example-broadcast-channel/src/lib/trimergeOptions.ts
@@ -53,15 +53,16 @@ export function createLocalStoreFactory(
     const store = new CoordinatingLocalStore(
       userId,
       clientId,
+      randomId(),
       onEvent,
       new IndexedDbCommitRepository(docId, {
         localIdGenerator: randomId,
         remoteId: 'localhost',
       }),
-      (userId, lastSyncInfo, onEvent) =>
+      (userId, localStoreId, lastSyncInfo, onEvent) =>
         new WebsocketRemote(
           { userId, readonly: false },
-
+          localStoreId,
           lastSyncInfo,
           onEvent,
           `ws://localhost:4444/${encodeURIComponent(docId)}`,

--- a/examples/trimerge-sync-basic-client/src/WebsocketRemote.ts
+++ b/examples/trimerge-sync-basic-client/src/WebsocketRemote.ts
@@ -13,7 +13,8 @@ export class WebsocketRemote<CommitMetadata, Delta, Presence>
   private bufferedEvents: SyncEvent<CommitMetadata, Delta, Presence>[] = [];
   constructor(
     auth: unknown,
-    { localStoreId, lastSyncCursor }: RemoteSyncInfo,
+    localStoreId: string,
+    { lastSyncCursor }: RemoteSyncInfo,
     private readonly onEvent: OnRemoteEventFn<CommitMetadata, Delta, Presence>,
     websocketUrl: string,
   ) {

--- a/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.test.ts
@@ -187,17 +187,15 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 2,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "HwWFgzWO",
                 },
               ],
-              "remotes": Array [
-                Object {
-                  "localStoreId": "test-doc-store",
-                },
-              ],
+              "remotes": Array [],
             }
           `);
   });
@@ -309,7 +307,9 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 4,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "YFy1LPs2",
@@ -318,11 +318,7 @@ describe('createIndexedDbBackendFactory', () => {
                   "ref": "aG60Gm4o",
                 },
               ],
-              "remotes": Array [
-                Object {
-                  "localStoreId": "test-doc-store",
-                },
-              ],
+              "remotes": Array [],
             }
           `);
   });
@@ -411,17 +407,15 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 2,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "HwWFgzWO",
                 },
               ],
-              "remotes": Array [
-                Object {
-                  "localStoreId": "test-doc-store",
-                },
-              ],
+              "remotes": Array [],
             }
           `);
   });
@@ -494,7 +488,9 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 1,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "blarg",
@@ -503,7 +499,6 @@ describe('createIndexedDbBackendFactory', () => {
               "remotes": Array [
                 Object {
                   "lastSyncCursor": "9",
-                  "localStoreId": "test-doc-store",
                 },
               ],
             }
@@ -586,7 +581,9 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 1,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "F2C9k7m0",
@@ -595,7 +592,6 @@ describe('createIndexedDbBackendFactory', () => {
               "remotes": Array [
                 Object {
                   "lastSyncCursor": "foo",
-                  "localStoreId": "test-doc-store",
                 },
               ],
             }
@@ -631,7 +627,9 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 1,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "F2C9k7m0",
@@ -640,7 +638,6 @@ describe('createIndexedDbBackendFactory', () => {
               "remotes": Array [
                 Object {
                   "lastSyncCursor": "foo",
-                  "localStoreId": "test-doc-store",
                 },
               ],
             }
@@ -660,7 +657,9 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 1,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "F2C9k7m0",
@@ -695,7 +694,9 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 1,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "F2C9k7m0",
@@ -704,7 +705,6 @@ describe('createIndexedDbBackendFactory', () => {
               "remotes": Array [
                 Object {
                   "lastSyncCursor": "foo",
-                  "localStoreId": "test-doc-store",
                 },
               ],
             }
@@ -758,7 +758,9 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 2,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "YSkdCqy1",
@@ -767,7 +769,6 @@ describe('createIndexedDbBackendFactory', () => {
               "remotes": Array [
                 Object {
                   "lastSyncCursor": "foo",
-                  "localStoreId": "test-doc-store",
                 },
               ],
             }
@@ -958,7 +959,9 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 3,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "uBHlRZDM",
@@ -967,7 +970,6 @@ describe('createIndexedDbBackendFactory', () => {
               "remotes": Array [
                 Object {
                   "lastSyncCursor": "foo",
-                  "localStoreId": "test-doc-store",
                 },
               ],
             }
@@ -1016,7 +1018,9 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 1,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "blah",
@@ -1025,7 +1029,6 @@ describe('createIndexedDbBackendFactory', () => {
               "remotes": Array [
                 Object {
                   "lastSyncCursor": "blah2",
-                  "localStoreId": "test-doc-store",
                 },
               ],
             }
@@ -1088,7 +1091,9 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 1,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "G0a5Az3Q",
@@ -1097,7 +1102,6 @@ describe('createIndexedDbBackendFactory', () => {
               "remotes": Array [
                 Object {
                   "lastSyncCursor": "foo",
-                  "localStoreId": "test-doc-store",
                 },
               ],
             }
@@ -1121,7 +1125,9 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 1,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "G0a5Az3Q",
@@ -1130,7 +1136,6 @@ describe('createIndexedDbBackendFactory', () => {
               "remotes": Array [
                 Object {
                   "lastSyncCursor": "foo",
-                  "localStoreId": "test-doc-store",
                 },
               ],
             }
@@ -1192,7 +1197,9 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 1,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "G0a5Az3Q",
@@ -1201,7 +1208,6 @@ describe('createIndexedDbBackendFactory', () => {
               "remotes": Array [
                 Object {
                   "lastSyncCursor": "foo",
-                  "localStoreId": "test-doc-store",
                 },
               ],
             }
@@ -1271,7 +1277,9 @@ describe('createIndexedDbBackendFactory', () => {
                   "syncId": 1,
                 },
               ],
-              "config": Array [],
+              "config": Array [
+                "test-doc-store",
+              ],
               "heads": Array [
                 Object {
                   "ref": "test",
@@ -1280,7 +1288,6 @@ describe('createIndexedDbBackendFactory', () => {
               "remotes": Array [
                 Object {
                   "lastSyncCursor": "foo",
-                  "localStoreId": "test-doc-store",
                 },
               ],
             }

--- a/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.test.ts
@@ -65,6 +65,7 @@ function makeIndexedDbCoordinatingLocalStoreFactory(
     return new CoordinatingLocalStore<any, any, any>(
       userId,
       clientId,
+      storeId,
       onEvent,
       new IndexedDbCommitRepository(docId, {
         localIdGenerator: () => storeId,
@@ -125,9 +126,14 @@ async function makeTestClientWithRemoteOnEventHandle(
         store = makeIndexedDbCoordinatingLocalStoreFactory(
           docId,
           storeId,
-          (userId, remoteInfo, onEventParam) => {
+          (userId, localStoreId, remoteInfo, onEventParam) => {
             onRemoteEvent = onEventParam;
-            const mockRemote = getMockRemote(userId, remoteInfo, onEventParam);
+            const mockRemote = getMockRemote(
+              userId,
+              localStoreId,
+              remoteInfo,
+              onEventParam,
+            );
             resolve();
             return mockRemote;
           },
@@ -443,11 +449,17 @@ describe('createIndexedDbBackendFactory', () => {
       'test-doc-store',
       (
         userId: string,
+        localStoreId: string,
         remoteSyncInfo: RemoteSyncInfo,
         onRemoteEvent: OnRemoteEventFn<any, any, any>,
       ) => {
         onEvent = onRemoteEvent;
-        return getMockRemote(userId, remoteSyncInfo, onRemoteEvent);
+        return getMockRemote(
+          userId,
+          localStoreId,
+          remoteSyncInfo,
+          onRemoteEvent,
+        );
       },
       addStoreMetadata,
     );

--- a/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
+++ b/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
@@ -433,12 +433,16 @@ interface TrimergeSyncDbSchema<CommitMetadata, Delta> extends DBSchema {
       lastSyncCursor?: string;
     };
   };
+  config: {
+    key: string;
+    value: ConfigValue;
+  };
 }
 
 function createIndexedDb<CommitMetadata, Delta>(
   dbName: string,
 ): Promise<IDBPDatabase<TrimergeSyncDbSchema<CommitMetadata, Delta>>> {
-  return openDB(dbName, 2, {
+  return openDB(dbName, IDB_SCHEMA_VERSION, {
     upgrade(db, oldVersion, newVersion, tx) {
       let commits;
       if (oldVersion < 1) {
@@ -451,6 +455,9 @@ function createIndexedDb<CommitMetadata, Delta>(
       if (oldVersion < 2) {
         db.createObjectStore('remotes');
         commits.createIndex('remoteSyncId', 'remoteSyncId');
+      }
+      if (oldVersion < 3) {
+        db.createObjectStore('config');
       }
     },
   });

--- a/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
+++ b/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
@@ -15,6 +15,7 @@ import { deleteDB, openDB } from 'idb';
 import { timeout } from './lib/timeout';
 
 const COMMIT_PAGE_SIZE = 100;
+const IDB_SCHEMA_VERSION = 3;
 
 function getSyncCounter<CommitMetadata, Delta>(
   commits: StoreValue<TrimergeSyncDbSchema<CommitMetadata, Delta>, 'commits'>[],
@@ -410,6 +411,8 @@ type TrimergeSyncDbCommit<CommitMetadata, Delta> = Commit<
   syncId: number;
   remoteSyncId: string;
 };
+
+type ConfigValue = string | number | boolean;
 
 interface TrimergeSyncDbSchema<CommitMetadata, Delta> extends DBSchema {
   heads: {

--- a/packages/trimerge-sync-indexed-db/src/testLib/MockRemote.ts
+++ b/packages/trimerge-sync-indexed-db/src/testLib/MockRemote.ts
@@ -59,6 +59,6 @@ export function getMockRemoteWithMap(
   commits?: Map<string, Commit<any, any>>,
   getRemoteMetadata?: (commit: Commit<any, any>) => any,
 ): GetRemoteFn<any, any, any> {
-  return (_userId, _remoteSyncInfo, onEvent) =>
+  return (_userId, _localStoreId, _remoteSyncInfo, onEvent) =>
     new MockRemote(onEvent, commits, getRemoteMetadata);
 }

--- a/packages/trimerge-sync/src/CoordinatingLocalStore.test.ts
+++ b/packages/trimerge-sync/src/CoordinatingLocalStore.test.ts
@@ -37,7 +37,9 @@ class MockCommitRepository
     //
   }
 
-  shutdown() {}
+  shutdown() {
+    //
+  }
 }
 
 class MockRemote implements Remote<unknown, unknown, unknown> {
@@ -56,6 +58,7 @@ describe('CoordinatingLocalStore', () => {
   it('handle double shutdown', async () => {
     const fn = jest.fn();
     const store = new CoordinatingLocalStore(
+      '',
       '',
       '',
       fn,
@@ -93,9 +96,10 @@ describe('CoordinatingLocalStore', () => {
       localStore = new CoordinatingLocalStore(
         '',
         '',
+        '',
         fn,
         new MockCommitRepository(),
-        (_, __, onEvent) => {
+        (_, __, ___, onEvent) => {
           mockRemote = new MockRemote(onEvent);
           sendSpy = jest.spyOn(mockRemote, 'send');
           resolve();
@@ -136,6 +140,7 @@ describe('CoordinatingLocalStore', () => {
   it('handle empty update call', async () => {
     const fn = jest.fn();
     const store = new CoordinatingLocalStore(
+      '',
       '',
       '',
       fn,

--- a/packages/trimerge-sync/src/CoordinatingLocalStore.test.ts
+++ b/packages/trimerge-sync/src/CoordinatingLocalStore.test.ts
@@ -22,7 +22,7 @@ class MockCommitRepository
   }
 
   async getRemoteSyncInfo(): Promise<RemoteSyncInfo> {
-    return { localStoreId: '', lastSyncCursor: undefined };
+    return { lastSyncCursor: undefined, firstSyncCursor: undefined };
   }
 
   async *getLocalCommits(): AsyncIterableIterator<

--- a/packages/trimerge-sync/src/CoordinatingLocalStore.ts
+++ b/packages/trimerge-sync/src/CoordinatingLocalStore.ts
@@ -9,6 +9,7 @@ import {
   OnStoreEventFn,
   Remote,
   RemoteStateEvent,
+  StoreConfigRepository,
   SyncEvent,
 } from './types';
 import {
@@ -71,6 +72,7 @@ export class CoordinatingLocalStore<CommitMetadata, Delta, Presence>
       Delta,
       Presence
     >,
+    private readonly configRepo: StoreConfigRepository,
     private readonly getRemote?: GetRemoteFn<CommitMetadata, Delta, Presence>,
     networkSettings: Partial<NetworkSettings> = {},
     private localChannel?: EventChannel<CommitMetadata, Delta, Presence>,
@@ -253,7 +255,7 @@ export class CoordinatingLocalStore<CommitMetadata, Delta, Presence>
       console.warn('ignoring error while shutting down', error);
     }
 
-    this.commitRepo.shutdown();
+    await this.commitRepo.shutdown();
   }
 
   private closeRemote(reconnect: boolean = false): Promise<void> {

--- a/packages/trimerge-sync/src/CoordinatingLocalStore.ts
+++ b/packages/trimerge-sync/src/CoordinatingLocalStore.ts
@@ -9,7 +9,6 @@ import {
   OnStoreEventFn,
   Remote,
   RemoteStateEvent,
-  StoreConfigRepository,
   SyncEvent,
 } from './types';
 import {
@@ -60,8 +59,9 @@ export class CoordinatingLocalStore<CommitMetadata, Delta, Presence>
   private initialized = false;
 
   constructor(
-    protected readonly userId: string,
-    protected readonly clientId: string,
+    private readonly userId: string,
+    private readonly clientId: string,
+    private readonly localStoreId: string,
     private readonly onStoreEvent: OnStoreEventFn<
       CommitMetadata,
       Delta,
@@ -72,7 +72,6 @@ export class CoordinatingLocalStore<CommitMetadata, Delta, Presence>
       Delta,
       Presence
     >,
-    private readonly configRepo: StoreConfigRepository,
     private readonly getRemote?: GetRemoteFn<CommitMetadata, Delta, Presence>,
     networkSettings: Partial<NetworkSettings> = {},
     private localChannel?: EventChannel<CommitMetadata, Delta, Presence>,
@@ -318,6 +317,7 @@ export class CoordinatingLocalStore<CommitMetadata, Delta, Presence>
         const remoteSyncInfo = await this.commitRepo.getRemoteSyncInfo();
         this.remote = await this.getRemote(
           this.userId,
+          this.localStoreId,
           remoteSyncInfo,
           (event) => {
             this.remoteQueue

--- a/packages/trimerge-sync/src/testLib/MemoryRemote.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryRemote.ts
@@ -21,7 +21,8 @@ export class MemoryRemote<CommitMetadata, Delta, Presence>
   constructor(
     private readonly store: MemoryStore<CommitMetadata, Delta, Presence>,
     private readonly userId: string,
-    { lastSyncCursor, localStoreId }: RemoteSyncInfo,
+    private readonly clientStoreId: string,
+    { lastSyncCursor }: RemoteSyncInfo,
     private readonly onEvent: OnRemoteEventFn<CommitMetadata, Delta, Presence>,
   ) {
     this.clientStoreId = localStoreId;
@@ -117,7 +118,7 @@ export class MemoryRemote<CommitMetadata, Delta, Presence>
       ) {
         continue;
       }
-      await remote.receive(event);
+      remote.receive(event);
     }
   }
 

--- a/packages/trimerge-sync/src/testLib/MemoryStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryStore.ts
@@ -153,8 +153,8 @@ export class MemoryStore<CommitMetadata, Delta, Presence> {
   }
   getRemoteSyncInfo(): Promise<RemoteSyncInfo> {
     return this.queue.add(async () => ({
-      localStoreId: this.localStoreId,
       lastSyncCursor: this.lastRemoteSyncCursor,
+      firstSyncCursor: undefined,
     }));
   }
 

--- a/packages/trimerge-sync/src/testLib/MemoryStore.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryStore.ts
@@ -70,6 +70,7 @@ export class MemoryStore<CommitMetadata, Delta, Presence> {
     const store = new CoordinatingLocalStore<CommitMetadata, Delta, Presence>(
       userId,
       clientId,
+      this.localStoreId,
       onEvent,
       new MemoryCommitRepository(this),
       this.getRemoteFn,
@@ -89,6 +90,7 @@ export class MemoryStore<CommitMetadata, Delta, Presence> {
 
   getRemote: GetRemoteFn<CommitMetadata, Delta, Presence> = (
     userId: string,
+    localStoreId: string,
     remoteSyncInfo,
     onEvent,
   ) => {
@@ -98,7 +100,7 @@ export class MemoryStore<CommitMetadata, Delta, Presence> {
     const be = new MemoryRemote(
       this,
       userId,
-      this.localStoreId,
+      localStoreId,
       remoteSyncInfo,
       onEvent,
     );

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -212,10 +212,10 @@ export type GetLocalStoreFn<CommitMetadata, Delta, Presence> = (
 
 export type RemoteSyncInfo = {
   /** The latest cursor that we're aware of from this remote. */
-  lastSyncCursor: string | undefined;
+  lastSyncCursor?: string;
 
   /** The first cursor after we've been syncing all changes. */
-  firstSyncCursor: string | undefined;
+  firstSyncCursor?: string;
 };
 
 export type GetRemoteFn<CommitMetadata, Delta, Presence> = (

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -243,28 +243,6 @@ export interface Remote<CommitMetadata, Delta, Presence> {
   shutdown(): void | Promise<void>;
 }
 
-type ExtendsFrom<Parent, Subtype extends Parent> = Subtype;
-
-/** Settings stored for a project using the ConfigRepository. */
-export type BaseStoreConfig = ExtendsFrom<
-  Record<string, JSONValue>,
-  {
-    localStoreId: string;
-  }
->;
-
-export type BaseStoreConfigKey = keyof BaseStoreConfig;
-
-/** Repository for storing project-specific settings (e.g. whether live collab is operating in "sparse mode") */
-export interface StoreConfigRepository<Config extends BaseStoreConfig> {
-  get<K extends keyof Config>(key: K): Promise<Config[K] | undefined>;
-
-  set<K extends keyof Config>(
-    key: K,
-    value: Config[K] | undefined,
-  ): Promise<void>;
-}
-
 export interface CommitRepository<CommitMetadata, Delta, Presence> {
   getLocalCommits(): AsyncIterableIterator<
     CommitsEvent<CommitMetadata, Delta, Presence>

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -1,3 +1,5 @@
+import type { JSONValue } from 'trimerge';
+
 export type ErrorCode =
   | 'invalid-sync-id'
   | 'invalid-commits'
@@ -220,6 +222,7 @@ export type RemoteSyncInfo = {
 
 export type GetRemoteFn<CommitMetadata, Delta, Presence> = (
   userId: string,
+  localStoreId: string,
   remoteSyncInfo: RemoteSyncInfo,
   onRemoteEvent: OnRemoteEventFn<CommitMetadata, Delta, Presence>,
 ) =>
@@ -238,6 +241,28 @@ export interface LocalStore<CommitMetadata, Delta, Presence> {
 export interface Remote<CommitMetadata, Delta, Presence> {
   send(event: SyncEvent<CommitMetadata, Delta, Presence>): void;
   shutdown(): void | Promise<void>;
+}
+
+type ExtendsFrom<Parent, Subtype extends Parent> = Subtype;
+
+/** Settings stored for a project using the ConfigRepository. */
+export type BaseStoreConfig = ExtendsFrom<
+  Record<string, JSONValue>,
+  {
+    localStoreId: string;
+  }
+>;
+
+export type BaseStoreConfigKey = keyof BaseStoreConfig;
+
+/** Repository for storing project-specific settings (e.g. whether live collab is operating in "sparse mode") */
+export interface StoreConfigRepository<Config extends BaseStoreConfig> {
+  get<K extends keyof Config>(key: K): Promise<Config[K] | undefined>;
+
+  set<K extends keyof Config>(
+    key: K,
+    value: Config[K] | undefined,
+  ): Promise<void>;
 }
 
 export interface CommitRepository<CommitMetadata, Delta, Presence> {

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -1,5 +1,3 @@
-import type { JSONValue } from 'trimerge';
-
 export type ErrorCode =
   | 'invalid-sync-id'
   | 'invalid-commits'

--- a/packages/trimerge-sync/src/types.ts
+++ b/packages/trimerge-sync/src/types.ts
@@ -211,8 +211,11 @@ export type GetLocalStoreFn<CommitMetadata, Delta, Presence> = (
 ) => LocalStore<CommitMetadata, Delta, Presence>;
 
 export type RemoteSyncInfo = {
-  localStoreId: string;
+  /** The latest cursor that we're aware of from this remote. */
   lastSyncCursor: string | undefined;
+
+  /** The first cursor after we've been syncing all changes. */
+  firstSyncCursor: string | undefined;
 };
 
 export type GetRemoteFn<CommitMetadata, Delta, Presence> = (


### PR DESCRIPTION
This PR:
 - removes localStoreId from `RemoteSyncInfo`
 - moves localStoreId to being managed in a new config store.

This is to align more closely with the direction we're moving with Descript and also, the direction we'd want to move anyway in a world where trimerge sync has the concept of snapshots natively.