### PR TITLE
add the ability to subscribe to errors emitted by trimergeclient

### DIFF
--- a/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.test.ts
+++ b/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.test.ts
@@ -592,7 +592,6 @@ describe('createIndexedDbBackendFactory', () => {
               "remotes": [
                 {
                   "lastSyncCursor": "foo",
-                  "localStoreId": "test-doc-store",
                 },
               ],
             }


### PR DESCRIPTION
This PR was reviewed in https://github.com/descriptinc/descript-web-v2/pull/16691. It adds a `subscribeErrors` method that will emit asynchronous errors that occur as a result of syncing.