### PR TITLE
`listen()` / `connect()` refactor on local store and remote interfaces 

### DIFF
--- a/examples/example-broadcast-channel/src/AppDoc.ts
+++ b/examples/example-broadcast-channel/src/AppDoc.ts
@@ -8,7 +8,7 @@ import {
   useTrimergeSyncStatus,
 } from './lib/trimergeHooks';
 import {
-  createLocalStoreFactory,
+  createLocalStore,
   diff,
   mergeAllBranches,
   patch,
@@ -35,6 +35,8 @@ export const defaultDoc = {
 
 function getOpts(
   docId: string,
+  userId: string,
+  clientId: string,
 ): TrimergeClientOptions<
   SavedAppDoc,
   LatestAppDoc,
@@ -49,7 +51,7 @@ function getOpts(
     },
     computeRef,
     mergeAllBranches,
-    getLocalStore: createLocalStoreFactory(docId),
+    localStore: createLocalStore(docId, userId, clientId),
   };
 }
 
@@ -60,7 +62,7 @@ export function useDemoAppDoc() {
     DEMO_DOC_ID,
     DEMO_USER_ID,
     currentTabId,
-    getOpts(DEMO_DOC_ID),
+    getOpts(DEMO_DOC_ID, DEMO_USER_ID, currentTabId),
   );
 }
 
@@ -69,7 +71,7 @@ export function useDemoAppDeleteDatabase() {
     DEMO_DOC_ID,
     DEMO_USER_ID,
     currentTabId,
-    getOpts(DEMO_DOC_ID),
+    getOpts(DEMO_DOC_ID, DEMO_USER_ID, currentTabId),
   );
 }
 
@@ -80,14 +82,19 @@ export function useDemoAppClientList() {
     string,
     Delta,
     FocusPresence
-  >(DEMO_DOC_ID, DEMO_USER_ID, currentTabId, getOpts(DEMO_DOC_ID));
+  >(
+    DEMO_DOC_ID,
+    DEMO_USER_ID,
+    currentTabId,
+    getOpts(DEMO_DOC_ID, DEMO_USER_ID, currentTabId),
+  );
 }
 export function useDemoAppSyncStatus() {
   return useTrimergeSyncStatus<SavedAppDoc, LatestAppDoc, string, Delta>(
     DEMO_DOC_ID,
     DEMO_USER_ID,
     currentTabId,
-    getOpts(DEMO_DOC_ID),
+    getOpts(DEMO_DOC_ID, DEMO_USER_ID, currentTabId),
   );
 }
 export function useDemoAppShutdown() {
@@ -95,6 +102,6 @@ export function useDemoAppShutdown() {
     DEMO_DOC_ID,
     DEMO_USER_ID,
     currentTabId,
-    getOpts(DEMO_DOC_ID),
+    getOpts(DEMO_DOC_ID, DEMO_USER_ID, currentTabId),
   );
 }

--- a/examples/trimerge-sync-basic-client/package.json
+++ b/examples/trimerge-sync-basic-client/package.json
@@ -47,6 +47,7 @@
     "rollup": "2.58.0",
     "rollup-plugin-typescript2": "0.30.0",
     "trimerge-sync": "0.20.0",
+    "trimerge-sync-indexed-db": "0.20.0",
     "@types/node": "^16.9.4",
     "ts-node": "^10.3.0",
     "ts-node-dev": "^1.1.8",

