### PR TITLE
always propagate fatal, non-reconnectable errors to TrimergeClient/to error listeners

### DIFF
--- a/packages/trimerge-sync/src/CoordinatingLocalStore.ts
+++ b/packages/trimerge-sync/src/CoordinatingLocalStore.ts
@@ -254,7 +254,9 @@ export class CoordinatingLocalStore<CommitMetadata, Delta, Presence>
         if (origin === 'remote' && event.fatal) {
           // Do not await on this or we'll deadlock
           void this.closeRemote(event.reconnect !== false);
-          if (event.code === 'unauthorized') {
+          // If the remote indicated that reconnecting won't address the issues
+          // we forward the error event to trimerge client.
+          if (!event.reconnect) {
             await this.sendEvent(event, { self: true, local: true }, true);
           }
         }

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -275,7 +275,6 @@ export class TrimergeClient<
       case 'error':
         if (remoteOrigin) {
           this.emitError('remote', new ErrorEventError(event));
-          this.updateSyncState({ remoteRead: 'error' });
         } else if (event.code === 'internal') {
           this.emitError('local-store', new ErrorEventError(event));
           this.updateSyncState({ localRead: 'error' });

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -273,14 +273,12 @@ export class TrimergeClient<
         this.updateSyncState({ localRead: 'ready' });
         break;
       case 'error':
-        if (event.code === 'internal' || event.code === 'unauthorized') {
-          if (remoteOrigin) {
-            this.emitError('remote', new ErrorEventError(event));
-            this.updateSyncState({ remoteRead: 'error' });
-          } else {
-            this.emitError('local-store', new ErrorEventError(event));
-            this.updateSyncState({ localRead: 'error' });
-          }
+        if (remoteOrigin) {
+          this.emitError('remote', new ErrorEventError(event));
+          this.updateSyncState({ remoteRead: 'error' });
+        } else if (event.code === 'internal') {
+          this.emitError('local-store', new ErrorEventError(event));
+          this.updateSyncState({ localRead: 'error' });
         }
         break;
 


### PR DESCRIPTION
Today, `CoordinatingLocalStore` doesn't propagate errors from remote by default. This means that if there is a fatal and nonreconnectable error in remote, information about the error are not propagated to consumers of TrimergeClient which can make debugging failures difficult.

This PR updates `CoordinatingLocalStore` to forward all errors for which `fatal` is true and `reconnect` is false to `TrimergeClient`

In addition, if we see an `error` event that originated from the remote in `TrimergeClient`, we emit an error from TrimergeClient. 