### PR TITLE
Propagate "Unauthorized" errors from remote.

### DIFF
--- a/packages/trimerge-sync/src/CoordinatingLocalStore.ts
+++ b/packages/trimerge-sync/src/CoordinatingLocalStore.ts
@@ -254,6 +254,9 @@ export class CoordinatingLocalStore<CommitMetadata, Delta, Presence>
         if (origin === 'remote' && event.fatal) {
           // Do not await on this or we'll deadlock
           void this.closeRemote(event.reconnect !== false);
+          if (event.code === 'unauthorized') {
+            await this.sendEvent(event, { self: true, local: true }, true);
+          }
         }
         break;
     }

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -271,12 +271,14 @@ export class TrimergeClient<
         this.updateSyncState({ localRead: 'ready' });
         break;
       case 'error':
-        if (event.code === 'internal') {
-          this.emitError(
-            remoteOrigin ? 'remote' : 'local-store',
-            new ErrorEventError(event),
-          );
-          this.updateSyncState({ localRead: 'error' });
+        if (event.code === 'internal' || event.code === 'unauthorized') {
+          if (remoteOrigin) {
+            this.emitError('remote', new ErrorEventError(event));
+            this.updateSyncState({ remoteRead: 'error' });
+          } else {
+            this.emitError('local-store', new ErrorEventError(event));
+            this.updateSyncState({ localRead: 'error' });
+          }
         }
         break;
 


### PR DESCRIPTION
This is a small change to the way error propagation in TrimergeSync works. It updates the error handling in CoordinatingLocalStore and TrimergeClient so that `unauthorized` error events are forwarded along to TrimergeClient and to TrimergeClient's error subscribers respectively.