### PR TITLE
Fix Race Condition in CoordinatingLocalStore

### DIFF
--- a/packages/trimerge-sync/src/CoordinatingLocalStore.test.ts
+++ b/packages/trimerge-sync/src/CoordinatingLocalStore.test.ts
@@ -1,9 +1,12 @@
 import { CoordinatingLocalStore } from './CoordinatingLocalStore';
 import { timeout } from './lib/Timeout';
 import { MemoryEventChannel } from './testLib/MemoryBroadcastChannel';
+import { MemoryCommitRepository } from './testLib/MemoryCommitRepository';
+import { MemoryStore } from './testLib/MemoryStore';
 import { MockRemote } from './testLib/MockRemote';
 import {
   AckCommitsEvent,
+  Commit,
   CommitRepository,
   CommitsEvent,
   Logger,
@@ -50,7 +53,7 @@ describe('CoordinatingLocalStore', () => {
     const fn = jest.fn();
     const store = new CoordinatingLocalStore('', '', {
       commitRepo: new MockCommitRepository(),
-      localChannel: new MemoryEventChannel('dummy'),
+      localChannel: new MemoryEventChannel('double-shutdown'),
     });
 
     store.listen(fn);
@@ -162,7 +165,7 @@ describe('CoordinatingLocalStore', () => {
     const fn = jest.fn();
     const store = new CoordinatingLocalStore('', '', {
       commitRepo: new MockCommitRepository(),
-      localChannel: new MemoryEventChannel('dummy'),
+      localChannel: new MemoryEventChannel('empty-update'),
     });
     store.listen(fn);
 
@@ -177,6 +180,124 @@ describe('CoordinatingLocalStore', () => {
             "type": "remote-state",
           },
           false,
+        ],
+      ]
+    `);
+  });
+
+  it("doesn't send commits to the remote until it's been initialized", async () => {
+    // this test is a bit complicated because it relies on the precise
+    // ordering of a couple of async operations. Specifically,
+    // the bug only occurs in the case that we have started connecting to a remote
+    // but we haven't sent it the existing commits and there is a pending save
+    // operation.
+
+    // What could happen previously is:
+    //  - we start connecting to the remote
+    //  - we start getting the local commits that we have to send to the remote
+    //  - we start saving a new commit
+    //  - we finish saving the new commit
+    //  - we send a message about the newly saved local commit, before the we've completed getting the local commits to send to the remote
+    //  - the remote gets the commits out of order
+
+    // Now we wait make sure to send the remote all of the commits we have in the local store while buffering any new commits that come.
+    // Those buffered commits are sent after we've sent all of the commits we have in the local store to the remote.
+
+    // remotePromise is used so that we can get the remote once the store has created it.
+    let remoteResolve: (val: MockRemote) => void;
+    const remotePromise = new Promise<MockRemote>((resolve) => {
+      remoteResolve = resolve;
+    });
+
+    // We use getCommitsPromise to block the completion of the getCommitsForRemote call until the
+    // addCommits call has been completed.
+    let getCommitsResolve: () => void;
+    const getCommitsPromise = new Promise<void>((resolve) => {
+      getCommitsResolve = resolve;
+    });
+
+    const commitRepo = new MemoryCommitRepository(new MemoryStore());
+    const existingCommits: Commit<unknown, unknown>[] = [
+      { ref: '1', delta: '', metadata: {} },
+    ];
+    await commitRepo.addCommits(existingCommits);
+
+    const realGetCommitsForRemote =
+      commitRepo.getCommitsForRemote.bind(commitRepo);
+    jest
+      .spyOn(commitRepo, 'getCommitsForRemote')
+      .mockImplementation(async function* () {
+        await getCommitsPromise;
+        yield* realGetCommitsForRemote();
+      });
+
+    const fn = jest.fn();
+    const store = new CoordinatingLocalStore('', '', '', {
+      onStoreEvent: fn,
+      commitRepo,
+      localChannel: new MemoryEventChannel('remote-initialization'),
+      getRemote: (_, __, ___, onEvent) => {
+        const remote = new MockRemote(onEvent);
+        remoteResolve(remote);
+        return remote;
+      },
+      networkSettings: {
+        electionTimeoutMs: 100,
+        initialDelayMs: 100,
+      },
+    });
+
+    const remote = await remotePromise;
+    const sendSpy = jest.spyOn(remote, 'send');
+
+    await store.update(
+      [{ baseRef: '1', ref: '2', delta: '', metadata: {} }],
+      undefined,
+    );
+
+    getCommitsResolve!();
+
+    await timeout();
+
+    expect(sendSpy.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "commits": [
+              {
+                "delta": "",
+                "metadata": {},
+                "ref": "1",
+              },
+              {
+                "baseRef": "1",
+                "delta": "",
+                "metadata": {},
+                "ref": "2",
+              },
+            ],
+            "type": "commits",
+          },
+        ],
+        [
+          {
+            "clientInfo": undefined,
+            "commits": [
+              {
+                "baseRef": "1",
+                "delta": "",
+                "metadata": {},
+                "ref": "2",
+              },
+            ],
+            "syncId": "2",
+            "type": "commits",
+          },
+        ],
+        [
+          {
+            "type": "ready",
+          },
         ],
       ]
     `);

--- a/packages/trimerge-sync/src/TrimergeClient.ts
+++ b/packages/trimerge-sync/src/TrimergeClient.ts
@@ -705,6 +705,7 @@ export class TrimergeClient<
   }
 
   public async shutdown(): Promise<void> {
+    this.logger?.debug('requested shutdown');
     invariant(!this.isShutdown, 'already shutdown');
     this.isShutdown = true;
 


### PR DESCRIPTION
This PR fixes a race condition in CoordinatingLocalStore that would allow it to send commits out of order to it's remote.

What could happen previously is:

 - we start connecting to the remote
 - we start getting the local commits that we have to send to the remote
 - we start saving a new commit
 - we finish saving the new commit
 - we send a message about the newly saved local commit, before the we've completed getting the local commits to send to the remote
 - the remote gets the commits out of order

This PR updates CoordinatingLocalStore so that it waits for initial read of local commits to complete before we start sending messages to the remote, buffering messages sent to the remote until the connection has completed.