--- a/examples/trimerge-sync-basic-client/src/WebsocketRemote.ts
+++ b/examples/trimerge-sync-basic-client/src/WebsocketRemote.ts
@@ -1,34 +1,44 @@
-import type {
+import invariant from 'invariant';
+import {
   ErrorCode,
+  Logger,
   OnRemoteEventFn,
+  PrefixLogger,
   Remote,
   RemoteSyncInfo,
   SyncEvent,
 } from 'trimerge-sync';
+import { IndexedDbCommitRepository } from 'trimerge-sync-indexed-db';
 
 export class WebsocketRemote<CommitMetadata, Delta, Presence>
   implements Remote<CommitMetadata, Delta, Presence>
 {
   private socket: WebSocket | undefined;
-  private bufferedEvents: SyncEvent<CommitMetadata, Delta, Presence>[] = [];
+  private bufferedEventsToServer: SyncEvent<CommitMetadata, Delta, Presence>[] =
+    [];
+  private bufferedEventsToClient: SyncEvent<CommitMetadata, Delta, Presence>[] =
+    [];
+  private logger: Logger | undefined;
+  private isShutdown = false;
+  private onEvent: OnRemoteEventFn<CommitMetadata, Delta, Presence> | undefined;
   constructor(
-    auth: unknown,
-    localStoreId: string,
-    { lastSyncCursor }: RemoteSyncInfo,
-    private readonly onEvent: OnRemoteEventFn<CommitMetadata, Delta, Presence>,
-    websocketUrl: string,
-  ) {
-    console.log(`[TRIMERGE-SYNC] Connecting to ${websocketUrl}...`);
-    this.socket = new WebSocket(websocketUrl);
+    private readonly auth: unknown,
+    private readonly commitRepo: IndexedDbCommitRepository<any, any, any>,
+    private readonly websocketUrl: string,
+  ) {}
+
+  async connect({ lastSyncCursor }: RemoteSyncInfo): Promise<void> {
+    this.logger?.log(`[TRIMERGE-SYNC] Connecting to ${this.websocketUrl}...`);
+    this.socket = new WebSocket(this.websocketUrl);
     this.socket.onopen = () => {
       if (!this.socket) {
-        console.warn(`[TRIMERGE-SYNC] Connected, but already shutdown...`);
+        this.logger?.warn(`[TRIMERGE-SYNC] Connected, but already shutdown...`);
         return;
       }
-      console.log(`[TRIMERGE-SYNC] Connected to ${websocketUrl}`);
-      onEvent({ type: 'remote-state', connect: 'online' });
-      const events = this.bufferedEvents;
-      this.bufferedEvents = [];
+      this.logger?.log(`[TRIMERGE-SYNC] Connected to ${this.websocketUrl}`);
+      this.emit({ type: 'remote-state', connect: 'online' });
+      const events = this.bufferedEventsToServer;
+      this.bufferedEventsToServer = [];
       for (const event of events) {
         this.send(event);
       }
@@ -36,48 +46,79 @@ export class WebsocketRemote<CommitMetadata, Delta, Presence>
     this.socket.onclose = () => this.fail('closed', 'disconnected');
     this.socket.onerror = () => this.fail('error', 'network', false);
     this.socket.onmessage = (event) => {
-      onEvent(JSON.parse(event.data));
+      this.emit(JSON.parse(event.data));
     };
+
+    const { localStoreId } = await this.commitRepo.dbInfo;
+
     this.send({
       type: 'init',
       version: 1,
-      localStoreId,
       lastSyncCursor,
-      auth,
+      localStoreId,
+      auth: this.auth,
     });
   }
 
-  send(event: SyncEvent<CommitMetadata, Delta, Presence>): void {
-    if (!this.socket) {
-      return;
+  listen(cb: OnRemoteEventFn<CommitMetadata, Delta, Presence>): void {
+    invariant(!this.onEvent, 'listen() called twice');
+    this.onEvent = cb;
+
+    if (this.bufferedEventsToClient.length > 0) {
+      const events = this.bufferedEventsToClient;
+      this.bufferedEventsToClient = [];
+      for (const event of events) {
+        this.emit(event);
+      }
     }
-    if (this.socket.readyState === WebSocket.CONNECTING) {
-      this.bufferedEvents.push(event);
-    } else {
-      this.socket.send(JSON.stringify(event));
-    }
+    this.bufferedEventsToClient = [];
   }
 
-  shutdown(): void {
-    if (!this.socket) {
+  get active() {
+    return this.socket?.readyState === WebSocket.OPEN;
+  }
+
+  disconnect(): void | Promise<void> {
+    if (
+      !this.socket ||
+      this.socket.readyState === WebSocket.CLOSING ||
+      this.socket.readyState === WebSocket.CLOSED
+    ) {
       return;
     }
-    if (this.socket.readyState !== WebSocket.CLOSED) {
-      console.log(
-        `[TRIMERGE-SYNC] Shutting down websocket ${this.socket.url}...`,
-      );
-      this.socket.close(1000, 'shutdown');
-    }
+    this.logger?.log(`Shutting down websocket ${this.socket.url}...`);
+    this.socket.close(1000, 'shutdown');
     this.socket = undefined;
-    this.onEvent({
+    this.emit({
       type: 'remote-state',
       connect: 'offline',
       read: 'offline',
     });
   }
 
+  private emit(event: SyncEvent<CommitMetadata, Delta, Presence>) {
+    if (this.onEvent) {
+      this.onEvent(event);
+    } else {
+      this.bufferedEventsToClient.push(event);
+    }
+  }
+
+  send(event: SyncEvent<CommitMetadata, Delta, Presence>): void {
+    invariant(this.socket, 'send() called on shutdown remote');
+    if (this.socket.readyState === WebSocket.CONNECTING) {
+      this.bufferedEventsToServer.push(event);
+    } else {
+      this.socket.send(JSON.stringify(event));
+    }
+  }
+
+  shutdown(): void {
+    invariant(!this.isShutdown, 'shutdown() called twice');
+  }
+
   fail(message: string, code: ErrorCode, reconnect = true) {
-    this.onEvent({
+    this.emit({
       type: 'error',
       code,
       message,
@@ -87,7 +128,7 @@ export class WebsocketRemote<CommitMetadata, Delta, Presence>
     this.shutdown();
   }
 
-  configureLogger(): void {
-    // noop
+  configureLogger(logger: Logger): void {
+    this.logger = new PrefixLogger('WEBSOCKET_REMOTE', logger);
   }
 }

--- a/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
+++ b/packages/trimerge-sync-indexed-db/src/IndexedDbCommitRepository.ts
@@ -112,7 +112,7 @@ export class IndexedDbCommitRepository<CommitMetadata, Delta, Presence>
   implements CommitRepository<CommitMetadata, Delta, Presence>
 {
   private readonly dbName: string;
-  private dbInfo: Promise<{
+  dbInfo: Promise<{
     db: IDBPDatabase<TrimergeSyncDbSchema<CommitMetadata, Delta>>;
     localStoreId: string;
   }>;

--- a/packages/trimerge-sync/src/CoordinatingLocalStore.test.ts
+++ b/packages/trimerge-sync/src/CoordinatingLocalStore.test.ts
@@ -1,15 +1,13 @@
 import { CoordinatingLocalStore } from './CoordinatingLocalStore';
 import { timeout } from './lib/Timeout';
 import { MemoryEventChannel } from './testLib/MemoryBroadcastChannel';
+import { MockRemote } from './testLib/MockRemote';
 import {
   AckCommitsEvent,
   CommitRepository,
   CommitsEvent,
   Logger,
-  OnRemoteEventFn,
-  Remote,
   RemoteSyncInfo,
-  SyncEvent,
 } from './types';
 
 class MockCommitRepository
@@ -47,30 +45,15 @@ class MockCommitRepository
   }
 }
 
-class MockRemote implements Remote<unknown, unknown, unknown> {
-  constructor(readonly onEvent: OnRemoteEventFn<unknown, unknown, unknown>) {}
-
-  send(event: SyncEvent<unknown, unknown, unknown>): void {
-    //
-  }
-
-  shutdown(): void | Promise<void> {
-    //
-  }
-
-  configureLogger() {
-    /* no-op */
-  }
-}
-
 describe('CoordinatingLocalStore', () => {
   it('handle double shutdown', async () => {
     const fn = jest.fn();
-    const store = new CoordinatingLocalStore('', '', '', {
-      onStoreEvent: fn,
+    const store = new CoordinatingLocalStore('', '', {
       commitRepo: new MockCommitRepository(),
       localChannel: new MemoryEventChannel('dummy'),
     });
+
+    store.listen(fn);
     await store.shutdown();
     await store.shutdown();
     expect(fn.mock.calls).toMatchInlineSnapshot(`
@@ -93,32 +76,65 @@ describe('CoordinatingLocalStore', () => {
       ]
     `);
   });
-  it('does not send two client join events if the current state is online', async () => {
+  it('correctly buffers events emitted before listening', async () => {
+    const store = new CoordinatingLocalStore('', '', {
+      commitRepo: new MockCommitRepository(),
+      localChannel: new MemoryEventChannel('dummy'),
+    });
+    await timeout();
     const fn = jest.fn();
-    let mockRemote: MockRemote;
-    let sendSpy: jest.SpyInstance;
-    let localStore: CoordinatingLocalStore<unknown, unknown, unknown>;
+    store.listen(fn);
+    expect(fn.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "connect": "offline",
+            "read": "offline",
+            "save": "ready",
+            "type": "remote-state",
+          },
+          false,
+        ],
+        [
+          {
+            "type": "ready",
+          },
+          false,
+        ],
+        [
+          {
+            "info": {
+              "clientId": "",
+              "presence": undefined,
+              "ref": undefined,
+              "userId": "",
+            },
+            "type": "client-presence",
+          },
+          false,
+        ],
+      ]
+    `);
+  });
+  it('does not send two client join events if the current state is online', async () => {
+    const remote = new MockRemote();
+    const sendSpy: jest.SpyInstance = jest.spyOn(remote, 'send');
 
-    await new Promise<void>((resolve) => {
-      localStore = new CoordinatingLocalStore('', '', '', {
-        onStoreEvent: fn,
-        commitRepo: new MockCommitRepository(),
-        getRemote: (_, __, ___, onEvent) => {
-          mockRemote = new MockRemote(onEvent);
-          sendSpy = jest.spyOn(mockRemote, 'send');
-          resolve();
-          return mockRemote;
-        },
-        localChannel: new MemoryEventChannel('dummy'),
-      });
+    const localStore = new CoordinatingLocalStore('', '', {
+      commitRepo: new MockCommitRepository(),
+      remote,
+      localChannel: new MemoryEventChannel('repeated-online-events'),
     });
 
-    mockRemote!.onEvent({ type: 'remote-state', connect: 'online' });
-    mockRemote!.onEvent({ type: 'remote-state', connect: 'online' });
+    // Wait for coordinating local store to listen to the remote.
+    await remote.connected;
+
+    remote.emit({ type: 'remote-state', connect: 'online' });
+    remote.emit({ type: 'remote-state', connect: 'online' });
 
     await timeout();
 
-    expect(sendSpy!.mock.calls).toMatchInlineSnapshot(`
+    expect(sendSpy.mock.calls).toMatchInlineSnapshot(`
       [
         [
           {
@@ -136,30 +152,20 @@ describe('CoordinatingLocalStore', () => {
             "type": "client-join",
           },
         ],
-        [
-          {
-            "info": {
-              "clientId": "",
-              "presence": undefined,
-              "ref": undefined,
-              "userId": "",
-            },
-            "type": "client-presence",
-          },
-        ],
       ]
     `);
 
-    await localStore!.shutdown();
+    await localStore.shutdown();
   });
 
   it('handle empty update call', async () => {
     const fn = jest.fn();
-    const store = new CoordinatingLocalStore('', '', '', {
-      onStoreEvent: fn,
+    const store = new CoordinatingLocalStore('', '', {
       commitRepo: new MockCommitRepository(),
       localChannel: new MemoryEventChannel('dummy'),
     });
+    store.listen(fn);
+
     await store.update([], undefined);
     expect(fn.mock.calls).toMatchInlineSnapshot(`
       [

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -158,7 +158,7 @@ export class TrimergeClient<
       migrate = (doc, metadata) => ({ doc: doc as LatestDoc, metadata }),
       mergeAllBranches,
       computeRef,
-      getLocalStore,
+      localStore,
       addNewCommitMetadata,
       docCache = new InMemoryDocCache(),
       shutdown: onShutdown,
@@ -177,7 +177,8 @@ export class TrimergeClient<
     this.computeRef = computeRef;
     this.addNewCommitMetadata = addNewCommitMetadata;
     this.docCache = docCache;
-    this.store = getLocalStore(userId, clientId, this.onStoreEvent);
+    this.store = localStore;
+    this.store.listen(this.onStoreEvent);
     this.setClientInfo(
       {
         userId,

--- a/packages/trimerge-sync/src/TrimergeClientOptions.ts
+++ b/packages/trimerge-sync/src/TrimergeClientOptions.ts
@@ -1,4 +1,4 @@
-import { CommitInfo, GetLocalStoreFn } from './types';
+import { CommitInfo, LocalStore } from './types';
 
 export type DocAndMetadata<Doc, CommitMetadata> = {
   doc: Doc;
@@ -86,8 +86,8 @@ export type TrimergeClientOptions<
   /** Merge all head commits */
   readonly mergeAllBranches: MergeAllBranchesFn<LatestDoc, CommitMetadata>;
 
-  /** Get the Local commit store. */
-  readonly getLocalStore: GetLocalStoreFn<CommitMetadata, Delta, Presence>;
+  /** The local commit store. */
+  readonly localStore: LocalStore<CommitMetadata, Delta, Presence>;
 
   /** How to convert a historical format of your document to the latest version of the document.
    *  If not supplied, the document will always be treated as if it is in the latest format.

--- a/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_2Users.test.ts
@@ -48,9 +48,10 @@ function makeClient(
     >
   >,
 ): TrimergeClient<TestSavedDoc, TestDoc, TestMetadata, Delta, TestPresence> {
-  return new TrimergeClient(userId, 'test', {
+  const clientId = 'test';
+  return new TrimergeClient(userId, clientId, {
     ...opts,
-    getLocalStore: store.getLocalStore,
+    localStore: store.getLocalStore({ userId, clientId }),
     ...optsOverrides,
   });
 }

--- a/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_3Users.test.ts
@@ -19,9 +19,10 @@ function makeClient(
   userId: string,
   store: MemoryStore<TestMetadata, Delta, TestPresence>,
 ): TrimergeClient<TestSavedDoc, TestDoc, TestMetadata, Delta, TestPresence> {
-  return new TrimergeClient(userId, 'test', {
+  const clientId = 'test';
+  return new TrimergeClient(userId, clientId, {
     ...TEST_OPTS,
-    getLocalStore: store.getLocalStore,
+    localStore: store.getLocalStore({ userId, clientId }),
   });
 }
 

--- a/packages/trimerge-sync/src/TrimergeClient_Fuzz.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Fuzz.test.ts
@@ -21,9 +21,10 @@ function makeClient(
   userId: string,
   store: MemoryStore<TestMetadata, Delta, TestPresence>,
 ): TrimergeClient<TestSavedDoc, TestDoc, TestMetadata, Delta, TestPresence> {
-  return new TrimergeClient(userId, 'test', {
+  const clientId = 'test';
+  return new TrimergeClient(userId, clientId, {
     ...TEST_OPTS,
-    getLocalStore: store.getLocalStore,
+    localStore: store.getLocalStore({ userId, clientId }),
   });
 }
 

--- a/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient_Migration.test.ts
@@ -25,28 +25,31 @@ const migrationOpts: Pick<
   },
 };
 
+const CLIENT_ID = 'test';
+
 function makeClientV1(
   userId: string,
   store: MemoryStore<TestMetadata, Delta, TestPresence>,
 ): TrimergeClient<DocV1, DocV1, TestMetadata, Delta, TestPresence> {
-  return new TrimergeClient(userId, 'test', {
+  return new TrimergeClient(userId, CLIENT_ID, {
     ...migrationOpts,
-    getLocalStore: store.getLocalStore,
+    localStore: store.getLocalStore({ userId, clientId: CLIENT_ID }),
   });
 }
 function makeClientV2(
   userId: string,
   store: MemoryStore<TestMetadata, Delta, TestPresence>,
 ): TrimergeClient<DocV1 | DocV2, DocV2, TestMetadata, Delta, TestPresence> {
+  const clientId = 'test';
   return new TrimergeClient<
     DocV1 | DocV2,
     DocV2,
     TestMetadata,
     Delta,
     TestPresence
-  >(userId, 'test', {
+  >(userId, clientId, {
     ...migrationOpts,
-    getLocalStore: store.getLocalStore,
+    localStore: store.getLocalStore({ userId, clientId }),
     migrate: (doc, metadata) => {
       switch (doc.v) {
         case 1:
@@ -65,9 +68,9 @@ function makeNonReferenceEqualMigrationClient(
   userId: string,
   store: MemoryStore<TestMetadata, Delta, TestPresence>,
 ): TrimergeClient<DocV1, DocV1, TestMetadata, Delta, TestPresence> {
-  return new TrimergeClient(userId, 'test', {
+  return new TrimergeClient(userId, CLIENT_ID, {
     ...TEST_OPTS,
-    getLocalStore: store.getLocalStore,
+    localStore: store.getLocalStore({ userId, clientId: CLIENT_ID }),
     migrate: (doc, metadata) => {
       return { doc: { ...doc }, metadata };
     },

--- a/packages/trimerge-sync/src/index.ts
+++ b/packages/trimerge-sync/src/index.ts
@@ -12,3 +12,5 @@ export * from './lib/GraphVisualizers';
 export * from './lib/Commits';
 export * from './lib/SubscriberList';
 export * from './lib/PrefixLogger';
+export * from './testLib/MockLocalStore';
+export * from './testLib/MockRemote';

--- a/packages/trimerge-sync/src/lib/GraphVisualizers.test.ts
+++ b/packages/trimerge-sync/src/lib/GraphVisualizers.test.ts
@@ -22,9 +22,10 @@ function makeClient(
   userId: string,
   store: MemoryStore<TestMetadata, Delta, TestPresence>,
 ): TrimergeClient<TestSavedDoc, TestDoc, TestMetadata, Delta, TestPresence> {
-  return new TrimergeClient(userId, 'test', {
+  const clientId = 'test';
+  return new TrimergeClient(userId, clientId, {
     ...TEST_OPTS,
-    getLocalStore: store.getLocalStore,
+    localStore: store.getLocalStore({ userId, clientId }),
   });
 }
 

--- a/packages/trimerge-sync/src/testLib/MemoryCommitRepository.test.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryCommitRepository.test.ts
@@ -3,14 +3,21 @@ import { MemoryStore } from './MemoryStore';
 describe('MemoryLocalStore', () => {
   it('can be shutdown twice', async () => {
     const store = new MemoryStore('test');
-    const local = store.getLocalStore('test', 'test', () => 0);
+    const local = store.getLocalStore({
+      userId: 'test',
+      clientId: 'test',
+    });
     await local.shutdown();
     await local.shutdown();
   });
   it('does not send after shutdown', async () => {
     const store = new MemoryStore('test');
+    const local = store.getLocalStore({
+      userId: 'test',
+      clientId: 'test',
+    });
     const fn = jest.fn();
-    const local = store.getLocalStore('test', 'test', fn);
+    local.listen(fn);
     await local.update(
       [
         {

--- a/packages/trimerge-sync/src/testLib/MemoryCommitRepository.ts
+++ b/packages/trimerge-sync/src/testLib/MemoryCommitRepository.ts
@@ -5,7 +5,6 @@ import {
   RemoteSyncInfo,
   CommitAck,
   CommitRepository,
-  Logger,
 } from '../types';
 import { MemoryStore } from './MemoryStore';
 
@@ -16,7 +15,7 @@ export class MemoryCommitRepository<CommitMetadata, Delta, Presence>
     private readonly store: MemoryStore<CommitMetadata, Delta, Presence>,
   ) {}
 
-  configureLogger(logger: Logger): void {
+  configureLogger(): void {
     /* no-op */
   }
 

--- a/packages/trimerge-sync/src/testLib/MockLocalStore.ts
+++ b/packages/trimerge-sync/src/testLib/MockLocalStore.ts
@@ -1,0 +1,64 @@
+import invariant from 'invariant';
+import {
+  ClientPresenceRef,
+  Commit,
+  LocalStore,
+  OnStoreEventFn,
+  SyncEvent,
+} from '../types';
+
+/** Simple LocalStore implementation that allows you simulate a local store emitting events to TrimergeClient. */
+export class MockLocalStore<CommitMetadata = any, Delta = any, Presence = any>
+  implements LocalStore<CommitMetadata, Delta, Presence>
+{
+  configureLogger(): void {
+    /* no-op */
+  }
+
+  private onEvent: OnStoreEventFn<CommitMetadata, Delta, Presence> | undefined;
+  isRemoteLeader = false;
+  private listenedResolve: (() => void) | undefined;
+  isShutdown = false;
+
+  async update(
+    _commits: readonly Commit<CommitMetadata, Delta>[],
+    _presence: ClientPresenceRef<Presence> | undefined,
+  ): Promise<void> {
+    return;
+  }
+
+  listen(onEvent: OnStoreEventFn<CommitMetadata, Delta, Presence>): void {
+    invariant(!this.onEvent, 'listen() called twice');
+    invariant(!this.isShutdown, 'listen() called after shutdown()');
+
+    if (this.listenedResolve) {
+      this.listenedResolve();
+      this.listenedResolve = undefined;
+    }
+    this.onEvent = onEvent;
+  }
+
+  shutdown() {
+    invariant(!this.isShutdown, 'shutdown() called twice');
+    this.onEvent = undefined;
+  }
+
+  emit(
+    event: SyncEvent<CommitMetadata, Delta, Presence>,
+    remoteOrigin?: boolean,
+  ) {
+    if (this.onEvent) {
+      this.onEvent(event, Boolean(remoteOrigin));
+    }
+  }
+
+  get listened(): Promise<void> {
+    if (this.onEvent) {
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+      this.listenedResolve = resolve;
+    });
+  }
+}

--- a/packages/trimerge-sync/src/testLib/MockRemote.ts
+++ b/packages/trimerge-sync/src/testLib/MockRemote.ts
@@ -1,0 +1,42 @@
+import invariant from 'invariant';
+import { Remote } from '../types';
+import { MockLocalStore } from './MockLocalStore';
+
+export class MockRemote<CommitMetadata = any, Delta = any, Presence = any>
+  extends MockLocalStore<CommitMetadata, Delta, Presence>
+  implements Remote<CommitMetadata, Delta, Presence>
+{
+  active = false;
+
+  private connectedResolve: (() => void) | undefined;
+
+  send(): void {
+    invariant(this.active, 'send() called on inactive remote');
+    return;
+  }
+  connect(): void | Promise<void> {
+    if (this.connectedResolve) {
+      this.connectedResolve();
+      this.connectedResolve = undefined;
+    }
+    this.active = true;
+  }
+  disconnect(): void | Promise<void> {
+    this.active = false;
+  }
+
+  get connected(): Promise<void> {
+    if (this.active) {
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+      this.connectedResolve = resolve;
+    });
+  }
+
+  shutdown() {
+    this.active = false;
+    super.shutdown();
+  }
+}


### PR DESCRIPTION
This PR reworks the interfaces for Trimerge Sync a bit. Previously, the interfaces for LocalStore and Remote were split across the class interfaces and the factory method interfaces which made working with these awkward in some scenarios.

This PR moves TrimergeSync to a model where LocalStore and Remote both represent the entirety of their interface. Namely, the `listen()` method on LocalStore and Remote and the `connect()` and `disconnect()` methods on Remote.

Instead of needing the callback up-front when constructing one of these interfaces. They now provide a `listen` method which accepts a callback. This allows us to separate the construction of the LocalStore with when it is actually listened to.

In addition, instead of constructing and throwing away the remotes dynamically, the Remote interface now supports transitioning from a connected to a disconnected state.

## Future Work

This PR improves the ergonomics of working with the TrimergeSync interfaces a bit but I think there is even more that we can do here. Specifically:
 - Establish a general purpose `SyncEventEmitter` /  `SyncEventChannel` interface that LocalStore and Remote implement.
 - Implement event buffering via a wrapper as opposed to implicitly within the implementations of local store and remote
   - In this PR, CoordinatingLocalStore immediately begins doing work on construction and buffers any events until it is listened to. For better separation of responsibilities, it would be preferable to not do any work until the CoordinatingLocalStore is listened to and implement the buffering logic in a general purpose BufferingSyncEventEmitter. 