### PR TITLE
Return corresponding commits for nodes in graphviz

### DIFF
--- a/packages/trimerge-sync/src/lib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/lib/GraphVisualizers.test.ts
@@ -454,4 +454,108 @@ describe('GraphVisualizers', () => {
       }"
     `);
   });
+
+  it('allows missing merge commits', async () => {
+    const commits: Commit<any, any>[] = [
+      {
+        graph: {
+          ref: 'middle-merge-base-ref',
+          delta: '',
+        },
+        edit: {
+          message: 'blah',
+        },
+        server: {
+          index: 1,
+          main: false,
+          timestamp: '2022-10-14T21:28:34.011Z',
+        },
+      },
+      {
+        graph: {
+          ref: 'middle-merge',
+          baseRef: 'middle-merge-base-ref',
+          mergeRef: 'middle-merge-merge-ref',
+          delta: '',
+        },
+        edit: {
+          message: 'merge',
+        },
+        server: {
+          index: 3,
+          main: true,
+          timestamp: '2022-10-14T21:28:35.788Z',
+        },
+      },
+      {
+        graph: {
+          ref: 'last-merge-base-ref',
+          baseRef: 'middle-merge-base-ref',
+          delta: '',
+        },
+        edit: {
+          message: 'convert Overdub to audio',
+        },
+        server: {
+          index: 4,
+          main: false,
+          timestamp: '2022-10-14T21:29:43.263Z',
+        },
+      },
+      {
+        graph: {
+          ref: 'last-merge-2',
+          baseRef: 'last-merge-base-ref',
+          mergeRef: 'middle-merge',
+          delta: '',
+        },
+        edit: {
+          message: 'merge',
+        },
+        server: {
+          index: 666,
+          main: true,
+          timestamp: '2022-10-14T21:29:44.911Z',
+        },
+      },
+      {
+        graph: {
+          ref: 'last-merge-1',
+          baseRef: 'last-merge-base-ref',
+          mergeRef: 'middle-merge',
+          delta: '',
+        },
+        edit: {
+          message: 'merge',
+        },
+        server: {
+          index: 680,
+          main: false,
+          timestamp: '2022-10-14T21:29:45.510Z',
+        },
+      },
+    ].map((commit) => ({
+      ref: commit.graph.ref,
+      baseRef: commit.graph.baseRef,
+      mergeRef: commit.graph.mergeRef,
+      metadata: commit.edit.message,
+    }));
+
+    expect(getTestDotGraph(commits, (commit) => commit.metadata).graph)
+      .toMatchInlineSnapshot(`
+      "digraph {
+      \\"middle-merge-base-ref\\" [shape=ellipse, label=\\"middle-merge-base-ref\\", color=black, fillcolor=azure, style=filled, id=\\"middle-merge-base-ref\\"];
+      \\"middle-merge\\" [shape=rectangle, label=\\"middle-merge\\", color=black, fillcolor=azure, style=filled, id=\\"middle-merge\\"];
+      \\"middle-merge-base-ref\\" -> \\"middle-merge\\" [label=left]
+      \\"last-merge-base-ref\\" [shape=ellipse, label=\\"last-merge-base-ref\\", color=black, fillcolor=azure, style=filled, id=\\"last-merge-base-ref\\"];
+      \\"middle-merge-base-ref\\" -> \\"last-merge-base-ref\\" [label=\\"convert Overdub to audio\\"]
+      \\"last-merge-2\\" [shape=rectangle, label=\\"last-merge-2\\", color=black, fillcolor=azure, style=filled, id=\\"last-merge-2\\"];
+      \\"last-merge-base-ref\\" -> \\"last-merge-2\\" [label=left]
+      \\"middle-merge\\" -> \\"last-merge-2\\" [label=right]
+      \\"last-merge-1\\" [shape=rectangle, label=\\"last-merge-1\\", color=black, fillcolor=azure, style=filled, id=\\"last-merge-1\\"];
+      \\"last-merge-base-ref\\" -> \\"last-merge-1\\" [label=left]
+      \\"middle-merge\\" -> \\"last-merge-1\\" [label=right]
+      }"
+    `);
+  });
 });

--- a/packages/trimerge-sync/src/lib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/lib/GraphVisualizers.test.ts
@@ -112,8 +112,8 @@ describe('GraphVisualizers', () => {
     `);
     expect(dotGraph(store, client1)).toMatchInlineSnapshot(`
       "digraph {
-      \\"X1xFORPw\\" [shape=ellipse, label=\\"X1xFORPw\\", color=black, fillcolor=azure, style=filled]
-      \\"OscPQkG7:F7kQ39Rs\\" [shape=ellipse, label=\\"OscPQkG7:F7kQ39Rs (2 commits)\\", color=black, fillcolor=azure, style=filled]
+      \\"X1xFORPw\\" [shape=ellipse, label=\\"X1xFORPw\\", color=black, fillcolor=azure, style=filled, id=\\"X1xFORPw\\"];
+      \\"OscPQkG7:F7kQ39Rs\\" [shape=ellipse, label=\\"OscPQkG7:F7kQ39Rs (2 commits)\\", color=black, fillcolor=azure, style=filled, id=\\"F7kQ39Rs\\"];
       }"
     `);
   });
