### PR TITLE
Make getCommitDoc iterative

### DIFF
--- a/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.test.ts
@@ -784,6 +784,7 @@ describe('createIndexedDbBackendFactory', () => {
         "localRead": "ready",
         "localSave": "ready",
         "remoteConnect": "online",
+        "remoteCursor": undefined,
         "remoteRead": "ready",
         "remoteSave": "ready",
       }

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -5,7 +5,6 @@ import {
   Differ,
   TrimergeClientOptions,
   AddNewCommitMetadataFn,
-  DocCache,
 } from './TrimergeClientOptions';
 
 import { create } from 'jsondiffpatch';

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -418,4 +418,27 @@ describe('TrimergeClient', () => {
 
     expect(client.doc).toEqual(commitOnTopOfSnapshotDoc);
   });
+
+  it('supports deep graphs', () => {
+    const numCommits = 1_000_000;
+    const { client, onEvent: sendLocalStoreEvent } =
+      makeTrimergeClient(undefined);
+
+    const commits = new Array(numCommits).fill(undefined).map((_, i) => ({
+      baseRef: i === 0 ? undefined : `${i - 1}`,
+      ref: `${i}`,
+      delta: 'hello', // doesn't matter
+      metadata: 'testCommitOnTopOfSnapshotDocValue',
+    }));
+
+    sendLocalStoreEvent(
+      {
+        type: 'commits',
+        commits,
+      },
+      true,
+    );
+
+    expect(() => client.doc).not.toThrowError();
+  });
 });

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -310,20 +310,37 @@ export class TrimergeClient<
       ),
   };
 
-  getCommitDoc(ref: string): CommitDoc<SavedDoc, CommitMetadata> {
-    const doc = this.docCache.get(ref);
-    if (doc !== undefined) {
-      return doc;
+  getCommitDoc(headRef: string): CommitDoc<SavedDoc, CommitMetadata> {
+    let baseDoc: CommitDoc<SavedDoc, CommitMetadata> | undefined;
+    const commitWalk: string[] = [];
+    let currentCommitRef: string | undefined = headRef;
+    while (!baseDoc && currentCommitRef !== undefined) {
+      if (this.docCache.has(currentCommitRef)) {
+        baseDoc = this.docCache.get(currentCommitRef);
+      }
+      commitWalk.push(currentCommitRef);
+      const commit = this.getCommit(currentCommitRef);
+      currentCommitRef = commit.baseRef;
     }
-    const { baseRef, delta, metadata } = this.getCommit(ref);
-    const baseValue = baseRef ? this.getCommitDoc(baseRef).doc : undefined;
-    const commitDoc: CommitDoc<SavedDoc, CommitMetadata> = {
-      ref,
-      doc: this.differ.patch(baseValue, delta),
-      metadata,
-    };
-    this.docCache.set(ref, commitDoc);
-    return commitDoc;
+
+    let resultDoc = baseDoc;
+    for (let i = commitWalk.length - 1; i >= 0; i--) {
+      const { ref, delta, metadata } = this.getCommit(commitWalk[i]);
+      resultDoc = {
+        ref,
+        doc: this.differ.patch(resultDoc?.doc, delta),
+        metadata,
+      };
+      this.docCache.set(ref, resultDoc);
+    }
+
+    // I don't believe this can actually happen but couldn't
+    // get the types to work out.
+    if (!resultDoc) {
+      throw new Error(`Could not construct commit doc for ref ${headRef}`);
+    }
+
+    return resultDoc;
   }
 
   private migrateCommit(

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -317,7 +317,9 @@ export class TrimergeClient<
     while (!baseDoc && currentCommitRef !== undefined) {
       if (this.docCache.has(currentCommitRef)) {
         baseDoc = this.docCache.get(currentCommitRef);
+        break;
       }
+
       commitWalk.push(currentCommitRef);
       const commit = this.getCommit(currentCommitRef);
       currentCommitRef = commit.baseRef;


### PR DESCRIPTION
We've seen that some projects can require constructing deep chains of commits so this moves to an iterative implementation of getCommitDoc to avoid stack limit exceeded errors.