### PR TITLE
Add a user-land shutdown callback.

### DIFF
--- a/packages/trimerge-sync/package.json
+++ b/packages/trimerge-sync/package.json
@@ -40,7 +40,8 @@
   },
   "homepage": "https://github.com/marcello3d/trimerge-sync#readme",
   "dependencies": {
-    "project-name-generator": "^2.1.9"
+    "project-name-generator": "^2.1.9",
+    "invariant": "^2.2.4"
   },
   "files": [
     "dist/**/*",

--- a/packages/trimerge-sync/package.json
+++ b/packages/trimerge-sync/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.0",
     "@rollup/plugin-node-resolve": "13.0.6",
+    "@types/invariant": "^2.2.35",
     "@types/project-name-generator": "2.1.1",
     "codecov": "3.8.3",
     "immer": "^9.0.6",

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -439,7 +439,6 @@ describe('TrimergeClient', () => {
   });
 
   it('errors on double shutdown', async () => {
-    const docId = 'test-doc-remote';
     const { client } = makeTrimergeClient(undefined, {});
 
     try {

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -446,7 +446,9 @@ describe('TrimergeClient', () => {
       await client.shutdown();
       fail();
     } catch (e) {
-      expect(e).toMatchInlineSnapshot(`[Error: already shutdown]`);
+      expect(e).toMatchInlineSnapshot(
+        `[Invariant Violation: already shutdown]`,
+      );
     }
   });
 
@@ -460,7 +462,7 @@ describe('TrimergeClient', () => {
       fail();
     } catch (e) {
       expect(e).toMatchInlineSnapshot(
-        `[Error: attempting to update doc after shutdown]`,
+        `[Invariant Violation: attempting to update doc after shutdown]`,
       );
     }
   });
@@ -475,7 +477,7 @@ describe('TrimergeClient', () => {
       fail();
     } catch (e) {
       expect(e).toMatchInlineSnapshot(
-        `[Error: attempting to update presence after shutdown]`,
+        `[Invariant Violation: attempting to update presence after shutdown]`,
       );
     }
   });

--- a/packages/trimerge-sync/src/TrimergeClient.test.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.test.ts
@@ -437,4 +437,47 @@ describe('TrimergeClient', () => {
 
     expect(() => client.getCommitDoc(`${numCommits - 1}`)).not.toThrowError();
   });
+
+  it('errors on double shutdown', async () => {
+    const docId = 'test-doc-remote';
+    const { client } = makeTrimergeClient(undefined, {});
+
+    try {
+      await client.shutdown();
+      await client.shutdown();
+      fail();
+    } catch (e) {
+      expect(e).toMatchInlineSnapshot(`[Error: already shutdown]`);
+    }
+  });
+
+  it('rejects edits after shutdown', async () => {
+    const { client } = makeTrimergeClient(undefined, {});
+
+    await client.shutdown();
+
+    try {
+      await client.updateDoc({ foo: 'bar' }, 'message');
+      fail();
+    } catch (e) {
+      expect(e).toMatchInlineSnapshot(
+        `[Error: attempting to update doc after shutdown]`,
+      );
+    }
+  });
+
+  it('rejects presence updates after shutdown', async () => {
+    const { client } = makeTrimergeClient(undefined, {});
+
+    await client.shutdown();
+
+    try {
+      client.updatePresence({ foo: 'bar' });
+      fail();
+    } catch (e) {
+      expect(e).toMatchInlineSnapshot(
+        `[Error: attempting to update presence after shutdown]`,
+      );
+    }
+  });
 });

--- a/packages/trimerge-sync/src/TrimergeClientOptions.ts
+++ b/packages/trimerge-sync/src/TrimergeClientOptions.ts
@@ -96,6 +96,9 @@ export type TrimergeClientOptions<
 
   readonly addNewCommitMetadata?: AddNewCommitMetadataFn<CommitMetadata>;
 
+  /** Any user-land cleanup that should be performed when TrimergeClient shuts down. */
+  readonly shutdown?: () => void | Promise<void>;
+
   /** This is an optional entry point to an alternative storage system for documents. This allows
    *  consumers of TrimergeClient to create snapshots of the document and cut off the recursive
    *  building up of the Document.


### PR DESCRIPTION
This allows clients of TrimergeClient to perform cleanup when TrimergeClients shutdown is called.