@@ -148,8 +148,8 @@ describe('GraphVisualizers', () => {
     expect(getTestDotGraph(commits, (commit) => commit.metadata).graph)
       .toMatchInlineSnapshot(`
       "digraph {
-      \\"1:3\\" [shape=ellipse, label=\\"1:3 (3 commits)\\", color=black, fillcolor=azure, style=filled]
-      \\"4\\" [shape=ellipse, label=\\"4\\", color=black, fillcolor=azure, style=filled]
+      \\"1:3\\" [shape=ellipse, label=\\"1:3 (3 commits)\\", color=black, fillcolor=azure, style=filled, id=\\"3\\"];
+      \\"4\\" [shape=ellipse, label=\\"4\\", color=black, fillcolor=azure, style=filled, id=\\"4\\"];
       \\"1:3\\" -> \\"4\\" [label=\\"fourth\\"]
       }"
     `);
@@ -186,12 +186,12 @@ describe('GraphVisualizers', () => {
     expect(getTestDotGraph(commits, (commit) => commit.metadata).graph)
       .toMatchInlineSnapshot(`
       "digraph {
-      \\"1\\" [shape=ellipse, label=\\"1\\", color=black, fillcolor=azure, style=filled]
-      \\"2\\" [shape=ellipse, label=\\"2\\", color=black, fillcolor=azure, style=filled]
+      \\"1\\" [shape=ellipse, label=\\"1\\", color=black, fillcolor=azure, style=filled, id=\\"1\\"];
+      \\"2\\" [shape=ellipse, label=\\"2\\", color=black, fillcolor=azure, style=filled, id=\\"2\\"];
       \\"1\\" -> \\"2\\" [label=\\"second\\"]
-      \\"3\\" [shape=ellipse, label=\\"3\\", color=black, fillcolor=azure, style=filled]
+      \\"3\\" [shape=ellipse, label=\\"3\\", color=black, fillcolor=azure, style=filled, id=\\"3\\"];
       \\"1\\" -> \\"3\\" [label=\\"third\\"]
-      \\"4\\" [shape=rectangle, label=\\"4\\", color=black, fillcolor=azure, style=filled]
+      \\"4\\" [shape=rectangle, label=\\"4\\", color=black, fillcolor=azure, style=filled, id=\\"4\\"];
       \\"3\\" -> \\"4\\" [label=left]
       \\"2\\" -> \\"4\\" [label=right]
       }"
@@ -259,22 +259,22 @@ describe('GraphVisualizers', () => {
     expect(getTestDotGraph(commits, (commit) => commit.metadata).graph)
       .toMatchInlineSnapshot(`
       "digraph {
-      \\"1\\" [shape=ellipse, label=\\"1\\", color=black, fillcolor=azure, style=filled]
-      \\"2\\" [shape=ellipse, label=\\"2\\", color=black, fillcolor=azure, style=filled]
+      \\"1\\" [shape=ellipse, label=\\"1\\", color=black, fillcolor=azure, style=filled, id=\\"1\\"];
+      \\"2\\" [shape=ellipse, label=\\"2\\", color=black, fillcolor=azure, style=filled, id=\\"2\\"];
       \\"1\\" -> \\"2\\" [label=\\"second\\"]
-      \\"3\\" [shape=ellipse, label=\\"3\\", color=black, fillcolor=azure, style=filled]
+      \\"3\\" [shape=ellipse, label=\\"3\\", color=black, fillcolor=azure, style=filled, id=\\"3\\"];
       \\"2\\" -> \\"3\\" [label=\\"third\\"]
-      \\"4\\" [shape=ellipse, label=\\"4\\", color=black, fillcolor=azure, style=filled]
+      \\"4\\" [shape=ellipse, label=\\"4\\", color=black, fillcolor=azure, style=filled, id=\\"4\\"];
       \\"3\\" -> \\"4\\" [label=\\"fourth\\"]
-      \\"5\\" [shape=ellipse, label=\\"5\\", color=black, fillcolor=azure, style=filled]
+      \\"5\\" [shape=ellipse, label=\\"5\\", color=black, fillcolor=azure, style=filled, id=\\"5\\"];
       \\"4\\" -> \\"5\\" [label=\\"fifth\\"]
-      \\"3prime\\" [shape=ellipse, label=\\"3prime\\", color=black, fillcolor=azure, style=filled]
+      \\"3prime\\" [shape=ellipse, label=\\"3prime\\", color=black, fillcolor=azure, style=filled, id=\\"3prime\\"];
       \\"2\\" -> \\"3prime\\" [label=\\"fifth\\"]
-      \\"4prime\\" [shape=ellipse, label=\\"4prime\\", color=black, fillcolor=azure, style=filled]
+      \\"4prime\\" [shape=ellipse, label=\\"4prime\\", color=black, fillcolor=azure, style=filled, id=\\"4prime\\"];
       \\"3prime\\" -> \\"4prime\\" [label=\\"sixth\\"]
-      \\"5prime\\" [shape=ellipse, label=\\"5prime\\", color=black, fillcolor=azure, style=filled]
+      \\"5prime\\" [shape=ellipse, label=\\"5prime\\", color=black, fillcolor=azure, style=filled, id=\\"5prime\\"];
       \\"4prime\\" -> \\"5prime\\" [label=\\"seventh\\"]
-      \\"merged4s\\" [shape=rectangle, label=\\"merged4s\\", color=black, fillcolor=azure, style=filled]
+      \\"merged4s\\" [shape=rectangle, label=\\"merged4s\\", color=black, fillcolor=azure, style=filled, id=\\"merged4s\\"];
       \\"4\\" -> \\"merged4s\\" [label=left]
       \\"4prime\\" -> \\"merged4s\\" [label=right]
       }"
@@ -323,12 +323,12 @@ describe('GraphVisualizers', () => {
     expect(getTestDotGraph(commits, (commit) => commit.metadata).graph)
       .toMatchInlineSnapshot(`
       "digraph {
-      \\"1\\" [shape=ellipse, label=\\"1\\", color=black, fillcolor=azure, style=filled]
-      \\"2:4\\" [shape=ellipse, label=\\"2:4 (3 commits)\\", color=black, fillcolor=azure, style=filled]
+      \\"1\\" [shape=ellipse, label=\\"1\\", color=black, fillcolor=azure, style=filled, id=\\"1\\"];
+      \\"2:4\\" [shape=ellipse, label=\\"2:4 (3 commits)\\", color=black, fillcolor=azure, style=filled, id=\\"4\\"];
       \\"1\\" -> \\"2:4\\" [label=\\"\\"]
-      \\"2prime\\" [shape=ellipse, label=\\"2prime\\", color=black, fillcolor=azure, style=filled]
+      \\"2prime\\" [shape=ellipse, label=\\"2prime\\", color=black, fillcolor=azure, style=filled, id=\\"2prime\\"];
       \\"1\\" -> \\"2prime\\" [label=\\"third\\"]
-      \\"5\\" [shape=rectangle, label=\\"5\\", color=black, fillcolor=azure, style=filled]
+      \\"5\\" [shape=rectangle, label=\\"5\\", color=black, fillcolor=azure, style=filled, id=\\"5\\"];
       \\"2:4\\" -> \\"5\\" [label=left]
       \\"2prime\\" -> \\"5\\" [label=right]
       }"
@@ -435,20 +435,20 @@ describe('GraphVisualizers', () => {
       metadata: commit.edit.message,
     }));
 
-    expect(getTestDotGraph(commits, (commit) => commit.metadata))
+    expect(getTestDotGraph(commits, (commit) => commit.metadata).graph)
       .toMatchInlineSnapshot(`
       "digraph {
-      \\"middle-merge-base-ref\\" [shape=ellipse, label=\\"middle-merge-base-ref\\", color=black, fillcolor=azure, style=filled]
-      \\"middle-merge-merge-ref\\" [shape=ellipse, label=\\"middle-merge-merge-ref\\", color=black, fillcolor=azure, style=filled]
-      \\"middle-merge\\" [shape=rectangle, label=\\"middle-merge\\", color=black, fillcolor=azure, style=filled]
+      \\"middle-merge-base-ref\\" [shape=ellipse, label=\\"middle-merge-base-ref\\", color=black, fillcolor=azure, style=filled, id=\\"middle-merge-base-ref\\"];
+      \\"middle-merge-merge-ref\\" [shape=ellipse, label=\\"middle-merge-merge-ref\\", color=black, fillcolor=azure, style=filled, id=\\"middle-merge-merge-ref\\"];
+      \\"middle-merge\\" [shape=rectangle, label=\\"middle-merge\\", color=black, fillcolor=azure, style=filled, id=\\"middle-merge\\"];
       \\"middle-merge-base-ref\\" -> \\"middle-merge\\" [label=left]
       \\"middle-merge-merge-ref\\" -> \\"middle-merge\\" [label=right]
-      \\"last-merge-base-ref\\" [shape=ellipse, label=\\"last-merge-base-ref\\", color=black, fillcolor=azure, style=filled]
+      \\"last-merge-base-ref\\" [shape=ellipse, label=\\"last-merge-base-ref\\", color=black, fillcolor=azure, style=filled, id=\\"last-merge-base-ref\\"];
       \\"middle-merge-base-ref\\" -> \\"last-merge-base-ref\\" [label=\\"convert Overdub to audio\\"]
-      \\"last-merge-2\\" [shape=rectangle, label=\\"last-merge-2\\", color=black, fillcolor=azure, style=filled]
+      \\"last-merge-2\\" [shape=rectangle, label=\\"last-merge-2\\", color=black, fillcolor=azure, style=filled, id=\\"last-merge-2\\"];
       \\"last-merge-base-ref\\" -> \\"last-merge-2\\" [label=left]
       \\"middle-merge\\" -> \\"last-merge-2\\" [label=right]
-      \\"last-merge-1\\" [shape=rectangle, label=\\"last-merge-1\\", color=black, fillcolor=azure, style=filled]
+      \\"last-merge-1\\" [shape=rectangle, label=\\"last-merge-1\\", color=black, fillcolor=azure, style=filled, id=\\"last-merge-1\\"];
       \\"last-merge-base-ref\\" -> \\"last-merge-1\\" [label=left]
       \\"middle-merge\\" -> \\"last-merge-1\\" [label=right]
       }"

--- a/packages/trimerge-sync/src/lib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/lib/GraphVisualizers.test.ts
@@ -70,7 +70,7 @@ function dotGraph(
 ) {
   return getTestDotGraph(store.getCommits(), (commit) =>
     JSON.stringify(client1.getCommitDoc(commit.ref).doc),
-  );
+  ).graph;
 }
 
 describe('GraphVisualizers', () => {
@@ -145,7 +145,7 @@ describe('GraphVisualizers', () => {
       },
     ];
 
-    expect(getTestDotGraph(commits, (commit) => commit.metadata))
+    expect(getTestDotGraph(commits, (commit) => commit.metadata).graph)
       .toMatchInlineSnapshot(`
       "digraph {
       \\"1:3\\" [shape=ellipse, label=\\"1:3 (3 commits)\\", color=black, fillcolor=azure, style=filled]
@@ -183,7 +183,7 @@ describe('GraphVisualizers', () => {
       },
     ];
 
-    expect(getTestDotGraph(commits, (commit) => commit.metadata))
+    expect(getTestDotGraph(commits, (commit) => commit.metadata).graph)
       .toMatchInlineSnapshot(`
       "digraph {
       \\"1\\" [shape=ellipse, label=\\"1\\", color=black, fillcolor=azure, style=filled]
@@ -256,7 +256,7 @@ describe('GraphVisualizers', () => {
       },
     ];
 
-    expect(getTestDotGraph(commits, (commit) => commit.metadata))
+    expect(getTestDotGraph(commits, (commit) => commit.metadata).graph)
       .toMatchInlineSnapshot(`
       "digraph {
       \\"1\\" [shape=ellipse, label=\\"1\\", color=black, fillcolor=azure, style=filled]
@@ -320,7 +320,7 @@ describe('GraphVisualizers', () => {
       },
     ];
 
-    expect(getTestDotGraph(commits, (commit) => commit.metadata))
+    expect(getTestDotGraph(commits, (commit) => commit.metadata).graph)
       .toMatchInlineSnapshot(`
       "digraph {
       \\"1\\" [shape=ellipse, label=\\"1\\", color=black, fillcolor=azure, style=filled]

--- a/packages/trimerge-sync/src/lib/GraphVisualizers.ts
+++ b/packages/trimerge-sync/src/lib/GraphVisualizers.ts
@@ -254,8 +254,15 @@ function getDotGraphFromNodes<CommitMetadata>(nodes: Map<string, Node>): {
     // if the node is a meta node, we just say that it represents the last commit.
     const representedCommit =
       node.nodeType === 'meta'
-        ? (node as MetaNode<CommitMetadata>).children.at(-1)!.commit
+        ? (node as MetaNode<CommitMetadata>).children.at(-1)?.commit
         : (node as CommitNode<CommitMetadata>).commit;
+
+    if (!representedCommit) {
+      throw new Error(
+        'Represented commit is undefined. Probably an empty meta node.',
+      );
+    }
+
     commits.push(representedCommit);
 
     lines.push(

--- a/packages/trimerge-sync/src/lib/GraphVisualizers.ts
+++ b/packages/trimerge-sync/src/lib/GraphVisualizers.ts
@@ -250,18 +250,22 @@ function getDotGraphFromNodes<CommitMetadata>(nodes: Map<string, Node>): {
 
     const color = userColors.get(node.userId);
 
+    // keep track of the commits that the nodes in the digraph represent.
+    // if the node is a meta node, we just say that it represents the last commit.
+    const representedCommit =
+      node.nodeType === 'meta'
+        ? (node as MetaNode<CommitMetadata>).children.at(-1)!.commit
+        : (node as CommitNode<CommitMetadata>).commit;
+    commits.push(representedCommit);
+
     lines.push(
       `"${node.id}" [shape=${
         node.nodeType === 'merge' ? 'rectangle' : 'ellipse'
       }, label="${node.label}", color=${
         node.isMain ? 'red' : 'black'
-      }, fillcolor=${color}, style=filled]`,
+      }, fillcolor=${color}, style=filled, id="${representedCommit.ref}"];`,
     );
-    if (node.nodeType === 'meta') {
-      commits.push((node as MetaNode<CommitMetadata>).children.at(-1)!.commit);
-    } else {
-      commits.push((node as CommitNode<CommitMetadata>).commit);
-    }
+
     if (node.baseRef) {
       const baseNode = nodes.get(node.baseRef);
       if (!baseNode) {

--- a/packages/trimerge-sync/src/lib/GraphVisualizers.ts
+++ b/packages/trimerge-sync/src/lib/GraphVisualizers.ts
@@ -166,9 +166,9 @@ function isLastChild(node: MetaNode, ref: string): boolean {
   );
 }
 
-class MetaNode implements Node {
+class MetaNode<CommitMetadata = unknown> implements Node {
   isReferenced = false;
-  constructor(readonly children: CommitNode<unknown>[] = []) {
+  constructor(readonly children: CommitNode<CommitMetadata>[] = []) {
     if (children.length < 2) {
       throw new Error('MetaNode must have at least 2 children');
     }
@@ -224,12 +224,18 @@ const COLORS = [
   'lightpink',
 ];
 
-function getDotGraphFromNodes(nodes: Map<string, Node>): string {
+function getDotGraphFromNodes<CommitMetadata>(nodes: Map<string, Node>): {
+  graph: string;
+  commits: Commit<CommitMetadata, unknown>[];
+} {
   const lines: string[] = ['digraph {'];
   const renderedNodes = new Set<Node>();
   let nextColorIdx = 0;
   const userColors = new Map<string | undefined, string>();
+  const commits: Commit<CommitMetadata, unknown>[] = [];
   for (const node of nodes.values()) {
+    // The structure of the map is that multiple commit refs can refer to a single node object
+    // so we only want to render each node once
     if (renderedNodes.has(node)) {
       continue;
     }
@@ -251,6 +257,11 @@ function getDotGraphFromNodes(nodes: Map<string, Node>): string {
         node.isMain ? 'red' : 'black'
       }, fillcolor=${color}, style=filled]`,
     );
+    if (node.nodeType === 'meta') {
+      commits.push((node as MetaNode<CommitMetadata>).children.at(-1)!.commit);
+    } else {
+      commits.push((node as CommitNode<CommitMetadata>).commit);
+    }
     if (node.baseRef) {
       const baseNode = nodes.get(node.baseRef);
       if (!baseNode) {
@@ -273,7 +284,7 @@ function getDotGraphFromNodes(nodes: Map<string, Node>): string {
     }
   }
   lines.push('}');
-  return lines.join('\n');
+  return { graph: lines.join('\n'), commits };
 }
 
 /**
@@ -290,8 +301,9 @@ export function getDotGraph<CommitMetadata>(
   getValue: (commit: Commit<CommitMetadata, any>) => string,
   getUserId: (commit: Commit<CommitMetadata, any>) => string,
   isMain: (commit: Commit<CommitMetadata, any>) => boolean,
-): string {
+): { graph: string; commits: Commit<CommitMetadata, unknown>[] } {
   const nodeMap = new Map<string, Node>();
+
   for (const commit of commits) {
     let node: Node = new CommitNode<CommitMetadata>(
       commit,
@@ -339,16 +351,25 @@ export function getDotGraph<CommitMetadata>(
     }
 
     if (isMergeCommit(commit)) {
-      const mergeNode = nodeMap.get(commit.mergeRef);
+      let mergeNode = nodeMap.get(commit.mergeRef);
+
+      // Allow for the possibility that we don't have the
+      // commit that corresponds to the mergeRef.
       if (mergeNode) {
         if (mergeNode.nodeType === 'meta') {
           splitMetaNode(mergeNode as MetaNode, commit.mergeRef, nodeMap);
         }
+
+        mergeNode = nodeMap.get(commit.mergeRef);
+        if (!mergeNode) {
+          throw new Error(`mergeNode not found: ${commit.mergeRef}`);
+        }
+        mergeNode.isReferenced = true;
       }
-      mergeNode.isReferenced = true;
     }
 
     nodeMap.set(commit.ref, node);
   }
+
   return getDotGraphFromNodes(nodeMap);
 }

--- a/packages/trimerge-sync/src/lib/GraphVisualizers.ts
+++ b/packages/trimerge-sync/src/lib/GraphVisualizers.ts
@@ -252,10 +252,15 @@ function getDotGraphFromNodes<CommitMetadata>(nodes: Map<string, Node>): {
 
     // keep track of the commits that the nodes in the digraph represent.
     // if the node is a meta node, we just say that it represents the last commit.
-    const representedCommit =
-      node.nodeType === 'meta'
-        ? (node as MetaNode<CommitMetadata>).children.at(-1)?.commit
-        : (node as CommitNode<CommitMetadata>).commit;
+    let representedCommit;
+
+    if (node.nodeType === 'meta') {
+      const metaNode = node as MetaNode<CommitMetadata>;
+      representedCommit =
+        metaNode.children[metaNode.children.length - 1].commit;
+    } else {
+      representedCommit = (node as CommitNode<CommitMetadata>).commit;
+    }
 
     if (!representedCommit) {
       throw new Error(

--- a/packages/trimerge-sync/src/lib/GraphVisualizers.ts
+++ b/packages/trimerge-sync/src/lib/GraphVisualizers.ts
@@ -258,11 +258,13 @@ function getDotGraphFromNodes(nodes: Map<string, Node>): string {
       }
       if (node.mergeRef) {
         const mergeNode = nodes.get(node.mergeRef);
-        if (!mergeNode) {
-          throw new Error(`mergeRef ${node.mergeRef} not found`);
-        }
+
         lines.push(`"${baseNode.id}" -> "${node.id}" [label=left]`);
-        lines.push(`"${mergeNode.id}" -> "${node.id}" [label=right]`);
+        if (mergeNode) {
+          lines.push(`"${mergeNode.id}" -> "${node.id}" [label=right]`);
+        } else {
+          console.warn('mergeNode not found: ', node.mergeRef);
+        }
       } else {
         lines.push(
           `"${baseNode.id}" -> "${node.id}" [label="${node.editLabel}"]`,
@@ -338,13 +340,10 @@ export function getDotGraph<CommitMetadata>(
 
     if (isMergeCommit(commit)) {
       const mergeNode = nodeMap.get(commit.mergeRef);
-      if (!mergeNode) {
-        throw new Error(
-          `commits should be partially ordered, but could not find ref ${commit.mergeRef}`,
-        );
-      }
-      if (mergeNode.nodeType === 'meta') {
-        splitMetaNode(mergeNode as MetaNode, commit.mergeRef, nodeMap);
+      if (mergeNode) {
+        if (mergeNode.nodeType === 'meta') {
+          splitMetaNode(mergeNode as MetaNode, commit.mergeRef, nodeMap);
+        }
       }
       mergeNode.isReferenced = true;
     }


### PR DESCRIPTION
This PR returns the commits that correspond to the nodes in the digraph returned by the getDotGraph function.

This allows consumers to get the corresponding elements in the rendered SVG, (e.g. to attach a click listener)