### PR TITLE
Add explicit `DocumentResolutionError` and `UnknownRefError` Error subclasses

### DIFF
--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -50,6 +50,11 @@ export type TrimergeClientErrorType =
   | 'remote' // emitted by the remote store
   | 'add-commits'; // occurred when we tried to add commits
 
+/** This error is emitted when TrimergeClient is unable to resolve the document at a particular commit. */
+export class DocumentResolutionError extends Error {
+  name = 'DocumentResolutionError';
+}
+
 export class TrimergeClientError extends Error {
   name = 'TrimergeClientError';
   constructor(readonly type: TrimergeClientErrorType, readonly cause: Error) {
@@ -384,7 +389,13 @@ export class TrimergeClient<
       }
 
       // otherwise, add the commit to the commit walk.
-      const commit = this.getCommit(currentCommitRef);
+      const commit = this.commits.get(currentCommitRef);
+
+      if (!commit) {
+        throw new DocumentResolutionError(
+          `Could not construct commit doc for ref ${headRef} because commit ${currentCommitRef} is missing`,
+        );
+      }
       commitWalk.push(commit);
       currentCommitRef = commit.baseRef;
     }
@@ -404,7 +415,9 @@ export class TrimergeClient<
     // I don't believe this can actually happen but couldn't
     // get the types to work out.
     if (!baseDoc) {
-      throw new Error(`Could not construct commit doc for ref ${headRef}`);
+      throw new DocumentResolutionError(
+        `Could not construct commit doc for ref ${headRef}`,
+      );
     }
 
     return baseDoc;
@@ -501,7 +514,7 @@ export class TrimergeClient<
         !this.commits.has(baseRef) &&
         !this.docCache.has(baseRef)
       ) {
-        throw new Error(
+        throw new DocumentResolutionError(
           `no way to resolve ${ref}: no cached doc for ${ref} and no cached doc or commit for ${baseRef}`,
         );
       }

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -55,6 +55,10 @@ export class DocumentResolutionError extends Error {
   name = 'DocumentResolutionError';
 }
 
+export class UnknownRefError extends Error {
+  name = 'UnknownRefError';
+}
+
 export class TrimergeClientError extends Error {
   name = 'TrimergeClientError';
   constructor(readonly type: TrimergeClientErrorType, readonly cause: Error) {
@@ -355,7 +359,7 @@ export class TrimergeClient<
     if (commit) {
       return commit;
     }
-    throw new Error(`unknown ref "${ref}"`);
+    throw new UnknownRefError(`unknown ref "${ref}"`);
   };
 
   private mergeHelpers: MergeHelpers<LatestDoc, CommitMetadata> = {


### PR DESCRIPTION
Error type indicates the context in which the error was thrown. The error subclass is specifically what went wrong.

If we fail to find a ref while we're attempting to construct a document, we'll throw a DocumentResolutionError. If we attempt to get a ref in some other context (e.g. during merging) and it's not found, that will percolate up as a UnknownRefError.